### PR TITLE
feat(validation): add Option<T> validation support

### DIFF
--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -74,6 +74,40 @@ assert!(range_rule.validate(50).is_ok());
 assert!(range_rule.validate(-1).is_err());
 ```
 
+## `Option<T>` Validation
+
+`Rule<T>` implements `Validate<Option<T>>` and `ValidateRef<Option<T>>`,
+allowing direct validation of optional values:
+
+- `None` with `Rule::Required` → `Err(Violation::value_missing())`
+- `None` without `Required` → `Ok(())`
+- `Some(v)` → delegates to the inner `Validate<T>` / `ValidateRef<T>` impl
+
+```rust
+use walrs_validation::{Rule, Validate, ValidateRef};
+
+let rule = Rule::<String>::Required.and(Rule::MinLength(3));
+
+// None fails because the rule includes Required
+assert!(rule.validate(None::<String>).is_err());
+
+// Some delegates to inner validation
+assert!(rule.validate(Some("hello".to_string())).is_ok());
+assert!(rule.validate(Some("hi".to_string())).is_err());
+
+// ValidateRef works with references
+assert!(rule.validate_ref(&None::<String>).is_err());
+assert!(rule.validate_ref(&Some("hello".to_string())).is_ok());
+
+// Without Required, None is accepted
+let optional_rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+assert!(optional_rule.validate(None::<i32>).is_ok());
+assert!(optional_rule.validate(Some(50)).is_ok());
+```
+
+Async variants (`ValidateAsync<Option<T>>`, `ValidateRefAsync<Option<T>>`) are
+also available when the `async` feature is enabled.
+
 ## Validation Traits
 
 The crate provides two main validation traits:

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -52,6 +52,37 @@
 //! assert!(range_rule.validate(50).is_ok());
 //! assert!(range_rule.validate(-1).is_err());
 //! ```
+//!
+//! ## `Option<T>` Validation
+//!
+//! `Rule<T>` implements `Validate<Option<T>>` and `ValidateRef<Option<T>>`,
+//! allowing direct validation of optional values:
+//!
+//! - `None` with `Rule::Required` → `Err(Violation::value_missing())`
+//! - `None` without `Required` → `Ok(())`
+//! - `Some(v)` → delegates to the inner `Validate<T>` / `ValidateRef<T>` impl
+//!
+//! ```rust
+//! use walrs_validation::{Rule, Validate, ValidateRef};
+//!
+//! let rule = Rule::<String>::Required.and(Rule::MinLength(3));
+//!
+//! // None fails because the rule includes Required
+//! assert!(rule.validate(None::<String>).is_err());
+//!
+//! // Some delegates to inner validation
+//! assert!(rule.validate(Some("hello".to_string())).is_ok());
+//! assert!(rule.validate(Some("hi".to_string())).is_err());
+//!
+//! // ValidateRef works with references
+//! assert!(rule.validate_ref(&None::<String>).is_err());
+//! assert!(rule.validate_ref(&Some("hello".to_string())).is_ok());
+//!
+//! // Without Required, None is accepted
+//! let optional_rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+//! assert!(optional_rule.validate(None::<i32>).is_ok());
+//! assert!(optional_rule.validate(Some(50)).is_ok());
+//! ```
 
 pub use indexmap;
 

--- a/crates/validation/src/rule_impls/date_chrono.rs
+++ b/crates/validation/src/rule_impls/date_chrono.rs
@@ -307,6 +307,26 @@ impl ValidateRef<NaiveDate> for Rule<NaiveDate> {
   }
 }
 
+impl Validate<Option<NaiveDate>> for Rule<NaiveDate> {
+  fn validate(&self, value: Option<NaiveDate>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_date(&v),
+    }
+  }
+}
+
+impl ValidateRef<Option<NaiveDate>> for Rule<NaiveDate> {
+  fn validate_ref(&self, value: &Option<NaiveDate>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_date(v),
+    }
+  }
+}
+
 // ============================================================================
 // Native Type Validation: Rule<NaiveDateTime>
 // ============================================================================
