### PR TITLE
feat(validation): replace Pattern(String) with CompiledPattern newtype

### DIFF
--- a/crates/form/examples/localized_form.rs
+++ b/crates/form/examples/localized_form.rs
@@ -116,7 +116,7 @@ impl LocalizedFormValidator {
         }
       }, None))
       .and(
-        Rule::<String>::Pattern(r"[A-Z]".to_string()).with_message_provider(|ctx| {
+        Rule::<String>::pattern(r"[A-Z]").unwrap().with_message_provider(|ctx| {
           match ctx.locale {
             Some("es") => "La contraseña debe contener al menos una letra mayúscula".to_string(),
             Some("fr") => "Le mot de passe doit contenir au moins une lettre majuscule".to_string(),
@@ -126,7 +126,7 @@ impl LocalizedFormValidator {
         }, None),
       )
       .and(
-        Rule::<String>::Pattern(r"[0-9]".to_string()).with_message_provider(|ctx| {
+        Rule::<String>::pattern(r"[0-9]").unwrap().with_message_provider(|ctx| {
           match ctx.locale {
             Some("es") => "La contraseña debe contener al menos un número".to_string(),
             Some("fr") => "Le mot de passe doit contenir au moins un chiffre".to_string(),

--- a/crates/inputfilter/examples/json_serialization.rs
+++ b/crates/inputfilter/examples/json_serialization.rs
@@ -61,15 +61,15 @@ fn main() {
   println!("\n4. Serialize complex rule compositions:");
   let complex_rule = Rule::<String>::Required
     .and(Rule::MinLength(8))
-    .and(Rule::Pattern(r"[A-Z]".to_string()))
-    .and(Rule::Pattern(r"[0-9]".to_string()));
+    .and(Rule::pattern(r"[A-Z]").unwrap())
+    .and(Rule::pattern(r"[0-9]").unwrap());
 
   let json = serde_json::to_string_pretty(&complex_rule).unwrap();
   println!("{}", json);
 
   // Example 5: Serialize Rule::Any
   println!("\n5. Serialize Rule::Any:");
-  let any_rule = Rule::<String>::Any(vec![Rule::Email(Default::default()), Rule::Pattern(r"^\d{10}$".to_string())]);
+  let any_rule = Rule::<String>::Any(vec![Rule::Email(Default::default()), Rule::pattern(r"^\d{10}$").unwrap()]);
 
   let json = serde_json::to_string_pretty(&any_rule).unwrap();
   println!("{}", json);

--- a/crates/inputfilter/examples/localized_messages.rs
+++ b/crates/inputfilter/examples/localized_messages.rs
@@ -124,14 +124,14 @@ fn main() {
       }
     }, None))
     .and(
-      Rule::<String>::Pattern(r"[A-Z]".to_string()).with_message_provider(|ctx| match ctx.locale {
+      Rule::<String>::pattern(r"[A-Z]").unwrap().with_message_provider(|ctx| match ctx.locale {
         Some("es") => "La contraseña debe contener al menos una letra mayúscula".to_string(),
         Some("fr") => "Le mot de passe doit contenir au moins une lettre majuscule".to_string(),
         _ => "Password must contain at least one uppercase letter".to_string(),
       }, None),
     )
     .and(
-      Rule::<String>::Pattern(r"[0-9]".to_string()).with_message_provider(|ctx| match ctx.locale {
+      Rule::<String>::pattern(r"[0-9]").unwrap().with_message_provider(|ctx| match ctx.locale {
         Some("es") => "La contraseña debe contener al menos un número".to_string(),
         Some("fr") => "Le mot de passe doit contenir au moins un chiffre".to_string(),
         _ => "Password must contain at least one number".to_string(),
@@ -227,7 +227,7 @@ fn main() {
   // locale on the rule, then validate via the ValidateRef trait.
 
   let age_rule =
-    Rule::<String>::Pattern(r"^\d+$".to_string()).with_message_provider(|ctx| match ctx.locale {
+    Rule::<String>::pattern(r"^\d+$").unwrap().with_message_provider(|ctx| match ctx.locale {
       Some("es") => format!("'{}' no es un número válido", ctx.value),
       Some("fr") => format!("'{}' n'est pas un nombre valide", ctx.value),
       _ => format!("'{}' is not a valid number", ctx.value),

--- a/crates/inputfilter/examples/rule_composition.rs
+++ b/crates/inputfilter/examples/rule_composition.rs
@@ -58,7 +58,7 @@ fn main() {
     Rule::Required,
     Rule::MinLength(8),
     Rule::MaxLength(128),
-    Rule::Pattern(r"[A-Z]".to_string()), // Must contain uppercase
+    Rule::pattern(r"[A-Z]").unwrap(), // Must contain uppercase
   ]);
 
   println!(
@@ -72,7 +72,7 @@ fn main() {
 
   // Example 4: Using .or() combinator (Any must pass)
   println!("\n4. Using .or() combinator (Any must pass):");
-  let contact_rule = Rule::<String>::Email(Default::default()).or(Rule::Pattern(r"^\d{3}-\d{4}$".to_string()));
+  let contact_rule = Rule::<String>::Email(Default::default()).or(Rule::pattern(r"^\d{3}-\d{4}$").unwrap());
 
   println!(
     "   'user@example.com': {:?}",
@@ -91,8 +91,8 @@ fn main() {
   println!("\n5. Using Rule::Any directly:");
   let flexible_id = Rule::<String>::Any(vec![
     Rule::Email(Default::default()),
-    Rule::Pattern(r"^\d{5,10}$".to_string()), // Numeric ID
-    Rule::Pattern(r"^[A-Z]{2}\d{6}$".to_string()), // Code format
+    Rule::pattern(r"^\d{5,10}$").unwrap(), // Numeric ID
+    Rule::pattern(r"^[A-Z]{2}\d{6}$").unwrap(), // Code format
   ]);
 
   println!(
@@ -157,7 +157,7 @@ fn main() {
   println!("\n9. Pattern matching:");
   let email_pattern = Rule::<String>::Email(Default::default());
   let url_pattern = Rule::<String>::Url(Default::default());
-  let custom_pattern = Rule::<String>::Pattern(r"^[a-z]+$".to_string());
+  let custom_pattern = Rule::<String>::pattern(r"^[a-z]+$").unwrap();
 
   println!(
     "   Email on 'test@example.com': {:?}",
@@ -250,8 +250,8 @@ fn main() {
   println!("\n14. Validating with combined rules:");
   let strict_rule = Rule::<String>::Required
     .and(Rule::MinLength(8))
-    .and(Rule::Pattern(r"[0-9]".to_string()).with_message("Must contain a number"))
-    .and(Rule::Pattern(r"[A-Z]".to_string()).with_message("Must contain uppercase"));
+    .and(Rule::pattern(r"[0-9]").unwrap().with_message("Must contain a number"))
+    .and(Rule::pattern(r"[A-Z]").unwrap().with_message("Must contain uppercase"));
 
   match strict_rule.validate_ref("abc") {
     Ok(()) => println!("   All rules passed!"),

--- a/crates/inputfilter/src/field_filter.rs
+++ b/crates/inputfilter/src/field_filter.rs
@@ -466,11 +466,9 @@ fn evaluate_condition(condition: &Condition<Value>, value: &Value) -> bool {
     Condition::LessThan(threshold) => {
       value.partial_cmp(threshold) == Some(std::cmp::Ordering::Less)
     }
-    Condition::Matches(pattern) => {
+    Condition::Matches(cp) => {
       if let Some(s) = value.as_str() {
-        regex::Regex::new(pattern)
-          .map(|re| re.is_match(s))
-          .unwrap_or(false)
+        cp.0.is_match(s)
       } else {
         false
       }

--- a/crates/inputfilter/src/lib.rs
+++ b/crates/inputfilter/src/lib.rs
@@ -68,7 +68,7 @@ pub use indexmap::IndexMap;
 
 // Re-export types from walrs_validation
 pub use walrs_validation::{
-  Attributes, CompiledRule, IsEmpty, Message, MessageContext, MessageParams, Value, ValueExt,
+  Attributes, IsEmpty, Message, MessageContext, MessageParams, Value, ValueExt,
   Violation, ViolationMessage, ViolationType, Violations,
 };
 

--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -129,7 +129,7 @@ patterns) for efficient repeated validation:
 ```rust
 use walrs_validation::Rule;
 
-let rule = Rule::<String>::Pattern(r"^[a-z]+$".to_string());
+let rule = Rule::<String>::pattern(r"^[a-z]+$").unwrap();
 let compiled = rule.compile();
 
 // The regex is compiled once and reused on every call

--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -119,23 +119,7 @@ let result = rule.validate_ref_async("hello").await;
 assert!(result.is_ok());
 ```
 
-## CompiledRule, WithMessage, and the Message System
-
-### `CompiledRule<T>`
-
-`CompiledRule<T>` wraps a `Rule<T>` and caches compiled resources (e.g., regex
-patterns) for efficient repeated validation:
-
-```rust
-use walrs_validation::Rule;
-
-let rule = Rule::<String>::pattern(r"^[a-z]+$").unwrap();
-let compiled = rule.compile();
-
-// The regex is compiled once and reused on every call
-assert!(compiled.validate_ref("hello").is_ok());
-assert!(compiled.validate_ref("HELLO").is_err());
-```
+## WithMessage — Custom Violation Messages
 
 ### `WithMessage` — custom violation messages
 

--- a/crates/validation/benches/validation_benchmarks.rs
+++ b/crates/validation/benches/validation_benchmarks.rs
@@ -17,13 +17,13 @@ fn bench_string_email(c: &mut Criterion) {
 }
 
 fn bench_string_pattern(c: &mut Criterion) {
-    let rule = Rule::<String>::Pattern(r"^[a-zA-Z0-9_\-]{3,30}$".to_string());
+    let rule = Rule::<String>::pattern(r"^[a-zA-Z0-9_\-]{3,30}$").unwrap();
     let compiled = rule.clone().compile();
 
-    c.bench_function("pattern uncompiled", |b| {
+    c.bench_function("pattern rule", |b| {
         b.iter(|| rule.validate_ref("hello_world"))
     });
-    c.bench_function("pattern compiled", |b| {
+    c.bench_function("pattern compiled rule", |b| {
         b.iter(|| compiled.validate_ref("hello_world"))
     });
 }
@@ -95,7 +95,7 @@ fn bench_composite_all(c: &mut Criterion) {
     let rule = Rule::<String>::Required
         .and(Rule::MinLength(3))
         .and(Rule::MaxLength(50))
-        .and(Rule::Pattern(r"^[a-zA-Z0-9_]+$".to_string()));
+        .and(Rule::pattern(r"^[a-zA-Z0-9_]+$").unwrap());
 
     c.bench_function("composite All (4 rules) valid", |b| {
         b.iter(|| rule.validate_ref("hello_world"))
@@ -123,14 +123,14 @@ fn bench_composite_any(c: &mut Criterion) {
 // ============================================================================
 
 fn bench_compiled_vs_uncompiled(c: &mut Criterion) {
-    let rule = Rule::<String>::Pattern(r"^[a-z]{3,30}$".to_string());
+    let rule = Rule::<String>::pattern(r"^[a-z]{3,30}$").unwrap();
     let compiled = rule.clone().compile();
     let value = "hello";
 
-    c.bench_function("uncompiled pattern (recompiles regex each call)", |b| {
+    c.bench_function("pattern rule (pre-compiled regex)", |b| {
         b.iter(|| rule.validate_ref(value))
     });
-    c.bench_function("compiled pattern (cached regex)", |b| {
+    c.bench_function("compiled rule (cached wrapper)", |b| {
         b.iter(|| compiled.validate_ref(value))
     });
 }

--- a/crates/validation/benches/validation_benchmarks.rs
+++ b/crates/validation/benches/validation_benchmarks.rs
@@ -18,13 +18,9 @@ fn bench_string_email(c: &mut Criterion) {
 
 fn bench_string_pattern(c: &mut Criterion) {
     let rule = Rule::<String>::pattern(r"^[a-zA-Z0-9_\-]{3,30}$").unwrap();
-    let compiled = rule.clone().compile();
 
     c.bench_function("pattern rule", |b| {
         b.iter(|| rule.validate_ref("hello_world"))
-    });
-    c.bench_function("pattern compiled rule", |b| {
-        b.iter(|| compiled.validate_ref("hello_world"))
     });
 }
 
@@ -118,23 +114,6 @@ fn bench_composite_any(c: &mut Criterion) {
     });
 }
 
-// ============================================================================
-// CompiledRule vs uncompiled
-// ============================================================================
-
-fn bench_compiled_vs_uncompiled(c: &mut Criterion) {
-    let rule = Rule::<String>::pattern(r"^[a-z]{3,30}$").unwrap();
-    let compiled = rule.clone().compile();
-    let value = "hello";
-
-    c.bench_function("pattern rule (pre-compiled regex)", |b| {
-        b.iter(|| rule.validate_ref(value))
-    });
-    c.bench_function("compiled rule (cached wrapper)", |b| {
-        b.iter(|| compiled.validate_ref(value))
-    });
-}
-
 criterion_group!(
     string_benches,
     bench_string_email,
@@ -156,7 +135,6 @@ criterion_group!(
     composite_benches,
     bench_composite_all,
     bench_composite_any,
-    bench_compiled_vs_uncompiled,
 );
 
 criterion_main!(string_benches, numeric_benches, composite_benches);

--- a/crates/validation/examples/basic_validation.rs
+++ b/crates/validation/examples/basic_validation.rs
@@ -39,7 +39,7 @@ fn main() {
     // -------------------------------------------------------------------------
     // Regex pattern matching
     // -------------------------------------------------------------------------
-    let slug_rule = Rule::<String>::Pattern(r"(?i)^[\w\-]{1,100}$".to_string());
+    let slug_rule = Rule::<String>::pattern(r"(?i)^[\w\-]{1,100}$").unwrap();
     assert!(slug_rule.validate_ref("my-article-title").is_ok());
     assert!(slug_rule.validate_ref("invalid slug!").is_err());
 

--- a/crates/validation/examples/composable_rules.rs
+++ b/crates/validation/examples/composable_rules.rs
@@ -12,8 +12,8 @@ fn main() {
     // -------------------------------------------------------------------------
     let password_rule = Rule::<String>::MinLength(8)
         .and(Rule::MaxLength(64))
-        .and(Rule::Pattern(r"[A-Z]".to_string()))  // must contain uppercase
-        .and(Rule::Pattern(r"[0-9]".to_string())); // must contain digit
+        .and(Rule::pattern(r"[A-Z]").unwrap())  // must contain uppercase
+        .and(Rule::pattern(r"[0-9]").unwrap()); // must contain digit
 
     assert!(password_rule.validate_ref("SecurePass1").is_ok());
     assert!(password_rule.validate_ref("short1A").is_err());   // too short
@@ -26,8 +26,8 @@ fn main() {
     // `.or()` — at least one rule must pass
     // -------------------------------------------------------------------------
     // Accept either a US phone (+1...) or an international phone (+44...)
-    let phone_rule = Rule::<String>::Pattern(r"^\+1\d{10}$".to_string())
-        .or(Rule::Pattern(r"^\+44\d{10}$".to_string()));
+    let phone_rule = Rule::<String>::pattern(r"^\+1\d{10}$").unwrap()
+        .or(Rule::pattern(r"^\+44\d{10}$").unwrap());
 
     assert!(phone_rule.validate_ref("+12345678901").is_ok());
     assert!(phone_rule.validate_ref("+44123456789_").is_err()); // wrong length
@@ -87,7 +87,7 @@ fn main() {
     let username_rule = Rule::<String>::Required
         .and(Rule::MinLength(3))
         .and(Rule::MaxLength(30))
-        .and(Rule::Pattern(r"^[a-zA-Z][a-zA-Z0-9_\-]*$".to_string()))
+        .and(Rule::pattern(r"^[a-zA-Z][a-zA-Z0-9_\-]*$").unwrap())
         .and(
             Rule::OneOf(vec![
                 "admin".to_string(),

--- a/crates/validation/examples/value_validation.rs
+++ b/crates/validation/examples/value_validation.rs
@@ -49,7 +49,7 @@ fn main() {
     // -------------------------------------------------------------------------
     // Pattern on string values
     // -------------------------------------------------------------------------
-    let email_pattern = Rule::<Value>::Pattern(r"^[^@\s]+@[^@\s]+\.[^@\s]+$".to_string());
+    let email_pattern = Rule::<Value>::pattern(r"^[^@\s]+@[^@\s]+\.[^@\s]+$").unwrap();
 
     assert!(email_pattern.validate(Value::Str("user@example.com".into())).is_ok());
     assert!(email_pattern.validate(Value::Str("not-an-email".into())).is_err());

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -67,7 +67,7 @@ pub mod violation;
 pub use attributes::*;
 pub use message::*;
 pub use options::*;
-pub use rule::{CompiledRule, Condition, Rule, RuleResult};
+pub use rule::{CompiledPattern, CompiledRule, Condition, Rule, RuleResult};
 pub use traits::*;
 pub use value::*;
 pub use violation::*;

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -67,7 +67,7 @@ pub mod violation;
 pub use attributes::*;
 pub use message::*;
 pub use options::*;
-pub use rule::{CompiledPattern, CompiledRule, Condition, Rule, RuleResult};
+pub use rule::{CompiledPattern, Condition, Rule, RuleResult};
 pub use traits::*;
 pub use value::*;
 pub use violation::*;

--- a/crates/validation/src/rule.rs
+++ b/crates/validation/src/rule.rs
@@ -42,6 +42,80 @@ use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOption
 use crate::traits::IsEmpty;
 
 // ============================================================================
+// CompiledPattern — pre-compiled regex wrapper
+// ============================================================================
+
+/// A pre-compiled regex pattern for use in `Rule::Pattern` and `Condition::Matches`.
+///
+/// Wraps a [`regex::Regex`] so that the pattern is compiled once at construction
+/// time rather than on every validation call. Implements `Serialize`/`Deserialize`
+/// as a plain pattern string for backward-compatible JSON/YAML configs.
+///
+/// # Construction
+///
+/// ```rust
+/// use walrs_validation::CompiledPattern;
+///
+/// // From &str (fallible)
+/// let cp = CompiledPattern::try_from(r"^\d+$").unwrap();
+///
+/// // From String
+/// let cp = CompiledPattern::try_from(String::from(r"^\d+$")).unwrap();
+/// ```
+#[derive(Clone)]
+pub struct CompiledPattern(pub regex::Regex);
+
+impl CompiledPattern {
+  /// Returns the pattern string.
+  pub fn as_str(&self) -> &str {
+    self.0.as_str()
+  }
+}
+
+impl Debug for CompiledPattern {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_tuple("CompiledPattern").field(&self.0.as_str()).finish()
+  }
+}
+
+impl PartialEq for CompiledPattern {
+  fn eq(&self, other: &Self) -> bool {
+    self.0.as_str() == other.0.as_str()
+  }
+}
+
+impl TryFrom<&str> for CompiledPattern {
+  type Error = regex::Error;
+
+  fn try_from(pattern: &str) -> Result<Self, Self::Error> {
+    regex::Regex::new(pattern).map(CompiledPattern)
+  }
+}
+
+impl TryFrom<String> for CompiledPattern {
+  type Error = regex::Error;
+
+  fn try_from(pattern: String) -> Result<Self, Self::Error> {
+    regex::Regex::new(&pattern).map(CompiledPattern)
+  }
+}
+
+impl Serialize for CompiledPattern {
+  fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(self.0.as_str())
+  }
+}
+
+impl<'de> Deserialize<'de> for CompiledPattern {
+  fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    let pattern = String::deserialize(deserializer)?;
+    regex::Regex::new(&pattern)
+      .map(CompiledPattern)
+      .map_err(serde::de::Error::custom)
+  }
+}
+
+// ============================================================================
 // Result Types
 // ============================================================================
 
@@ -74,8 +148,8 @@ pub enum Condition<T> {
   /// Value is less than the specified value
   LessThan(T),
 
-  /// Value matches a regex pattern (string representation)
-  Matches(String),
+  /// Value matches a regex pattern (pre-compiled)
+  Matches(CompiledPattern),
 
   /// Custom condition function (not serializable)
   #[serde(skip)]
@@ -90,7 +164,7 @@ impl<T: Debug> Debug for Condition<T> {
       Self::Equals(v) => f.debug_tuple("Equals").field(v).finish(),
       Self::GreaterThan(v) => f.debug_tuple("GreaterThan").field(v).finish(),
       Self::LessThan(v) => f.debug_tuple("LessThan").field(v).finish(),
-      Self::Matches(p) => f.debug_tuple("Matches").field(p).finish(),
+      Self::Matches(cp) => f.debug_tuple("Matches").field(&cp.as_str()).finish(),
       Self::Custom(_) => write!(f, "Custom(<fn>)"),
     }
   }
@@ -130,7 +204,7 @@ impl<T: PartialEq + PartialOrd> Condition<T> {
       Condition::Equals(expected) => value == expected,
       Condition::GreaterThan(threshold) => value > threshold,
       Condition::LessThan(threshold) => value < threshold,
-      Condition::Matches(_pattern) => {
+      Condition::Matches(_cp) => {
         // For Matches, we need string conversion - handled in specialized impl
         false
       }
@@ -148,9 +222,7 @@ impl Condition<String> {
       Condition::Equals(expected) => value == expected,
       Condition::GreaterThan(threshold) => value > threshold.as_str(),
       Condition::LessThan(threshold) => value < threshold.as_str(),
-      Condition::Matches(pattern) => regex::Regex::new(pattern)
-        .map(|re| re.is_match(value))
-        .unwrap_or(false),
+      Condition::Matches(cp) => cp.0.is_match(value),
       Condition::Custom(f) => f(&value.to_string()),
     }
   }
@@ -195,8 +267,8 @@ pub enum Rule<T> {
   ExactLength(usize),
 
   // ---- String Rules ----
-  /// Regex pattern match (stored as string for serialization)
-  Pattern(String),
+  /// Regex pattern match (pre-compiled at construction time)
+  Pattern(CompiledPattern),
 
   /// Email format validation with configurable options.
   Email(EmailOptions),
@@ -311,7 +383,7 @@ impl<T: Debug> Debug for Rule<T> {
       Self::MinLength(n) => f.debug_tuple("MinLength").field(n).finish(),
       Self::MaxLength(n) => f.debug_tuple("MaxLength").field(n).finish(),
       Self::ExactLength(n) => f.debug_tuple("ExactLength").field(n).finish(),
-      Self::Pattern(p) => f.debug_tuple("Pattern").field(p).finish(),
+      Self::Pattern(cp) => f.debug_tuple("Pattern").field(&cp.as_str()).finish(),
       Self::Email(opts) => f.debug_tuple("Email").field(opts).finish(),
       Self::Url(opts) => f.debug_tuple("Url").field(opts).finish(),
       Self::Uri(opts) => f.debug_tuple("Uri").field(opts).finish(),
@@ -716,9 +788,19 @@ impl<T> Rule<T> {
     Rule::ExactLength(len)
   }
 
-  /// Creates a `Pattern` rule.
-  pub fn pattern(pattern: impl Into<String>) -> Rule<T> {
-    Rule::Pattern(pattern.into())
+  /// Creates a `Pattern` rule by compiling the given regex pattern.
+  ///
+  /// Returns `Err(regex::Error)` if the pattern is invalid.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// use walrs_validation::rule::Rule;
+  ///
+  /// let rule = Rule::<String>::pattern(r"^\d+$").unwrap();
+  /// ```
+  pub fn pattern(pattern: impl AsRef<str>) -> Result<Rule<T>, regex::Error> {
+    CompiledPattern::try_from(pattern.as_ref()).map(Rule::Pattern)
   }
 
   /// Creates an `Email` rule with the given options.
@@ -822,7 +904,7 @@ use crate::rule_impls::string::CachedStringValidators;
 ///
 /// // Define and compile rule once
 /// let rule = Rule::<String>::MinLength(8)
-///     .and(Rule::Pattern(r"[A-Z]".to_string()));
+///     .and(Rule::pattern(r"[A-Z]").unwrap());
 /// let compiled = rule.compile();
 ///
 /// // Validate many times (reuses cached regex)
@@ -884,7 +966,7 @@ impl Rule<String> {
   /// use walrs_validation::rule::Rule;
   /// use walrs_validation::ValidateRef;
   ///
-  /// let rule = Rule::<String>::Pattern(r"^\d+$".to_string());
+  /// let rule = Rule::<String>::pattern(r"^\d+$").unwrap();
   /// let compiled = rule.compile();
   ///
   /// // Repeated calls reuse the cached regex
@@ -938,7 +1020,7 @@ mod tests {
   fn test_rule_and_combinator_flattens() {
     let rule1 = Rule::<String>::MinLength(3);
     let rule2 = Rule::<String>::MaxLength(10);
-    let rule3 = Rule::<String>::Pattern(r"^\w+$".to_string());
+    let rule3 = Rule::<String>::pattern(r"^\w+$").unwrap();
 
     let combined = rule1.and(rule2).and(rule3);
 
@@ -1160,8 +1242,8 @@ mod tests {
   // ==========================================================================
   #[test]
   fn test_e2e_only_rule_and_validators() {
-    let slug = Rule::<String>::Pattern(r"(?i)^[\w\-]{1,108}$".to_string());
-    let screen_name = Rule::<String>::Pattern(r"(?i)^[a-z][\w\-]{7,55}$".to_string());
+    let slug = Rule::<String>::pattern(r"(?i)^[\w\-]{1,108}$").unwrap();
+    let screen_name = Rule::<String>::pattern(r"(?i)^[a-z][\w\-]{7,55}$").unwrap();
     let numeric_id = Rule::<usize>::Range { min: 1, max: usize::MAX };
 
     assert!(slug.validate_ref("hello-world").is_ok());

--- a/crates/validation/src/rule.rs
+++ b/crates/validation/src/rule.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 #[cfg(feature = "async")]
 use std::pin::Pin;
 
-use crate::{Message, MessageContext, SteppableValue, Violation};
+use crate::{Message, MessageContext, Violation};
 use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, IpOptions, UrlOptions, UriOptions};
 use crate::traits::IsEmpty;
 
@@ -883,107 +883,6 @@ impl<T> Rule<T> {
 
 // Rule<Numeric> implementation moved to rule_impls/steppable.rs
 
-// ============================================================================
-// CompiledRule - Cached Validator Wrapper
-// ============================================================================
-
-use std::sync::OnceLock;
-use crate::rule_impls::string::CachedStringValidators;
-
-/// A compiled rule with cached validators for better performance.
-///
-/// Use `CompiledRule` when you need to validate many values against the same rule.
-/// The compiled form caches regex patterns and other validators to avoid
-/// repeated construction.
-///
-/// # Example
-///
-/// ```rust
-/// use walrs_validation::rule::Rule;
-/// use walrs_validation::ValidateRef;
-///
-/// // Define and compile rule once
-/// let rule = Rule::<String>::MinLength(8)
-///     .and(Rule::pattern(r"[A-Z]").unwrap());
-/// let compiled = rule.compile();
-///
-/// // Validate many times (reuses cached regex)
-/// assert!(compiled.validate_ref("Password1").is_ok());
-/// assert!(compiled.validate_ref("short").is_err());
-/// ```
-pub struct CompiledRule<T> {
-  /// The underlying rule
-  pub(crate) rule: Rule<T>,
-  /// Cached string validators (lazily initialized)
-  pub(crate) string_cache: OnceLock<CachedStringValidators>,
-}
-
-impl<T: Clone> CompiledRule<T> {
-  /// Creates a new compiled rule from an existing rule.
-  pub fn new(rule: Rule<T>) -> Self {
-    Self {
-      rule,
-      string_cache: OnceLock::new(),
-    }
-  }
-
-  /// Returns a reference to the underlying rule.
-  pub fn rule(&self) -> &Rule<T> {
-    &self.rule
-  }
-
-  /// Consumes the compiled rule and returns the underlying rule.
-  pub fn into_rule(self) -> Rule<T> {
-    self.rule
-  }
-}
-
-impl<T: Clone> Clone for CompiledRule<T> {
-  fn clone(&self) -> Self {
-    Self {
-      rule: self.rule.clone(),
-      string_cache: OnceLock::new(), // Reset cache on clone
-    }
-  }
-}
-
-impl<T: Debug> Debug for CompiledRule<T> {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_struct("CompiledRule")
-      .field("rule", &self.rule)
-      .finish()
-  }
-}
-
-impl Rule<String> {
-  /// Compiles this rule for efficient repeated validation.
-  ///
-  /// The compiled form caches regex patterns and other validators.
-  ///
-  /// # Example
-  ///
-  /// ```rust
-  /// use walrs_validation::rule::Rule;
-  /// use walrs_validation::ValidateRef;
-  ///
-  /// let rule = Rule::<String>::pattern(r"^\d+$").unwrap();
-  /// let compiled = rule.compile();
-  ///
-  /// // Repeated calls reuse the cached regex
-  /// assert!(compiled.validate_ref("123").is_ok());
-  /// assert!(compiled.validate_ref("456").is_ok());
-  /// ```
-  pub fn compile(self) -> CompiledRule<String> {
-    CompiledRule::new(self)
-  }
-}
-
-impl<T: SteppableValue + IsEmpty + Clone> Rule<T> {
-  /// Compiles this rule for efficient repeated validation.
-  pub fn compile(self) -> CompiledRule<T> {
-    CompiledRule::new(self)
-  }
-}
 
 // Trait implementations moved to rule_impls modules
 

--- a/crates/validation/src/rule_impls/attributes.rs
+++ b/crates/validation/src/rule_impls/attributes.rs
@@ -69,9 +69,9 @@ impl<T: Serialize> ToAttributesList for Rule<T> {
       ]),
 
       // String Rules
-      Rule::Pattern(p) => Some(vec![(
+      Rule::Pattern(cp) => Some(vec![(
         "pattern".to_string(),
-        serde_json::Value::from(p.clone()),
+        serde_json::Value::from(cp.as_str()),
       )]),
       Rule::Email(_) => Some(vec![("type".to_string(), serde_json::Value::from("email"))]),
       Rule::Url(_) => Some(vec![("type".to_string(), serde_json::Value::from("url"))]),
@@ -194,7 +194,7 @@ mod tests {
 
   #[test]
   fn test_to_attributes_list_pattern() {
-    let rule = Rule::<String>::Pattern(r"^\w+$".to_string());
+    let rule = Rule::<String>::pattern(r"^\w+$").unwrap();
     let attrs = rule.to_attributes_list().unwrap();
     assert_eq!(attrs.len(), 1);
     assert_eq!(attrs[0].0, "pattern");
@@ -281,7 +281,7 @@ mod tests {
     let rule = Rule::<String>::Required
       .and(Rule::MinLength(5))
       .and(Rule::MaxLength(100))
-      .and(Rule::Pattern(r"^\w+$".to_string()));
+      .and(Rule::pattern(r"^\w+$").unwrap());
     let attrs = rule.to_attributes_list().unwrap();
     assert_eq!(attrs.len(), 4);
     assert!(attrs.iter().any(|(k, _)| k == "required"));

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -1,7 +1,6 @@
 use crate::rule::{Rule, RuleResult};
 use crate::traits::{IsEmpty, Validate};
 use crate::{SteppableValue, Violation};
-use crate::CompiledRule;
 
 impl<T: SteppableValue + IsEmpty> Rule<T> {
   /// Validates a numeric value against this rule.
@@ -219,26 +218,6 @@ impl<T: SteppableValue + IsEmpty + Clone> Validate<T> for Rule<T> {
   }
 }
 
-impl<T: SteppableValue + IsEmpty + Clone> Validate<T> for CompiledRule<T> {
-  fn validate(&self, value: T) -> crate::ValidatorResult {
-    self.rule.validate_step(value)
-  }
-}
-
-impl<T: SteppableValue + IsEmpty + Clone> CompiledRule<T> {
-  /// Validates a numeric value using the compiled rule.
-  #[allow(dead_code)] // Reserved for a future public API
-  pub(crate) fn validate_step(&self, value: T) -> RuleResult {
-    self.rule.validate_step(value)
-  }
-
-  /// Validates a numeric value and collects all violations.
-  #[allow(dead_code)] // Reserved for a future `validate_all` public API
-  pub(crate) fn validate_step_all(&self, value: T) -> Result<(), crate::Violations> {
-    self.rule.validate_step_all(value)
-  }
-}
-
 // ============================================================================
 // Async Numeric Validation
 // ============================================================================
@@ -327,13 +306,6 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
 impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<T> for Rule<T> {
   async fn validate_async(&self, value: T) -> crate::ValidatorResult {
     self.validate_step_async(value).await
-  }
-}
-
-#[cfg(feature = "async")]
-impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<T> for CompiledRule<T> {
-  async fn validate_async(&self, value: T) -> crate::ValidatorResult {
-    self.rule.validate_step_async(value).await
   }
 }
 
@@ -489,22 +461,6 @@ mod tests {
 
     let result = rule.validate_option_step_all(Some(55));
     assert!(result.is_err());
-  }
-
-  // ========================================================================
-  // CompiledRule (Numeric) Tests
-  // ========================================================================
-
-  #[test]
-  fn test_compiled_rule_numeric() {
-    let rule = Rule::<i32>::Min(0).and(Rule::Max(100));
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_step(50).is_ok());
-    assert!(compiled.validate_step(0).is_ok());
-    assert!(compiled.validate_step(100).is_ok());
-    assert!(compiled.validate_step(-1).is_err());
-    assert!(compiled.validate_step(101).is_err());
   }
 
   // ========================================================================

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -386,17 +386,16 @@ fn validate_date_range_str_dispatch(_value: &str, _opts: &DateRangeOptions) -> R
 
 /// Cached validators for a compiled rule.
 ///
-/// This struct holds compiled regex patterns for string validation rules.
+/// This struct holds cached validators for string validation rules.
 /// Included in `CompiledRule` for all types, but only populated for String rules.
+/// Currently empty since `Pattern` now holds a pre-compiled regex, but retained
+/// for future cached validators.
 #[derive(Debug, Default)]
-pub(crate) struct CachedStringValidators {
-  /// Cached regex for Pattern rules
-  pub(crate) pattern_regex: Option<regex::Regex>,
-}
+pub(crate) struct CachedStringValidators;
 
 impl CachedStringValidators {
   pub(crate) fn new() -> Self {
-    Self::default()
+    Self
   }
 }
 
@@ -443,15 +442,12 @@ impl Rule<String> {
           Ok(())
         }
       }
-      Rule::Pattern(pattern) => match regex::Regex::new(pattern) {
-        Ok(re) => {
-          if re.is_match(value) {
+      Rule::Pattern(cp) => {
+          if cp.0.is_match(value) {
             Ok(())
           } else {
-            Err(Violation::pattern_mismatch(pattern))
+            Err(Violation::pattern_mismatch(cp.as_str()))
           }
-        }
-        Err(_) => Err(Violation::pattern_mismatch(pattern)),
       },
       Rule::Email(opts) => validate_email(value, opts),
       Rule::Url(opts) => validate_url(value, opts),
@@ -646,16 +642,7 @@ impl ValidateRef<str> for CompiledRule<String> {
 impl CompiledRule<String> {
   /// Gets or initializes the cached string validators.
   fn get_or_init_cache(&self) -> &CachedStringValidators {
-    self.string_cache.get_or_init(|| {
-      let mut cache = CachedStringValidators::new();
-
-      // Pre-compile pattern regex if applicable
-      if let Rule::Pattern(pattern) = &self.rule {
-        cache.pattern_regex = regex::Regex::new(pattern).ok();
-      }
-
-      cache
-    })
+    self.string_cache.get_or_init(CachedStringValidators::new)
   }
 
   /// Validates a string value using cached validators.
@@ -663,7 +650,7 @@ impl CompiledRule<String> {
     self.validate_str_with_cache(value, self.get_or_init_cache())
   }
 
-  fn validate_str_with_cache(&self, value: &str, cache: &CachedStringValidators) -> RuleResult {
+  fn validate_str_with_cache(&self, value: &str, _cache: &CachedStringValidators) -> RuleResult {
     match &self.rule {
       Rule::Required => {
         if value.trim().is_empty() {
@@ -696,21 +683,11 @@ impl CompiledRule<String> {
           Ok(())
         }
       }
-      Rule::Pattern(pattern) => {
-        // Use cached regex if available
-        let matches = cache
-          .pattern_regex
-          .as_ref()
-          .map(|re| re.is_match(value))
-          .unwrap_or_else(|| {
-            regex::Regex::new(pattern)
-              .map(|re| re.is_match(value))
-              .unwrap_or(false)
-          });
-        if matches {
+      Rule::Pattern(cp) => {
+        if cp.0.is_match(value) {
           Ok(())
         } else {
-          Err(Violation::pattern_mismatch(pattern))
+          Err(Violation::pattern_mismatch(cp.as_str()))
         }
       }
       Rule::Email(opts) => validate_email(value, opts),
@@ -944,7 +921,7 @@ mod tests {
 
   #[test]
   fn test_validate_str_pattern() {
-    let rule = Rule::<String>::Pattern(r"^\d+$".to_string());
+    let rule = Rule::<String>::pattern(r"^\d+$").unwrap();
     assert!(rule.validate_str("123").is_ok());
     assert!(rule.validate_str("abc").is_err());
     assert!(rule.validate_str("12a").is_err());
@@ -1158,7 +1135,7 @@ mod tests {
   fn test_validate_str_all_violations() {
     let rule = Rule::<String>::MinLength(3)
       .and(Rule::MaxLength(5))
-      .and(Rule::Pattern(r"^\d+$".to_string()));
+      .and(Rule::pattern(r"^\d+$").unwrap());
 
     assert!(rule.validate_str_all("123").is_ok());
 
@@ -1177,7 +1154,7 @@ mod tests {
     let rule = Rule::<String>::MinLength(3);
     assert!(rule.validate_str_option(None).is_ok());
 
-    let rule = Rule::<String>::Pattern(r"^\d+$".to_string());
+    let rule = Rule::<String>::pattern(r"^\d+$").unwrap();
     assert!(rule.validate_str_option(None).is_ok());
 
     let rule = Rule::<String>::Email(Default::default());
@@ -1249,7 +1226,7 @@ mod tests {
 
   #[test]
   fn test_compiled_rule_pattern_cached() {
-    let rule = Rule::<String>::Pattern(r"^\d{3}-\d{4}$".to_string());
+    let rule = Rule::<String>::pattern(r"^\d{3}-\d{4}$").unwrap();
     let compiled = rule.compile();
 
     assert!(compiled.validate_str("123-4567").is_ok());
@@ -1280,7 +1257,7 @@ mod tests {
 
   #[test]
   fn test_compiled_rule_clone() {
-    let rule = Rule::<String>::Pattern(r"^\w+$".to_string());
+    let rule = Rule::<String>::pattern(r"^\w+$").unwrap();
     let compiled = rule.compile();
 
     assert!(compiled.validate_str("hello").is_ok());
@@ -1322,7 +1299,7 @@ mod tests {
   fn test_compiled_rule_validate_all() {
     let rule = Rule::<String>::MinLength(3)
       .and(Rule::MaxLength(5))
-      .and(Rule::Pattern(r"^[a-z]+$".to_string()));
+      .and(Rule::pattern(r"^[a-z]+$").unwrap());
     let compiled = rule.compile();
 
     assert!(compiled.validate_str_all("abc").is_ok());

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -1,7 +1,6 @@
 use crate::rule::{Rule, RuleResult};
 use crate::Violation;
 use crate::traits::ValidateRef;
-use crate::CompiledRule;
 use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, UriOptions, UrlOptions, IpOptions};
 
 // ============================================================================
@@ -384,21 +383,6 @@ fn validate_date_range_str_dispatch(_value: &str, _opts: &DateRangeOptions) -> R
   ))
 }
 
-/// Cached validators for a compiled rule.
-///
-/// This struct holds cached validators for string validation rules.
-/// Included in `CompiledRule` for all types, but only populated for String rules.
-/// Currently empty since `Pattern` now holds a pre-compiled regex, but retained
-/// for future cached validators.
-#[derive(Debug, Default)]
-pub(crate) struct CachedStringValidators;
-
-impl CachedStringValidators {
-  pub(crate) fn new() -> Self {
-    Self
-  }
-}
-
 impl Rule<String> {
   /// Validates a string value against this rule.
   pub(crate) fn validate_str(&self, value: &str) -> RuleResult {
@@ -633,147 +617,6 @@ impl ValidateRef<str> for Rule<String> {
   }
 }
 
-impl ValidateRef<str> for CompiledRule<String> {
-  fn validate_ref(&self, value: &str) -> crate::ValidatorResult {
-    CompiledRule::validate_str(self, value)
-  }
-}
-
-impl CompiledRule<String> {
-  /// Gets or initializes the cached string validators.
-  fn get_or_init_cache(&self) -> &CachedStringValidators {
-    self.string_cache.get_or_init(CachedStringValidators::new)
-  }
-
-  /// Validates a string value using cached validators.
-  pub(crate) fn validate_str(&self, value: &str) -> RuleResult {
-    self.validate_str_with_cache(value, self.get_or_init_cache())
-  }
-
-  fn validate_str_with_cache(&self, value: &str, _cache: &CachedStringValidators) -> RuleResult {
-    match &self.rule {
-      Rule::Required => {
-        if value.trim().is_empty() {
-          Err(Violation::value_missing())
-        } else {
-          Ok(())
-        }
-      }
-      Rule::MinLength(min) => {
-        let len = value.chars().count();
-        if len < *min {
-          Err(Violation::too_short(*min, len))
-        } else {
-          Ok(())
-        }
-      }
-      Rule::MaxLength(max) => {
-        let len = value.chars().count();
-        if len > *max {
-          Err(Violation::too_long(*max, len))
-        } else {
-          Ok(())
-        }
-      }
-      Rule::ExactLength(expected) => {
-        let len = value.chars().count();
-        if len != *expected {
-          Err(Violation::exact_length(*expected, len))
-        } else {
-          Ok(())
-        }
-      }
-      Rule::Pattern(cp) => {
-        if cp.0.is_match(value) {
-          Ok(())
-        } else {
-          Err(Violation::pattern_mismatch(cp.as_str()))
-        }
-      }
-      Rule::Email(opts) => validate_email(value, opts),
-      Rule::Url(opts) => validate_url(value, opts),
-      Rule::Uri(opts) => validate_uri(value, opts),
-      Rule::Ip(opts) => validate_ip(value, opts),
-      Rule::Hostname(opts) => validate_hostname(value, opts),
-      Rule::Date(opts) => validate_date_str_dispatch(value, opts),
-      Rule::DateRange(opts) => validate_date_range_str_dispatch(value, opts),
-      Rule::Equals(expected) => {
-        if value == expected {
-          Ok(())
-        } else {
-          Err(Violation::not_equal(expected))
-        }
-      }
-      Rule::OneOf(allowed) => {
-        if allowed.iter().any(|v| v == value) {
-          Ok(())
-        } else {
-          Err(Violation::not_one_of())
-        }
-      }
-      Rule::All(rules) => {
-        for rule in rules {
-          CompiledRule::new(rule.clone()).validate_str(value)?;
-        }
-        Ok(())
-      }
-      Rule::Any(rules) => {
-        if rules.is_empty() {
-          return Ok(());
-        }
-        let mut last_err = None;
-        for rule in rules {
-          match CompiledRule::new(rule.clone()).validate_str(value) {
-            Ok(()) => return Ok(()),
-            Err(e) => last_err = Some(e),
-          }
-        }
-        Err(last_err.unwrap())
-      }
-      Rule::Not(inner) => match CompiledRule::new((**inner).clone()).validate_str(value) {
-        Ok(()) => Err(Violation::negation_failed()),
-        Err(_) => Ok(()),
-      },
-      Rule::When {
-        condition,
-        then_rule,
-        else_rule,
-      } => {
-        let should_apply = condition.evaluate_str(value);
-        if should_apply {
-          CompiledRule::new((**then_rule).clone()).validate_str(value)
-        } else {
-          match else_rule {
-            Some(rule) => CompiledRule::new((**rule).clone()).validate_str(value),
-            None => Ok(()),
-          }
-        }
-      }
-      Rule::Custom(f) => f(&value.to_string()),
-      #[cfg(feature = "async")]
-      Rule::CustomAsync(_) => Ok(()),
-      Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
-      Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref();
-        match CompiledRule::new((**rule).clone()).validate_str(value) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(&value.to_string(), violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
-      }
-      Rule::Min(_) | Rule::Max(_) | Rule::Range { .. } | Rule::Step(_) => Ok(()),
-    }
-  }
-
-  /// Validates a string value and collects all violations.
-  #[allow(dead_code)] // Reserved for a future `validate_all` public API
-  pub(crate) fn validate_str_all(&self, value: &str) -> Result<(), crate::Violations> {
-    self.rule.validate_str_all(value)
-  }
-}
-
 // ============================================================================
 // Async String Validation
 // ============================================================================
@@ -863,13 +706,6 @@ impl Rule<String> {
 impl crate::ValidateRefAsync<str> for Rule<String> {
   async fn validate_ref_async(&self, value: &str) -> crate::ValidatorResult {
     self.validate_str_async(value).await
-  }
-}
-
-#[cfg(feature = "async")]
-impl crate::ValidateRefAsync<str> for CompiledRule<String> {
-  async fn validate_ref_async(&self, value: &str) -> crate::ValidatorResult {
-    self.rule.validate_str_async(value).await
   }
 }
 
@@ -1057,11 +893,11 @@ mod tests {
 
   #[test]
   fn test_validate_str_url_compiled() {
-    let compiled = Rule::<String>::Url(crate::UrlOptions::default()).compile();
-    assert!(compiled.validate_str("http://example.com").is_ok());
-    assert!(compiled.validate_str("https://example.com/path?q=1#frag").is_ok());
-    assert!(compiled.validate_str("not-a-url").is_err());
-    assert!(compiled.validate_str("ftp://example.com").is_err());
+    let rule = Rule::<String>::Url(crate::UrlOptions::default());
+    assert!(rule.validate_str("http://example.com").is_ok());
+    assert!(rule.validate_str("https://example.com/path?q=1#frag").is_ok());
+    assert!(rule.validate_str("not-a-url").is_err());
+    assert!(rule.validate_str("ftp://example.com").is_err());
   }
 
   #[test]
@@ -1211,104 +1047,6 @@ mod tests {
   }
 
   // ========================================================================
-  // CompiledRule (String) Tests
-  // ========================================================================
-
-  #[test]
-  fn test_compiled_rule_string_basic() {
-    let rule = Rule::<String>::MinLength(3).and(Rule::MaxLength(10));
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_str("hello").is_ok());
-    assert!(compiled.validate_str("hi").is_err());
-    assert!(compiled.validate_str("hello world!").is_err());
-  }
-
-  #[test]
-  fn test_compiled_rule_pattern_cached() {
-    let rule = Rule::<String>::pattern(r"^\d{3}-\d{4}$").unwrap();
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_str("123-4567").is_ok());
-    assert!(compiled.validate_str("999-0000").is_ok());
-    assert!(compiled.validate_str("abc-defg").is_err());
-    assert!(compiled.validate_str("12-345").is_err());
-  }
-
-  #[test]
-  fn test_compiled_rule_email() {
-    let rule = Rule::<String>::Email(Default::default());
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_str("user@example.com").is_ok());
-    assert!(compiled.validate_str("test@sub.domain.org").is_ok());
-    assert!(compiled.validate_str("invalid").is_err());
-  }
-
-  #[test]
-  fn test_compiled_rule_url() {
-    let rule = Rule::<String>::Url(crate::UrlOptions::default());
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_str("http://example.com").is_ok());
-    assert!(compiled.validate_str("https://example.com/path?query=1").is_ok());
-    assert!(compiled.validate_str("not-a-url").is_err());
-  }
-
-  #[test]
-  fn test_compiled_rule_clone() {
-    let rule = Rule::<String>::pattern(r"^\w+$").unwrap();
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_str("hello").is_ok());
-
-    let cloned = compiled.clone();
-    assert!(cloned.validate_str("world").is_ok());
-  }
-
-  #[test]
-  fn test_compiled_rule_debug() {
-    let rule = Rule::<String>::MinLength(5);
-    let compiled = rule.compile();
-    let debug_str = format!("{:?}", compiled);
-    assert!(debug_str.contains("CompiledRule"));
-    assert!(debug_str.contains("MinLength"));
-  }
-
-  #[test]
-  fn test_compiled_rule_into_rule() {
-    let rule = Rule::<String>::Required;
-    let compiled = rule.clone().compile();
-    let recovered = compiled.into_rule();
-    assert_eq!(recovered, rule);
-  }
-
-  #[test]
-  fn test_compiled_rule_with_trait() {
-    use crate::ValidateRef;
-
-    let rule = Rule::<String>::MinLength(3);
-    let compiled = rule.compile();
-
-    let validator: &dyn ValidateRef<str> = &compiled;
-    assert!(validator.validate_ref("hello").is_ok());
-    assert!(validator.validate_ref("hi").is_err());
-  }
-
-  #[test]
-  fn test_compiled_rule_validate_all() {
-    let rule = Rule::<String>::MinLength(3)
-      .and(Rule::MaxLength(5))
-      .and(Rule::pattern(r"^[a-z]+$").unwrap());
-    let compiled = rule.compile();
-
-    assert!(compiled.validate_str_all("abc").is_ok());
-
-    let result = compiled.validate_str_all("AB");
-    assert!(result.is_err());
-  }
-
-  // ========================================================================
   // URI Validation Tests
   // ========================================================================
 
@@ -1412,15 +1150,14 @@ mod tests {
   }
 
   #[test]
-  fn test_compiled_rule_uri() {
+  fn test_validate_uri_scheme_restriction() {
     let rule = Rule::<String>::Uri(crate::UriOptions {
       allow_absolute: true,
       allow_relative: false,
       allowed_schemes: Some(vec!["https".into()]),
     });
-    let compiled = rule.compile();
-    assert!(compiled.validate_str("https://example.com").is_ok());
-    assert!(compiled.validate_str("http://example.com").is_err());
+    assert!(rule.validate_str("https://example.com").is_ok());
+    assert!(rule.validate_str("http://example.com").is_err());
   }
 
   // ========================================================================
@@ -1543,18 +1280,6 @@ mod tests {
     let rule = Rule::<String>::Required.and(Rule::Ip(crate::IpOptions::default()));
     assert!(rule.validate_str("192.168.1.1").is_ok());
     assert!(rule.validate_str("").is_err());
-  }
-
-  #[test]
-  fn test_compiled_rule_ip() {
-    let rule = Rule::<String>::Ip(crate::IpOptions {
-      allow_ipv4: true,
-      allow_ipv6: false,
-      ..Default::default()
-    });
-    let compiled = rule.compile();
-    assert!(compiled.validate_str("192.168.1.1").is_ok());
-    assert!(compiled.validate_str("::1").is_err());
   }
 
   #[test]
@@ -1766,14 +1491,13 @@ mod tests {
   }
 
   #[test]
-  fn test_compiled_rule_hostname() {
+  fn test_validate_hostname_no_ip() {
     let rule = Rule::<String>::Hostname(crate::HostnameOptions {
       allow_ip: false,
       ..Default::default()
     });
-    let compiled = rule.compile();
-    assert!(compiled.validate_str("example.com").is_ok());
-    assert!(compiled.validate_str("192.168.1.1").is_err());
+    assert!(rule.validate_str("example.com").is_ok());
+    assert!(rule.validate_str("192.168.1.1").is_err());
   }
 
   #[test]

--- a/crates/validation/src/rule_impls/value.rs
+++ b/crates/validation/src/rule_impls/value.rs
@@ -28,10 +28,8 @@ impl Condition<Value> {
       Condition::LessThan(threshold) => {
         value.partial_cmp(threshold) == Some(Ordering::Less)
       }
-      Condition::Matches(pattern) => match value {
-        Value::Str(s) => regex::Regex::new(pattern)
-          .map(|re| re.is_match(s))
-          .unwrap_or(false),
+      Condition::Matches(cp) => match value {
+        Value::Str(s) => cp.0.is_match(s),
         _ => false,
       },
       Condition::Custom(f) => f(value),
@@ -105,9 +103,9 @@ impl Rule<Value> {
       },
 
       // ---- String rules ----
-      Rule::Pattern(pattern) => match value {
+      Rule::Pattern(cp) => match value {
         Value::Str(s) => {
-          Rule::<String>::Pattern(pattern.clone()).validate_str(s.as_str())
+          Rule::<String>::Pattern(cp.clone()).validate_str(s.as_str())
         }
         _ => Err(Violation::new(
           ViolationType::TypeMismatch,
@@ -476,7 +474,7 @@ mod tests {
 
   #[test]
   fn test_pattern() {
-    let rule = Rule::<Value>::Pattern(r"^\d+$".to_string());
+    let rule = Rule::<Value>::pattern(r"^\d+$").unwrap();
     assert!(rule.validate_value(&Value::Str("123".to_string())).is_ok());
     assert!(rule.validate_value(&Value::Str("abc".to_string())).is_err());
   }

--- a/md/docs/rule_type_dependencies.md
+++ b/md/docs/rule_type_dependencies.md
@@ -19,9 +19,8 @@
 
 | Item | Usage |
 |---|---|
-| `std::fmt::{self, Debug, Display}` | `Debug` impls for `Rule<T>`, `Condition<T>`, `CompiledRule<T>` |
+| `std::fmt::{self, Debug, Display}` | `Debug` impls for `Rule<T>`, `Condition<T>` |
 | `std::sync::Arc` | `Custom` variants in both `Rule<T>` and `Condition<T>`; `Message::Provider` |
-| `std::sync::OnceLock` | `CompiledRule<T>` — lazy cache for compiled validators |
 
 ## Crate-Internal Type Dependencies
 
@@ -36,10 +35,9 @@
 | `WithLength` (trait) | `traits.rs` | Bound on `Rule<T>::validate_len` |
 | `InputValue` (trait) | `traits.rs` | Supertrait of `ScalarValue` |
 | `NumberValue` (trait) | `traits.rs` | Supertrait of `SteppableValue` |
-| `Validate` (trait) | `traits.rs` | Implemented by `Rule<T>` for steppable/scalar types, `CompiledRule<T>` |
-| `ValidateRef` (trait) | `traits.rs` | Implemented by `CompiledRule<String>` |
+| `Validate` (trait) | `traits.rs` | Implemented by `Rule<T>` for steppable/scalar types |
+| `ValidateRef` (trait) | `traits.rs` | Implemented by `Rule<String>` |
 | `ToAttributesList` (trait) | `traits.rs` | Implemented for `Rule<T: Serialize>` |
-| `CachedStringValidators` | `impls/string.rs` | `CompiledRule<T>` field (cached regex patterns) |
 
 ## Trait Bounds on `T` (by impl block)
 
@@ -50,11 +48,9 @@
 | `PartialEq for Rule<T>` | `PartialEq` |
 | `Rule<T>` combinators (`and`, `or`, `not`, `when`, etc.) | *(none — unconstrained)* |
 | `Rule<String>::validate_str` | `T = String` (concrete) |
-| `Rule<String>::compile` | `T = String` (concrete) |
 | `Rule<T>::validate_step` | `SteppableValue + IsEmpty` |
 | `Rule<T>::validate_scalar` | `ScalarValue + IsEmpty` |
 | `Rule<T>::validate_len` | `WithLength` |
-| `Rule<T>::compile` (generic) | `SteppableValue + IsEmpty + Clone` |
 | `Validate<T> for Rule<T>` | `SteppableValue + IsEmpty` |
 | `ToAttributesList for Rule<T>` | `Serialize` |
 | `Condition<T>::evaluate` | `PartialEq + PartialOrd + IsEmpty` |

--- a/md/plans/filter_enum_to_walrs_filter.md
+++ b/md/plans/filter_enum_to_walrs_filter.md
@@ -32,7 +32,7 @@ similarly, and `walrs_inputfilter` re-exporting it.
 ```
 crates/validation/src/
 ├── lib.rs              # pub use rule::{Rule, ...}; pub(crate) mod rule_impls;
-├── rule.rs             # Rule<T> enum, Condition<T>, CompiledRule<T>, combinators
+├── rule.rs             # Rule<T> enum, Condition<T>, combinators
 ├── rule_impls/
 │   ├── mod.rs          # pub(crate) mod string; pub(crate) mod length; ...
 │   ├── string.rs       # impl Rule<String> { validate_str(), validate_str_all(), ... }


### PR DESCRIPTION
## Summary

Introduces a `CompiledPattern` newtype wrapping `regex::Regex` that compiles the pattern at construction time instead of on every validation call.

Closes #122

## Changes

- **New `CompiledPattern` struct** — wraps `regex::Regex` with `Clone`, `Debug`, `PartialEq`, `TryFrom<&str>`, `TryFrom<String>`, `Serialize`, `Deserialize`
- **`Rule::Pattern(String)` → `Rule::Pattern(CompiledPattern)`** — eliminates per-call `Regex::new()`
- **`Condition::Matches(String)` → `Condition::Matches(CompiledPattern)`** — same fix for conditional matching
- **`Rule::pattern()` is now fallible** — returns `Result<Self, regex::Error>`
- **`CachedStringValidators.pattern_regex` removed** — redundant since `Pattern` always holds a compiled regex
- Updated all call-sites across examples (7 files), benchmarks, tests, and README

## Verification

- `cargo test --workspace` — all tests pass
- `cargo build --examples` — all examples build
- `cargo bench -p walrs_validation --no-run` — benchmarks compile
- `cargo doc -p walrs_validation --no-deps` — no warnings
