### PR TITLE
refactor(validation): DRY WithMessage handling via Message helper methods

### DIFF
--- a/crates/validation/src/message.rs
+++ b/crates/validation/src/message.rs
@@ -377,6 +377,57 @@ impl<T: ?Sized> Message<T> {
     }
   }
 
+  /// Applies `WithMessage` semantics to a validation result.
+  ///
+  /// On `Ok(())`, returns `Ok(())` unchanged.
+  /// On `Err(violation)`, resolves the custom message (via [`resolve_or`](Self::resolve_or))
+  /// and returns a new [`Violation`] with the overridden message.
+  ///
+  /// # Arguments
+  ///
+  /// * `result` — the inner validation result to wrap
+  /// * `value` — the value being validated (passed to the message provider)
+  /// * `effective_locale` — locale for i18n message resolution
+  pub(crate) fn wrap_result(
+    &self,
+    result: crate::rule::RuleResult,
+    value: &T,
+    effective_locale: Option<&str>,
+  ) -> crate::rule::RuleResult {
+    match result {
+      Ok(()) => Ok(()),
+      Err(violation) => {
+        let msg = self.resolve_or(value, violation.message(), effective_locale);
+        Err(crate::Violation::new(violation.violation_type(), msg))
+      }
+    }
+  }
+
+  /// Applies `WithMessage` semantics to collected violations.
+  ///
+  /// Each violation in `inner` gets its message resolved via
+  /// [`resolve_or`](Self::resolve_or), then a new [`Violation`] with the
+  /// overridden message is pushed into `target`.
+  ///
+  /// # Arguments
+  ///
+  /// * `inner` — violations collected from the inner rule
+  /// * `value` — the value being validated (passed to the message provider)
+  /// * `effective_locale` — locale for i18n message resolution
+  /// * `target` — the accumulator to push wrapped violations into
+  pub(crate) fn wrap_violations(
+    &self,
+    inner: crate::Violations,
+    value: &T,
+    effective_locale: Option<&str>,
+    target: &mut crate::Violations,
+  ) {
+    for violation in inner {
+      let msg = self.resolve_or(value, violation.message(), effective_locale);
+      target.push(crate::Violation::new(violation.violation_type(), msg));
+    }
+  }
+
   /// Returns `true` if this is a static message.
   pub fn is_static(&self) -> bool {
     matches!(self, Message::Static(_))
@@ -793,5 +844,112 @@ mod tests {
     assert_eq!(msg.resolve("x", None), "Static message.");
     assert_eq!(msg.resolve("x", Some("es")), "Static message.");
     assert_eq!(msg.resolve("x", Some("fr")), "Static message.");
+  }
+
+  // ========================================================================
+  // wrap_result / wrap_violations tests
+  // ========================================================================
+
+  #[test]
+  fn test_wrap_result_ok_passthrough() {
+    let msg: Message<str> = Message::from("custom error");
+    let result = msg.wrap_result(Ok(()), "value", None);
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn test_wrap_result_err_with_static_message() {
+    let msg: Message<str> = Message::from("custom error");
+    let violation = crate::Violation::new(crate::ViolationType::ValueMissing, "original");
+    let result = msg.wrap_result(Err(violation), "value", None);
+    let err = result.unwrap_err();
+    assert_eq!(err.message(), "custom error");
+    assert_eq!(err.violation_type(), crate::ViolationType::ValueMissing);
+  }
+
+  #[test]
+  fn test_wrap_result_err_with_empty_static_falls_back() {
+    let msg: Message<str> = Message::Static(String::new());
+    let violation = crate::Violation::new(crate::ViolationType::TooShort, "original msg");
+    let result = msg.wrap_result(Err(violation), "value", None);
+    let err = result.unwrap_err();
+    assert_eq!(err.message(), "original msg");
+  }
+
+  #[test]
+  fn test_wrap_result_err_with_provider() {
+    let msg: Message<i32> = Message::provider(|ctx| format!("Bad value: {}", ctx.value));
+    let violation = crate::Violation::new(crate::ViolationType::RangeOverflow, "too big");
+    let result = msg.wrap_result(Err(violation), &42, None);
+    let err = result.unwrap_err();
+    assert_eq!(err.message(), "Bad value: 42");
+    assert_eq!(err.violation_type(), crate::ViolationType::RangeOverflow);
+  }
+
+  #[test]
+  fn test_wrap_result_with_locale() {
+    let msg: Message<str> = Message::provider(|ctx| match ctx.locale {
+      Some("es") => "Error personalizado".to_string(),
+      _ => "Custom error".to_string(),
+    });
+    let violation = crate::Violation::new(crate::ViolationType::ValueMissing, "original");
+
+    let result = msg.wrap_result(Err(violation), "x", Some("es"));
+    assert_eq!(result.unwrap_err().message(), "Error personalizado");
+  }
+
+  #[test]
+  fn test_wrap_violations_empty() {
+    let msg: Message<str> = Message::from("custom");
+    let inner = crate::Violations::default();
+    let mut target = crate::Violations::default();
+    msg.wrap_violations(inner, "value", None, &mut target);
+    assert!(target.is_empty());
+  }
+
+  #[test]
+  fn test_wrap_violations_maps_messages() {
+    let msg: Message<str> = Message::from("overridden");
+    let inner = crate::Violations::new(vec![
+      crate::Violation::new(crate::ViolationType::TooShort, "too short"),
+      crate::Violation::new(crate::ViolationType::TooLong, "too long"),
+    ]);
+    let mut target = crate::Violations::default();
+    msg.wrap_violations(inner, "value", None, &mut target);
+
+    assert_eq!(target.len(), 2);
+    assert_eq!(target[0].message(), "overridden");
+    assert_eq!(target[0].violation_type(), crate::ViolationType::TooShort);
+    assert_eq!(target[1].message(), "overridden");
+    assert_eq!(target[1].violation_type(), crate::ViolationType::TooLong);
+  }
+
+  #[test]
+  fn test_wrap_violations_empty_static_preserves_originals() {
+    let msg: Message<str> = Message::Static(String::new());
+    let inner = crate::Violations::new(vec![
+      crate::Violation::new(crate::ViolationType::TooShort, "original short"),
+    ]);
+    let mut target = crate::Violations::default();
+    msg.wrap_violations(inner, "value", None, &mut target);
+
+    assert_eq!(target.len(), 1);
+    assert_eq!(target[0].message(), "original short");
+  }
+
+  #[test]
+  fn test_wrap_violations_with_locale_provider() {
+    let msg: Message<str> = Message::provider(|ctx| match ctx.locale {
+      Some("fr") => format!("Erreur pour '{}'", ctx.value),
+      _ => format!("Error for '{}'", ctx.value),
+    });
+    let inner = crate::Violations::new(vec![
+      crate::Violation::new(crate::ViolationType::ValueMissing, "missing"),
+    ]);
+    let mut target = crate::Violations::default();
+    msg.wrap_violations(inner, "test", Some("fr"), &mut target);
+
+    assert_eq!(target.len(), 1);
+    assert_eq!(target[0].message(), "Erreur pour 'test'");
   }
 }

--- a/crates/validation/src/rule_impls/date_chrono.rs
+++ b/crates/validation/src/rule_impls/date_chrono.rs
@@ -280,14 +280,8 @@ impl Rule<NaiveDate> {
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_date_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_date_inner(value, eff), value, eff)
       }
       // Inapplicable rules pass through
       _ => Ok(()),