@@ -412,6 +432,26 @@ impl Validate<NaiveDateTime> for Rule<NaiveDateTime> {
 impl ValidateRef<NaiveDateTime> for Rule<NaiveDateTime> {
   fn validate_ref(&self, value: &NaiveDateTime) -> crate::ValidatorResult {
     self.validate_datetime(value)
+  }
+}
+
+impl Validate<Option<NaiveDateTime>> for Rule<NaiveDateTime> {
+  fn validate(&self, value: Option<NaiveDateTime>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_datetime(&v),
+    }
+  }
+}
+
+impl ValidateRef<Option<NaiveDateTime>> for Rule<NaiveDateTime> {
+  fn validate_ref(&self, value: &Option<NaiveDateTime>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_datetime(v),
+    }
   }
 }
 
@@ -733,5 +773,75 @@ mod tests {
     let err = result.unwrap_err();
     assert_eq!(err.violation_type(), ViolationType::CustomError);
     assert!(err.message().contains("Invalid min date bound"));
+  }
+
+  // ========================================================================
+  // Option<NaiveDate> / Option<NaiveDateTime> Validation (trait impls)
+  // ========================================================================
+
+  #[test]
+  fn test_option_date_none_required() {
+    let rule = Rule::<NaiveDate>::Required;
+    assert!(rule.validate(None::<NaiveDate>).is_err());
+    assert!(rule.validate_ref(&None::<NaiveDate>).is_err());
+  }
+
+  #[test]
+  fn test_option_date_none_not_required() {
+    let d = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+    let rule = Rule::<NaiveDate>::Min(d);
+    assert!(rule.validate(None::<NaiveDate>).is_ok());
+    assert!(rule.validate_ref(&None::<NaiveDate>).is_ok());
+  }
+
+  #[test]
+  fn test_option_date_some_valid() {
+    let min = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+    let val = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
+    let rule = Rule::<NaiveDate>::Min(min);
+    assert!(rule.validate(Some(val)).is_ok());
+    assert!(rule.validate_ref(&Some(val)).is_ok());
+  }
+
+  #[test]
+  fn test_option_date_some_invalid() {
+    let min = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let val = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let rule = Rule::<NaiveDate>::Min(min);
+    assert!(rule.validate(Some(val)).is_err());
+    assert!(rule.validate_ref(&Some(val)).is_err());
+  }
+
+  #[test]
+  fn test_option_datetime_none_required() {
+    let rule = Rule::<NaiveDateTime>::Required;
+    assert!(rule.validate(None::<NaiveDateTime>).is_err());
+    assert!(rule.validate_ref(&None::<NaiveDateTime>).is_err());
+  }
+
+  #[test]
+  fn test_option_datetime_none_not_required() {
+    let dt = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let rule = Rule::<NaiveDateTime>::Min(dt);
+    assert!(rule.validate(None::<NaiveDateTime>).is_ok());
+    assert!(rule.validate_ref(&None::<NaiveDateTime>).is_ok());
+  }
+
+  #[test]
+  fn test_option_datetime_some_valid() {
+    let min = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let val = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap().and_hms_opt(12, 0, 0).unwrap();
+    let rule = Rule::<NaiveDateTime>::Min(min);
+    assert!(rule.validate(Some(val)).is_ok());
+    assert!(rule.validate_ref(&Some(val)).is_ok());
+  }
+
+  #[test]
+  fn test_option_datetime_some_invalid() {
+    let min = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let val = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap().and_hms_opt(12, 0, 0).unwrap();
+    let rule = Rule::<NaiveDateTime>::Min(min);
+    assert!(rule.validate(Some(val)).is_err());
+    assert!(rule.validate_ref(&Some(val)).is_err());
   }
 }

--- a/crates/validation/src/rule_impls/date_jiff.rs
+++ b/crates/validation/src/rule_impls/date_jiff.rs
@@ -307,6 +307,26 @@ impl ValidateRef<Date> for Rule<Date> {
   }
 }
 
+impl Validate<Option<Date>> for Rule<Date> {
+  fn validate(&self, value: Option<Date>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_date(&v),
+    }
+  }
+}
+
+impl ValidateRef<Option<Date>> for Rule<Date> {
+  fn validate_ref(&self, value: &Option<Date>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_date(v),
+    }
+  }
+}
+
 // ============================================================================
 // Native Type Validation: Rule<DateTime>
 // ============================================================================
