### PR TITLE
fix(validation): remove vestigial `indexmap` feature flag

### DIFF
--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -23,7 +23,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["serde_json_bridge"]
 async = []
 serde_json_bridge = ["dep:serde_json"]
-indexmap = []
 chrono = ["dep:chrono"]
 jiff = ["dep:jiff"]
 

--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -21,7 +21,7 @@ To enable optional features:
 
 ```toml
 [dependencies]
-walrs_validation = { version = "0.1", features = ["async", "chrono", "indexmap"] }
+walrs_validation = { version = "0.1", features = ["async", "chrono"] }
 ```
 
 ## Validation Rules
@@ -180,7 +180,7 @@ The `serde_json_bridge` feature (enabled by default) provides `From<serde_json::
 
 ### `indexmap` Support
 
-The `indexmap` feature provides `From<IndexMap<String, V>> for Value` for constructing `Value::Object` from an `IndexMap`.
+`indexmap` is a required dependency. `From<IndexMap<String, V>> for Value` is always available for constructing `Value::Object` from an `IndexMap`. The crate also re-exports `indexmap` for convenience.
 
 ### Date Validation (`chrono` / `jiff`)
 


### PR DESCRIPTION
## Summary

Removes the no-op `indexmap = []` feature flag from `walrs_validation`. The `indexmap` dependency is already required (non-optional), so this feature flag served no purpose.

## Changes

- **`crates/validation/Cargo.toml`**: Removed `indexmap = []` from `[features]`
- **`crates/validation/README.md`**: Removed `indexmap` from optional features example; updated the "indexmap Support" section to describe it as built-in

## Verification

- `cargo test -p walrs_validation` — all tests pass (295 unit + 38 doc tests)
- `cargo doc -p walrs_validation --no-deps` — no warnings

Closes #131