@@ -409,14 +403,8 @@ impl Rule<NaiveDateTime> {
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_datetime_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_datetime_inner(value, eff), value, eff)
       }
       _ => Ok(()),
     }

--- a/crates/validation/src/rule_impls/date_jiff.rs
+++ b/crates/validation/src/rule_impls/date_jiff.rs
@@ -281,14 +281,8 @@ impl Rule<Date> {
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_date_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_date_inner(value, eff), value, eff)
       }
       _ => Ok(()),
     }
@@ -409,14 +403,8 @@ impl Rule<DateTime> {
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_datetime_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_datetime_inner(value, eff), value, eff)
       }
       _ => Ok(()),
     }

--- a/crates/validation/src/rule_impls/length.rs
+++ b/crates/validation/src/rule_impls/length.rs
@@ -92,15 +92,8 @@ impl<T: WithLength> Rule<T> {
         message,
         locale,
       } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_len_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg =
-              message.resolve_or(value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_len_inner(value, eff), value, eff)
       }
       // Non-length rules don't apply to collections - pass through
       Rule::Pattern(_)
@@ -198,14 +191,10 @@ impl<T: WithLength> Rule<T> {
         message,
         locale,
       } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
+        let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = crate::Violations::default();
-        rule.collect_len_violations(value, effective_locale, &mut inner_violations);
-        for violation in inner_violations {
-          let custom_msg =
-            message.resolve_or(value, violation.message(), effective_locale);
-          violations.push(Violation::new(violation.violation_type(), custom_msg));
-        }
+        rule.collect_len_violations(value, eff, &mut inner_violations);
+        message.wrap_violations(inner_violations, value, eff, violations);
       }
       _ => {
         if let Err(v) = self.validate_len_inner(value, inherited_locale) {

--- a/crates/validation/src/rule_impls/scalar.rs
+++ b/crates/validation/src/rule_impls/scalar.rs
@@ -113,15 +113,8 @@ impl<T: ScalarValue + IsEmpty> Rule<T> {
         message,
         locale,
       } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_scalar_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg =
-              message.resolve_or(&value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_scalar_inner(value, eff), &value, eff)
       }
 
       // Step and string-only rules are pass-through for scalar types.
@@ -228,14 +221,10 @@ impl<T: ScalarValue + IsEmpty> Rule<T> {
         message,
         locale,
       } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
+        let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = Violations::default();
-        rule.collect_violations_scalar(value, effective_locale, &mut inner_violations);
-        for violation in inner_violations {
-          let custom_msg =
-            message.resolve_or(&value, violation.message(), effective_locale);
-          violations.push(Violation::new(violation.violation_type(), custom_msg));
-        }
+        rule.collect_violations_scalar(value, eff, &mut inner_violations);
+        message.wrap_violations(inner_violations, &value, eff, violations);
       }
 
       _ => {

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -102,14 +102,8 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_step_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(&value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_step_inner(value, eff), &value, eff)
       },
       // String rules don't apply to numbers - pass through
       Rule::MinLength(_)