@@ -412,6 +432,26 @@ impl Validate<DateTime> for Rule<DateTime> {
 impl ValidateRef<DateTime> for Rule<DateTime> {
   fn validate_ref(&self, value: &DateTime) -> crate::ValidatorResult {
     self.validate_datetime(value)
+  }
+}
+
+impl Validate<Option<DateTime>> for Rule<DateTime> {
+  fn validate(&self, value: Option<DateTime>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_datetime(&v),
+    }
+  }
+}
+
+impl ValidateRef<Option<DateTime>> for Rule<DateTime> {
+  fn validate_ref(&self, value: &Option<DateTime>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_datetime(v),
+    }
   }
 }
 
@@ -721,5 +761,79 @@ mod tests {
     let err = result.unwrap_err();
     assert_eq!(err.violation_type(), ViolationType::CustomError);
     assert!(err.message().contains("Invalid min date bound"));
+  }
+
+  // ========================================================================
+  // Option<Date> Validation
+  // ========================================================================
+
+  #[test]
+  fn test_option_date_none_required() {
+    let rule = Rule::<Date>::Required;
+    assert!(rule.validate(None::<Date>).is_err());
+    assert!(rule.validate_ref(&None::<Date>).is_err());
+  }
+
+  #[test]
+  fn test_option_date_none_not_required() {
+    let d = jiff::civil::date(2024, 1, 1);
+    let rule = Rule::<Date>::Min(d);
+    assert!(rule.validate(None::<Date>).is_ok());
+    assert!(rule.validate_ref(&None::<Date>).is_ok());
+  }
+
+  #[test]
+  fn test_option_date_some_valid() {
+    let min = jiff::civil::date(2024, 1, 1);
+    let val = jiff::civil::date(2024, 6, 15);
+    let rule = Rule::<Date>::Min(min);
+    assert!(rule.validate(Some(val)).is_ok());
+    assert!(rule.validate_ref(&Some(val)).is_ok());
+  }
+
+  #[test]
+  fn test_option_date_some_invalid() {
+    let min = jiff::civil::date(2024, 6, 1);
+    let val = jiff::civil::date(2024, 1, 15);
+    let rule = Rule::<Date>::Min(min);
+    assert!(rule.validate(Some(val)).is_err());
+    assert!(rule.validate_ref(&Some(val)).is_err());
+  }
+
+  // ========================================================================
+  // Option<DateTime> Validation
+  // ========================================================================
+
+  #[test]
+  fn test_option_datetime_none_required() {
+    let rule = Rule::<DateTime>::Required;
+    assert!(rule.validate(None::<DateTime>).is_err());
+    assert!(rule.validate_ref(&None::<DateTime>).is_err());
+  }
+
+  #[test]
+  fn test_option_datetime_none_not_required() {
+    let dt = jiff::civil::date(2024, 1, 1).at(0, 0, 0, 0);
+    let rule = Rule::<DateTime>::Min(dt);
+    assert!(rule.validate(None::<DateTime>).is_ok());
+    assert!(rule.validate_ref(&None::<DateTime>).is_ok());
+  }
+
+  #[test]
+  fn test_option_datetime_some_valid() {
+    let min = jiff::civil::date(2024, 1, 1).at(0, 0, 0, 0);
+    let val = jiff::civil::date(2024, 6, 15).at(12, 0, 0, 0);
+    let rule = Rule::<DateTime>::Min(min);
+    assert!(rule.validate(Some(val)).is_ok());
+    assert!(rule.validate_ref(&Some(val)).is_ok());
+  }
+
+  #[test]
+  fn test_option_datetime_some_invalid() {
+    let min = jiff::civil::date(2024, 6, 1).at(0, 0, 0, 0);
+    let val = jiff::civil::date(2024, 1, 15).at(12, 0, 0, 0);
+    let rule = Rule::<DateTime>::Min(min);
+    assert!(rule.validate(Some(val)).is_err());
+    assert!(rule.validate_ref(&Some(val)).is_err());
   }
 }

--- a/crates/validation/src/rule_impls/scalar.rs
+++ b/crates/validation/src/rule_impls/scalar.rs
@@ -1,5 +1,5 @@
 use crate::rule::{Rule, RuleResult};
