### PR TITLE
feat(validation): implement WithLength for IndexMap and IndexSet

### DIFF
--- a/crates/validation/src/rule_impls/length.rs
+++ b/crates/validation/src/rule_impls/length.rs
@@ -281,6 +281,51 @@ mod tests {
   }
 
   #[test]
+  fn test_validate_len_indexmap() {
+    use indexmap::IndexMap;
+
+    let rule = Rule::<IndexMap<String, i32>>::MinLength(1).and(Rule::MaxLength(3));
+
+    let mut map = IndexMap::new();
+    map.insert("a".to_string(), 1);
+    assert!(rule.validate_len(&map).is_ok());
+
+    map.insert("b".to_string(), 2);
+    map.insert("c".to_string(), 3);
+    assert!(rule.validate_len(&map).is_ok());
+
+    map.insert("d".to_string(), 4);
+    assert!(rule.validate_len(&map).is_err());
+
+    let empty_map: IndexMap<String, i32> = IndexMap::new();
+    assert!(rule.validate_len(&empty_map).is_err());
+  }
+
+  #[test]
+  fn test_validate_len_indexset() {
+    use indexmap::IndexSet;
+
+    let rule = Rule::<IndexSet<String>>::MinLength(2).and(Rule::MaxLength(4));
+
+    let mut set = IndexSet::new();
+    set.insert("a".to_string());
+    assert!(rule.validate_len(&set).is_err()); // too short
+
+    set.insert("b".to_string());
+    assert!(rule.validate_len(&set).is_ok());
+
+    set.insert("c".to_string());
+    set.insert("d".to_string());
+    assert!(rule.validate_len(&set).is_ok());
+
+    set.insert("e".to_string());
+    assert!(rule.validate_len(&set).is_err()); // too long
+
+    let empty_set: IndexSet<String> = IndexSet::new();
+    assert!(rule.validate_len(&empty_set).is_err());
+  }
+
+  #[test]
   fn test_validate_len_all_violations() {
     // Contradictory rule - will always fail
     let rule = Rule::<Vec<i32>>::MinLength(3).and(Rule::MaxLength(2));

--- a/crates/validation/src/traits.rs
+++ b/crates/validation/src/traits.rs
@@ -1,4 +1,5 @@
 use crate::{Violation};
+use indexmap::{IndexMap, IndexSet};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 
 /// Result type for validation operations.
@@ -193,6 +194,8 @@ impl_with_length_len!(HashSet<T, S>, T, S);
 impl_with_length_len!(HashMap<K, V, S>, K, V, S);
 impl_with_length_len!(Vec<T>, T);
 impl_with_length_len!(VecDeque<T>, T);
+impl_with_length_len!(IndexMap<K, V, S>, K, V, S);
+impl_with_length_len!(IndexSet<T, S>, T, S);
 
 // ============================================================================
 // Async Validation Traits
@@ -309,6 +312,27 @@ mod tests {
     map.insert("a", 1);
     map.insert("b", 2);
     assert_eq!(map.length(), 2);
+  }
+
+  #[test]
+  fn test_with_length_indexmap() {
+    let mut map = IndexMap::new();
+    assert_eq!(map.length(), 0);
+    map.insert("a", 1);
+    map.insert("b", 2);
+    map.insert("c", 3);
+    assert_eq!(map.length(), 3);
+  }
+
+  #[test]
+  fn test_with_length_indexset() {
+    let mut set = IndexSet::new();
+    assert_eq!(set.length(), 0);
+    set.insert("x");
+    set.insert("y");
+    assert_eq!(set.length(), 2);
+    set.insert("x"); // duplicate — no change
+    assert_eq!(set.length(), 2);
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

Implements `WithLength` trait for `IndexMap<K, V, S>` and `IndexSet<T, S>` from the `indexmap` crate, giving them parity with their `std` counterparts (`HashMap`, `HashSet`).

## Changes

**`crates/validation/src/traits.rs`**
- Import `indexmap::{IndexMap, IndexSet}`
- Add `impl_with_length_len!(IndexMap<K, V, S>, K, V, S)`
- Add `impl_with_length_len!(IndexSet<T, S>, T, S)`
- Add unit tests for both new implementations

**`crates/validation/src/rule_impls/length.rs`**
- Add `test_validate_len_indexmap` — validates min/max length rules against `IndexMap`
- Add `test_validate_len_indexset` — validates min/max length rules against `IndexSet`

## Notes

- `indexmap` is already an unconditional dependency of `walrs_validation`
- Uses the existing `impl_with_length_len!` macro — no macro changes needed
- All existing tests continue to pass

Closes #127