@@ -195,13 +189,10 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
         }
       }
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
+        let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = crate::Violations::default();
-        rule.collect_violations(value, effective_locale, &mut inner_violations);
-        for violation in inner_violations {
-          let custom_msg = message.resolve_or(&value, violation.message(), effective_locale);
-          violations.push(Violation::new(violation.violation_type(), custom_msg));
-        }
+        rule.collect_violations(value, eff, &mut inner_violations);
+        message.wrap_violations(inner_violations, &value, eff, violations);
       }
       _ => {
         if let Err(v) = self.validate_step_inner(value, inherited_locale) {
@@ -305,14 +296,8 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
           }
         }
         Rule::WithMessage { rule, message, locale } => {
-          let effective_locale = locale.as_deref().or(inherited_locale);
-          match rule.validate_step_async_inner(value, effective_locale).await {
-            Ok(()) => Ok(()),
-            Err(violation) => {
-              let custom_msg = message.resolve_or(&value, violation.message(), effective_locale);
-              Err(Violation::new(violation.violation_type(), custom_msg))
-            }
-          }
+          let eff = locale.as_deref().or(inherited_locale);
+          message.wrap_result(rule.validate_step_async_inner(value, eff).await, &value, eff)
         }
 
         // All sync rules — delegate to sync validation

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -497,15 +497,8 @@ impl Rule<String> {
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
       Rule::WithMessage { rule, message, locale } => {
-        // Use this variant's locale if set, otherwise inherit from parent
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_str_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg = message.resolve_or(&value.to_string(), violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_str_inner(value, eff), &value.to_string(), eff)
       },
       // Numeric rules don't apply to strings - pass through
       Rule::Min(_) | Rule::Max(_) | Rule::Range { .. } | Rule::Step(_) => Ok(()),
@@ -594,13 +587,10 @@ impl Rule<String> {
         }
       }
       Rule::WithMessage { rule, message, locale } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