-use crate::traits::{IsEmpty, Validate};
+use crate::traits::{IsEmpty, Validate, ValidateRef};
 use crate::{ScalarValue, Violation, Violations};
 
 impl<T: ScalarValue + IsEmpty> Rule<T> {
@@ -263,6 +263,46 @@ impl Validate<char> for Rule<char> {
   }
 }
 
+impl Validate<Option<bool>> for Rule<bool> {
+  fn validate(&self, value: Option<bool>) -> crate::traits::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate(v),
+    }
+  }
+}
+
+impl ValidateRef<Option<bool>> for Rule<bool> {
+  fn validate_ref(&self, value: &Option<bool>) -> crate::traits::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate(*v),
+    }
+  }
+}
+
+impl Validate<Option<char>> for Rule<char> {
+  fn validate(&self, value: Option<char>) -> crate::traits::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate(v),
+    }
+  }
+}
+
+impl ValidateRef<Option<char>> for Rule<char> {
+  fn validate_ref(&self, value: &Option<char>) -> crate::traits::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate(*v),
+    }
+  }
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -505,5 +545,73 @@ mod tests {
     assert!(rule.validate_scalar('a').is_ok());
     assert!(rule.validate_scalar('z').is_ok());
     assert!(rule.validate_scalar('A').is_err());
+  }
+
+  // ==========================================================================
+  // Option<bool> / Option<char> Validation (trait impls)
+  // ==========================================================================
+
+  #[test]
+  fn test_option_bool_none_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<bool>::Required;
+    assert!(Validate::<Option<bool>>::validate(&rule, None).is_err());
+    assert!(ValidateRef::<Option<bool>>::validate_ref(&rule, &None).is_err());
+  }
+
+  #[test]
+  fn test_option_bool_none_not_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<bool>::Equals(true);
+    assert!(Validate::<Option<bool>>::validate(&rule, None).is_ok());
+    assert!(ValidateRef::<Option<bool>>::validate_ref(&rule, &None).is_ok());
+  }
+
+  #[test]
+  fn test_option_bool_some_valid() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<bool>::Equals(true);
+    assert!(Validate::<Option<bool>>::validate(&rule, Some(true)).is_ok());
+    assert!(ValidateRef::<Option<bool>>::validate_ref(&rule, &Some(true)).is_ok());
+  }
+
+  #[test]
+  fn test_option_bool_some_invalid() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<bool>::Equals(true);
+    assert!(Validate::<Option<bool>>::validate(&rule, Some(false)).is_err());
+    assert!(ValidateRef::<Option<bool>>::validate_ref(&rule, &Some(false)).is_err());
+  }
+
+  #[test]
+  fn test_option_char_none_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<char>::Required;
+    assert!(Validate::<Option<char>>::validate(&rule, None).is_err());
+    assert!(ValidateRef::<Option<char>>::validate_ref(&rule, &None).is_err());
+  }
+
+  #[test]
+  fn test_option_char_none_not_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<char>::Equals('a');
+    assert!(Validate::<Option<char>>::validate(&rule, None).is_ok());
+    assert!(ValidateRef::<Option<char>>::validate_ref(&rule, &None).is_ok());
+  }
+
+  #[test]
+  fn test_option_char_some_valid() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<char>::Equals('a');
+    assert!(Validate::<Option<char>>::validate(&rule, Some('a')).is_ok());
+    assert!(ValidateRef::<Option<char>>::validate_ref(&rule, &Some('a')).is_ok());
+  }
+
+  #[test]
+  fn test_option_char_some_invalid() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<char>::Equals('a');
+    assert!(Validate::<Option<char>>::validate(&rule, Some('b')).is_err());
+    assert!(ValidateRef::<Option<char>>::validate_ref(&rule, &Some('b')).is_err());
   }
 }

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -1,5 +1,5 @@
 use crate::rule::{Rule, RuleResult};
-use crate::traits::{IsEmpty, Validate};
+use crate::traits::{IsEmpty, Validate, ValidateRef};
 use crate::{SteppableValue, Violation};
 
 impl<T: SteppableValue + IsEmpty> Rule<T> {
@@ -218,6 +218,26 @@ impl<T: SteppableValue + IsEmpty + Clone> Validate<T> for Rule<T> {
   }
 }
 
+impl<T: SteppableValue + IsEmpty + Clone> Validate<Option<T>> for Rule<T> {
+  fn validate(&self, value: Option<T>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate(v),
+    }
+  }
+}
+
+impl<T: SteppableValue + IsEmpty + Clone> ValidateRef<Option<T>> for Rule<T> {
+  fn validate_ref(&self, value: &Option<T>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate(*v),
+    }
+  }
+}
+
 // ============================================================================
 // Async Numeric Validation
 // ============================================================================
@@ -309,6 +329,28 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<T> 
   }
 }
 
+#[cfg(feature = "async")]
+impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<Option<T>> for Rule<T> {
+  async fn validate_async(&self, value: Option<T>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_step_async(v).await,
+    }
+  }
+}
+
+#[cfg(feature = "async")]
+impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateRefAsync<Option<T>> for Rule<T> {
+  async fn validate_ref_async(&self, value: &Option<T>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_step_async(*v).await,
+    }
+  }
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -316,6 +358,7 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<T> 
 #[cfg(test)]
 mod tests {
   use crate::rule::{Condition, Rule};
+  use crate::{Validate, ValidateRef};
 
   // ========================================================================
   // Numeric Validation Tests
@@ -480,6 +523,91 @@ mod tests {
     let eq = Condition::<i32>::Equals(42);
     assert!(eq.evaluate(&42));
     assert!(!eq.evaluate(&0));
+  }
+
+  // ========================================================================
+  // Option<T> Validation (Numeric)
+  // ========================================================================
+
+  #[test]
+  fn test_option_none_required_i32() {
+    let rule = Rule::<i32>::Required;
+    assert!(rule.validate(None::<i32>).is_err());
+    assert!(rule.validate_ref(&None::<i32>).is_err());
+  }
+
+  #[test]
+  fn test_option_none_not_required_i32() {
+    let rule = Rule::<i32>::Min(0);
+    assert!(rule.validate(None::<i32>).is_ok());
+    assert!(rule.validate_ref(&None::<i32>).is_ok());
+  }
+
+  #[test]
+  fn test_option_some_valid_i32() {
+    let rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+    assert!(rule.validate(Some(50)).is_ok());
+    assert!(rule.validate_ref(&Some(50)).is_ok());
+  }
+
+  #[test]
+  fn test_option_some_invalid_i32() {
+    let rule = Rule::<i32>::Min(0);
+    assert!(rule.validate(Some(-1)).is_err());
+    assert!(rule.validate_ref(&Some(-1)).is_err());
+  }
+
+  #[test]
+  fn test_option_none_all_with_required() {
+    let rule = Rule::<i32>::Required.and(Rule::Min(0));
+    assert!(rule.validate(None::<i32>).is_err());
+  }
+
+  #[test]
+  fn test_option_none_all_without_required() {
+    let rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+    assert!(rule.validate(None::<i32>).is_ok());
+  }
+
+  #[test]
+  fn test_option_some_valid_f64() {
+    let rule = Rule::<f64>::Min(0.0).and(Rule::Max(1.0));
+    assert!(rule.validate(Some(0.5)).is_ok());
+    assert!(rule.validate_ref(&Some(0.5)).is_ok());
+  }
+
+  #[test]
+  fn test_option_some_invalid_f64() {
+    let rule = Rule::<f64>::Min(0.0);
+    assert!(rule.validate(Some(-0.1)).is_err());
+    assert!(rule.validate_ref(&Some(-0.1)).is_err());
+  }
+
+  #[cfg(feature = "async")]
+  mod async_option_tests {
+    use crate::rule::Rule;
+    use crate::{ValidateAsync, ValidateRefAsync};
+
+    #[tokio::test]
+    async fn test_async_option_none_required() {
+      let rule = Rule::<i32>::Required;
+      assert!(rule.validate_async(None::<i32>).await.is_err());
+      assert!(rule.validate_ref_async(&None::<i32>).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_none_not_required() {
+      let rule = Rule::<i32>::Min(0);
+      assert!(rule.validate_async(None::<i32>).await.is_ok());
+      assert!(rule.validate_ref_async(&None::<i32>).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_some_valid() {
+      let rule = Rule::<i32>::Min(0);
+      assert!(rule.validate_async(Some(5)).await.is_ok());
+      assert!(rule.validate_ref_async(&Some(5)).await.is_ok());
+    }
   }
 }
 

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -637,58 +637,6 @@ impl ValidateRef<Option<String>> for Rule<String> {
   }
 }
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn validate_option_string_none_is_ok_when_not_required() {
-    let rule = Rule::<String>::default();
-
-    assert!(Validate::<Option<String>>::validate(&rule, None).is_ok());
-  }
-
-  #[test]
-  fn validate_option_string_none_errors_when_required() {
-    let rule = Rule::<String>::default().required();
-
-    let result = Validate::<Option<String>>::validate(&rule, None);
-    assert_eq!(result, Err(Violation::value_missing()));
-  }
-
-  #[test]
-  fn validate_option_string_some_delegates_to_string_validation() {
-    let rule = Rule::<String>::default().email(EmailOptions::default());
-
-    assert!(Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok());
-    assert!(Validate::<Option<String>>::validate(&rule, Some("not-an-email".to_owned())).is_err());
-  }
-
-  #[test]
-  fn validate_ref_option_string_none_is_ok_when_not_required() {
-    let rule = Rule::<String>::default();
-
-    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &None).is_ok());
-  }
-
-  #[test]
-  fn validate_ref_option_string_none_errors_when_required() {
-    let rule = Rule::<String>::default().required();
-
-    let result = ValidateRef::<Option<String>>::validate_ref(&rule, &None);
-    assert_eq!(result, Err(Violation::value_missing()));
-  }
-
-  #[test]
-  fn validate_ref_option_string_some_delegates_to_string_validation() {
-    let rule = Rule::<String>::default().email(EmailOptions::default());
-    let valid = Some("user@example.com".to_owned());
-    let invalid = Some("not-an-email".to_owned());
-
-    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &valid).is_ok());
-    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &invalid).is_err());
-  }
-}
 // ============================================================================
 // Async String Validation
 // ============================================================================