+        let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = crate::Violations::default();
-        rule.collect_violations_str(value, effective_locale, &mut inner_violations);
-        for violation in inner_violations {
-          let custom_msg = message.resolve_or(&value.to_string(), violation.message(), effective_locale);
-          violations.push(Violation::new(violation.violation_type(), custom_msg));
-        }
+        rule.collect_violations_str(value, eff, &mut inner_violations);
+        message.wrap_violations(inner_violations, &value.to_string(), eff, violations);
       }
       _ => {
         if let Err(v) = self.validate_str_inner(value, inherited_locale) {
@@ -701,18 +691,8 @@ impl Rule<String> {
           }
         }
         Rule::WithMessage { rule, message, locale } => {
-          let effective_locale = locale.as_deref().or(inherited_locale);
-          match rule.validate_str_async_inner(value, effective_locale).await {
-            Ok(()) => Ok(()),
-            Err(violation) => {
-              let custom_msg = message.resolve_or(
-                &value.to_string(),
-                violation.message(),
-                effective_locale,
-              );
-              Err(Violation::new(violation.violation_type(), custom_msg))
-            }
-          }
+          let eff = locale.as_deref().or(inherited_locale);
+          message.wrap_result(rule.validate_str_async_inner(value, eff).await, &value.to_string(), eff)
         }
 
         // All sync rules — delegate to sync validation

--- a/crates/validation/src/rule_impls/value.rs
+++ b/crates/validation/src/rule_impls/value.rs
@@ -285,15 +285,8 @@ impl Rule<Value> {
         message,
         locale,
       } => {
-        let effective_locale = locale.as_deref().or(inherited_locale);
-        match rule.validate_value_inner(value, effective_locale) {
-          Ok(()) => Ok(()),
-          Err(violation) => {
-            let custom_msg =
-              message.resolve_or(value, violation.message(), effective_locale);
-            Err(Violation::new(violation.violation_type(), custom_msg))
-          }
-        }
+        let eff = locale.as_deref().or(inherited_locale);
+        message.wrap_result(rule.validate_value_inner(value, eff), value, eff)
       }
     }
   }
@@ -395,18 +388,8 @@ impl Rule<Value> {
           }
         }
         Rule::WithMessage { rule, message, locale } => {
-          let effective_locale = locale.as_deref().or(inherited_locale);
-          match rule.validate_value_async_inner(value, effective_locale).await {
-            Ok(()) => Ok(()),
-            Err(violation) => {
-              let custom_msg = message.resolve_or(
-                value,
-                violation.message(),
-                effective_locale,
-              );
-              Err(Violation::new(violation.violation_type(), custom_msg))
-            }
-          }
+          let eff = locale.as_deref().or(inherited_locale);
+          message.wrap_result(rule.validate_value_async_inner(value, eff).await, value, eff)
         }
 
         // All sync rules — delegate to sync validation


### PR DESCRIPTION
## Summary

Add `wrap_result` and `wrap_violations` helper methods to `Message<T>` to eliminate repeated `WithMessage` enum variant handling across all `Rule` impl files.

## Changes

- **`wrap_result`** — encapsulates the fail-fast pattern (12 call sites across 7 files)
- **`wrap_violations`** — encapsulates the fail-slow/collect pattern (4 call sites across 4 files)

Each `WithMessage` match arm reduced from 7–11 lines → 3–5 lines.

### Files changed

| File | Sites updated |
|------|--------------|
| `message.rs` | +2 methods, +10 unit tests |
| `scalar.rs` | 2 sites |
| `steppable.rs` | 3 sites (sync, collect, async) |
| `string.rs` | 3 sites (sync, collect, async) |
| `value.rs` | 2 sites (sync, async) |
| `date_jiff.rs` | 2 sites (Date, DateTime) |
| `date_chrono.rs` | 2 sites (NaiveDate, NaiveDateTime) |
| `length.rs` | 2 sites (sync, collect) |

## Testing

All **349 unit tests + 39 doc tests** pass. Full workspace builds clean.