@@ -810,6 +758,59 @@ impl crate::ValidateRefAsync<Option<String>> for Rule<String> {
 #[cfg(test)]
 mod tests {
   use crate::rule::{Condition, Rule};
+  use crate::{EmailOptions, Validate, ValidateRef, Violation};
+
+  // ========================================================================
+  // Option<String> Validation Tests
+  // ========================================================================
+
+  #[test]
+  fn validate_option_string_none_is_ok_when_not_required() {
+    let rule = Rule::<String>::All(vec![]);
+
+    assert!(Validate::<Option<String>>::validate(&rule, None).is_ok());
+  }
+
+  #[test]
+  fn validate_option_string_none_errors_when_required() {
+    let rule = Rule::<String>::Required;
+
+    let result = Validate::<Option<String>>::validate(&rule, None);
+    assert_eq!(result, Err(Violation::value_missing()));
+  }
+
+  #[test]
+  fn validate_option_string_some_delegates_to_string_validation() {
+    let rule = Rule::<String>::Email(EmailOptions::default());
+
+    assert!(Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok());
+    assert!(Validate::<Option<String>>::validate(&rule, Some("not-an-email".to_owned())).is_err());
+  }
+
+  #[test]
+  fn validate_ref_option_string_none_is_ok_when_not_required() {
+    let rule = Rule::<String>::All(vec![]);
+
+    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &None).is_ok());
+  }
+
+  #[test]
+  fn validate_ref_option_string_none_errors_when_required() {
+    let rule = Rule::<String>::Required;
+
+    let result = ValidateRef::<Option<String>>::validate_ref(&rule, &None);
+    assert_eq!(result, Err(Violation::value_missing()));
+  }
+
+  #[test]
+  fn validate_ref_option_string_some_delegates_to_string_validation() {
+    let rule = Rule::<String>::Email(EmailOptions::default());
+    let valid = Some("user@example.com".to_owned());
+    let invalid = Some("not-an-email".to_owned());
+
+    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &valid).is_ok());
+    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &invalid).is_err());
+  }
 
   // ========================================================================
   // String Validation Tests

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -1,6 +1,6 @@
 use crate::rule::{Rule, RuleResult};
 use crate::Violation;
-use crate::traits::ValidateRef;
+use crate::traits::{Validate, ValidateRef};
 use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, UriOptions, UrlOptions, IpOptions};
 
 // ============================================================================
@@ -617,6 +617,26 @@ impl ValidateRef<str> for Rule<String> {
   }
 }
 
+impl Validate<Option<String>> for Rule<String> {
+  fn validate(&self, value: Option<String>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(ref v) => self.validate_ref(v.as_str()),
+    }
+  }
+}
+
+impl ValidateRef<Option<String>> for Rule<String> {
+  fn validate_ref(&self, value: &Option<String>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => ValidateRef::<str>::validate_ref(self, v.as_str()),
+    }
+  }
+}
+
 // ============================================================================
 // Async String Validation
 // ============================================================================
@@ -706,6 +726,28 @@ impl Rule<String> {
 impl crate::ValidateRefAsync<str> for Rule<String> {
   async fn validate_ref_async(&self, value: &str) -> crate::ValidatorResult {
     self.validate_str_async(value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateAsync<Option<String>> for Rule<String> {
+  async fn validate_async(&self, value: Option<String>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(ref v) => self.validate_str_async(v.as_str()).await,
+    }
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateRefAsync<Option<String>> for Rule<String> {
+  async fn validate_ref_async(&self, value: &Option<String>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_str_async(v.as_str()).await,
+    }
   }
 }
 

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -637,6 +637,58 @@ impl ValidateRef<Option<String>> for Rule<String> {
   }
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn validate_option_string_none_is_ok_when_not_required() {
+    let rule = Rule::<String>::default();
+
+    assert!(Validate::<Option<String>>::validate(&rule, None).is_ok());
+  }
+
+  #[test]
+  fn validate_option_string_none_errors_when_required() {
+    let rule = Rule::<String>::default().required();
+
+    let result = Validate::<Option<String>>::validate(&rule, None);
+    assert_eq!(result, Err(Violation::value_missing()));
+  }
+
+  #[test]
+  fn validate_option_string_some_delegates_to_string_validation() {
+    let rule = Rule::<String>::default().email(EmailOptions::default());
+
+    assert!(Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok());
+    assert!(Validate::<Option<String>>::validate(&rule, Some("not-an-email".to_owned())).is_err());
+  }
+
+  #[test]
+  fn validate_ref_option_string_none_is_ok_when_not_required() {
+    let rule = Rule::<String>::default();
+
+    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &None).is_ok());
+  }
+
+  #[test]
+  fn validate_ref_option_string_none_errors_when_required() {
+    let rule = Rule::<String>::default().required();
+
+    let result = ValidateRef::<Option<String>>::validate_ref(&rule, &None);
+    assert_eq!(result, Err(Violation::value_missing()));
+  }
+
+  #[test]
+  fn validate_ref_option_string_some_delegates_to_string_validation() {
+    let rule = Rule::<String>::default().email(EmailOptions::default());
+    let valid = Some("user@example.com".to_owned());
+    let invalid = Some("not-an-email".to_owned());
+
+    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &valid).is_ok());
+    assert!(ValidateRef::<Option<String>>::validate_ref(&rule, &invalid).is_err());
+  }
+}
 // ============================================================================
 // Async String Validation
 // ============================================================================

--- a/crates/validation/src/rule_impls/value.rs
+++ b/crates/validation/src/rule_impls/value.rs
@@ -311,6 +311,26 @@ impl Validate<Value> for Rule<Value> {
   }
 }
 
+impl Validate<Option<Value>> for Rule<Value> {
+  fn validate(&self, value: Option<Value>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(ref v) => ValidateRef::<Value>::validate_ref(self, v),
+    }
+  }
+}
+
+impl ValidateRef<Option<Value>> for Rule<Value> {
+  fn validate_ref(&self, value: &Option<Value>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => ValidateRef::<Value>::validate_ref(self, v),
+    }
+  }
+}
+
 // ============================================================================
 // Async Value Validation
 // ============================================================================
@@ -407,6 +427,28 @@ impl crate::ValidateRefAsync<Value> for Rule<Value> {
 impl crate::ValidateAsync<Value> for Rule<Value> {
   async fn validate_async(&self, value: Value) -> crate::ValidatorResult {
     self.validate_value_async(&value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateAsync<Option<Value>> for Rule<Value> {
+  async fn validate_async(&self, value: Option<Value>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(ref v) => self.validate_value_async(v).await,
+    }
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateRefAsync<Option<Value>> for Rule<Value> {
+  async fn validate_ref_async(&self, value: &Option<Value>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_value_async(v).await,
+    }
   }
 }
 
@@ -620,6 +662,60 @@ mod tests {
     let rule = Rule::<Value>::Min(value!(10));
     assert!(rule.validate_value(&value!(15)).is_ok());
     assert!(rule.validate_value(&value!(5)).is_err());
+  }
+
+  // ========================================================================
+  // Option<Value> Validation (trait impls)
+  // ========================================================================
+
+  #[test]
+  fn test_option_value_none_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<Value>::Required;
+    assert!(Validate::<Option<Value>>::validate(&rule, None).is_err());
+    assert!(ValidateRef::<Option<Value>>::validate_ref(&rule, &None).is_err());
+  }
+
+  #[test]
+  fn test_option_value_none_not_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<Value>::MinLength(3);
+    assert!(Validate::<Option<Value>>::validate(&rule, None).is_ok());
+    assert!(ValidateRef::<Option<Value>>::validate_ref(&rule, &None).is_ok());
+  }
+
+  #[test]
+  fn test_option_value_some_valid() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<Value>::MinLength(3);
+    let val = Value::Str("hello".to_string());
+    assert!(Validate::<Option<Value>>::validate(&rule, Some(val.clone())).is_ok());
+    assert!(ValidateRef::<Option<Value>>::validate_ref(&rule, &Some(val)).is_ok());
+  }
+
+  #[test]
+  fn test_option_value_some_invalid() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<Value>::MinLength(5);
+    let val = Value::Str("hi".to_string());
+    assert!(Validate::<Option<Value>>::validate(&rule, Some(val.clone())).is_err());
+    assert!(ValidateRef::<Option<Value>>::validate_ref(&rule, &Some(val)).is_err());
+  }
+
+  #[test]
+  fn test_option_value_none_all_with_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<Value>::Required.and(Rule::MinLength(3));
+    assert!(Validate::<Option<Value>>::validate(&rule, None).is_err());
+    assert!(ValidateRef::<Option<Value>>::validate_ref(&rule, &None).is_err());
+  }
+
+  #[test]
+  fn test_option_value_none_all_without_required() {
+    use crate::{Validate, ValidateRef};
+    let rule = Rule::<Value>::MinLength(3).and(Rule::MaxLength(10));
+    assert!(Validate::<Option<Value>>::validate(&rule, None).is_ok());
+    assert!(ValidateRef::<Option<Value>>::validate_ref(&rule, &None).is_ok());
   }
 }
 


### PR DESCRIPTION
## Summary

Add `Validate<Option<T>>` and `ValidateRef<Option<T>>` (plus async variants) trait implementations for `Rule<T>` across all supported types, enabling direct validation of optional values without manual unwrapping.

Closes #124

## Semantics

| Input | Condition | Result |
|-------|-----------|--------|
| `None` | `requires_value()` is true | `Err(Violation::value_missing())` |
| `None` | not required | `Ok(())` |
| `Some(v)` | — | Delegates to existing inner validation |

## Changes

**24 trait impls** across 6 `rule_impls` files:

| File | Impls |
|------|-------|
| `string.rs` | `Validate/ValidateRef/ValidateAsync/ValidateRefAsync<Option<String>>` |
| `scalar.rs` | `Validate/ValidateRef<Option<bool>>`, `Validate/ValidateRef<Option<char>>` |
| `value.rs` | `Validate/ValidateRef/ValidateAsync/ValidateRefAsync<Option<Value>>` |
| `steppable.rs` | Generic `Validate/ValidateRef/ValidateAsync/ValidateRefAsync<Option<T>>` |
| `date_jiff.rs` | `Validate/ValidateRef<Option<Date>>`, `Validate/ValidateRef<Option<DateTime>>` |
| `date_chrono.rs` | `Validate/ValidateRef<Option<NaiveDate>>`, `Validate/ValidateRef<Option<NaiveDateTime>>` |

**Docs**: Updated `lib.rs` module doc (with doc test) and `README.md` with an `Option<T> Validation` section.

## Testing

- 438 tests pass (`cargo test -p walrs_validation --features "async,chrono,jiff"`)
- Full workspace passes (`cargo test --workspace`)
- `cargo doc` builds clean
