### PR TITLE
feat(walrs_validation): #135 add missing ValidateRef and async impls for scalar/numeric Rule<T> types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 # Tests and Reports
 **/htmlReport/
+
+# Worktrees
+claude/worktrees/

--- a/crates/validation/src/rule_impls/scalar.rs
+++ b/crates/validation/src/rule_impls/scalar.rs
@@ -196,10 +196,10 @@ impl<T: ScalarValue + IsEmpty> Rule<T> {
             any_passed = true;
             break;
           }
-          any_violations.extend(rule_violations.into_iter());
+          any_violations.extend(rule_violations);
         }
         if !any_passed && !rules.is_empty() {
-          violations.extend(any_violations.into_iter());
+          violations.extend(any_violations);
         }
       }
 
@@ -246,9 +246,21 @@ impl Validate<bool> for Rule<bool> {
   }
 }
 
+impl ValidateRef<bool> for Rule<bool> {
+  fn validate_ref(&self, value: &bool) -> crate::traits::ValidatorResult {
+    self.validate_scalar(*value)
+  }
+}
+
 impl Validate<char> for Rule<char> {
   fn validate(&self, value: char) -> crate::traits::ValidatorResult {
     self.validate_scalar(value)
+  }
+}
+
+impl ValidateRef<char> for Rule<char> {
+  fn validate_ref(&self, value: &char) -> crate::traits::ValidatorResult {
+    self.validate_scalar(*value)
   }
 }
 
@@ -288,6 +300,177 @@ impl ValidateRef<Option<char>> for Rule<char> {
       None if self.requires_value() => Err(Violation::value_missing()),
       None => Ok(()),
       Some(v) => self.validate(*v),
+    }
+  }
+}
+
+// ============================================================================
+// Async Scalar Validation (bool / char)
+// ============================================================================
+
+#[cfg(feature = "async")]
+impl<T: ScalarValue + IsEmpty + Send + Sync> Rule<T> {
+  /// Validates a scalar value asynchronously.
+  ///
+  /// Runs all rules: sync rules execute inline, `CustomAsync` rules are awaited.
+  pub(crate) async fn validate_scalar_async(&self, value: T) -> RuleResult {
+    self.validate_scalar_async_inner(value, None).await
+  }
+
+  /// Internal async validation with inherited locale.
+  fn validate_scalar_async_inner<'a>(
+    &'a self,
+    value: T,
+    inherited_locale: Option<&'a str>,
+  ) -> std::pin::Pin<Box<dyn std::future::Future<Output = RuleResult> + Send + 'a>>
+  where
+    T: 'a,
+  {
+    Box::pin(async move {
+      match self {
+        Rule::CustomAsync(f) => f(&value).await,
+
+        Rule::All(rules) => {
+          for rule in rules {
+            rule
+              .validate_scalar_async_inner(value, inherited_locale)
+              .await?;
+          }
+          Ok(())
+        }
+        Rule::Any(rules) => {
+          if rules.is_empty() {
+            return Ok(());
+          }
+          let mut last_err = None;
+          for rule in rules {
+            match rule
+              .validate_scalar_async_inner(value, inherited_locale)
+              .await
+            {
+              Ok(()) => return Ok(()),
+              Err(e) => last_err = Some(e),
+            }
+          }
+          Err(last_err.unwrap())
+        }
+        Rule::Not(inner) => {
+          match inner
+            .validate_scalar_async_inner(value, inherited_locale)
+            .await
+          {
+            Ok(()) => Err(Violation::negation_failed()),
+            Err(_) => Ok(()),
+          }
+        }
+        Rule::When {
+          condition,
+          then_rule,
+          else_rule,
+        } => {
+          if condition.evaluate(&value) {
+            then_rule
+              .validate_scalar_async_inner(value, inherited_locale)
+              .await
+          } else {
+            match else_rule {
+              Some(rule) => {
+                rule
+                  .validate_scalar_async_inner(value, inherited_locale)
+                  .await
+              }
+              None => Ok(()),
+            }
+          }
+        }
+        Rule::WithMessage {
+          rule,
+          message,
+          locale,
+        } => {
+          let eff = locale.as_deref().or(inherited_locale);
+          message.wrap_result(
+            rule.validate_scalar_async_inner(value, eff).await,
+            &value,
+            eff,
+          )
+        }
+
+        // All sync rules — delegate to sync validation
+        other => other.validate_scalar_inner(value, inherited_locale),
+      }
+    })
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateAsync<bool> for Rule<bool> {
+  async fn validate_async(&self, value: bool) -> crate::ValidatorResult {
+    self.validate_scalar_async(value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateRefAsync<bool> for Rule<bool> {
+  async fn validate_ref_async(&self, value: &bool) -> crate::ValidatorResult {
+    self.validate_scalar_async(*value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateAsync<Option<bool>> for Rule<bool> {
+  async fn validate_async(&self, value: Option<bool>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_scalar_async(v).await,
+    }
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateRefAsync<Option<bool>> for Rule<bool> {
+  async fn validate_ref_async(&self, value: &Option<bool>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_scalar_async(*v).await,
+    }
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateAsync<char> for Rule<char> {
+  async fn validate_async(&self, value: char) -> crate::ValidatorResult {
+    self.validate_scalar_async(value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateRefAsync<char> for Rule<char> {
+  async fn validate_ref_async(&self, value: &char) -> crate::ValidatorResult {
+    self.validate_scalar_async(*value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateAsync<Option<char>> for Rule<char> {
+  async fn validate_async(&self, value: Option<char>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_scalar_async(v).await,
+    }
+  }
+}
+
+#[cfg(feature = "async")]
+impl crate::ValidateRefAsync<Option<char>> for Rule<char> {
+  async fn validate_ref_async(&self, value: &Option<char>) -> crate::ValidatorResult {
+    match value {
+      None if self.requires_value() => Err(Violation::value_missing()),
+      None => Ok(()),
+      Some(v) => self.validate_scalar_async(*v).await,
     }
   }
 }
@@ -373,7 +556,7 @@ mod tests {
   fn test_validate_scalar_not() {
     let rule = Rule::<i32>::Min(0).not();
     assert!(rule.validate_scalar(-1).is_ok()); // fails Min(0) → NOT passes
-    assert!(rule.validate_scalar(0).is_err());  // passes Min(0) → NOT fails
+    assert!(rule.validate_scalar(0).is_err()); // passes Min(0) → NOT fails
   }
 
   // ==========================================================================
@@ -388,9 +571,9 @@ mod tests {
       then_rule: Box::new(Rule::Max(10)),
       else_rule: None,
     };
-    assert!(rule.validate_scalar(0).is_ok());    // condition false → skip
-    assert!(rule.validate_scalar(5).is_ok());    // condition true, 5 <= 10
-    assert!(rule.validate_scalar(11).is_err());  // condition true, 11 > 10
+    assert!(rule.validate_scalar(0).is_ok()); // condition false → skip
+    assert!(rule.validate_scalar(5).is_ok()); // condition true, 5 <= 10
+    assert!(rule.validate_scalar(11).is_err()); // condition true, 11 > 10
   }
 
   #[test]
@@ -402,7 +585,7 @@ mod tests {
       else_rule: Some(Box::new(Rule::Equals(0))),
     };
     assert!(rule.validate_scalar(100).is_ok()); // then branch passes
-    assert!(rule.validate_scalar(0).is_ok());   // else branch passes
+    assert!(rule.validate_scalar(0).is_ok()); // else branch passes
     assert!(rule.validate_scalar(50).is_err()); // else branch: 50 ≠ 0
     assert!(rule.validate_scalar(75).is_err()); // then branch: 75 ≠ 100
   }
@@ -602,5 +785,113 @@ mod tests {
     let rule = Rule::<char>::Equals('a');
     assert!(Validate::<Option<char>>::validate(&rule, Some('b')).is_err());
     assert!(ValidateRef::<Option<char>>::validate_ref(&rule, &Some('b')).is_err());
+  }
+
+  // ==========================================================================
+  // ValidateRef<T> (non-Option) for bool / char
+  // ==========================================================================
+
+  #[test]
+  fn test_validate_ref_bool() {
+    use crate::ValidateRef;
+    let rule = Rule::<bool>::Equals(true);
+    assert!(ValidateRef::<bool>::validate_ref(&rule, &true).is_ok());
+    assert!(ValidateRef::<bool>::validate_ref(&rule, &false).is_err());
+  }
+
+  #[test]
+  fn test_validate_ref_char() {
+    use crate::ValidateRef;
+    let rule = Rule::<char>::Range { min: 'a', max: 'z' };
+    assert!(ValidateRef::<char>::validate_ref(&rule, &'m').is_ok());
+    assert!(ValidateRef::<char>::validate_ref(&rule, &'A').is_err());
+  }
+
+  // ==========================================================================
+  // Async tests for bool / char
+  // ==========================================================================
+
+  #[cfg(feature = "async")]
+  mod async_scalar_tests {
+    use crate::rule::Rule;
+    use crate::{ValidateAsync, ValidateRefAsync};
+
+    // --- bool ---
+
+    #[tokio::test]
+    async fn test_async_validate_bool() {
+      let rule = Rule::<bool>::Equals(true);
+      assert!(rule.validate_async(true).await.is_ok());
+      assert!(rule.validate_async(false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_validate_ref_bool() {
+      let rule = Rule::<bool>::Equals(true);
+      assert!(rule.validate_ref_async(&true).await.is_ok());
+      assert!(rule.validate_ref_async(&false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_bool_none_required() {
+      let rule = Rule::<bool>::Required;
+      assert!(rule.validate_async(None::<bool>).await.is_err());
+      assert!(rule.validate_ref_async(&None::<bool>).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_bool_none_not_required() {
+      let rule = Rule::<bool>::Equals(true);
+      assert!(rule.validate_async(None::<bool>).await.is_ok());
+      assert!(rule.validate_ref_async(&None::<bool>).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_bool_some() {
+      let rule = Rule::<bool>::Equals(true);
+      assert!(rule.validate_async(Some(true)).await.is_ok());
+      assert!(rule.validate_ref_async(&Some(true)).await.is_ok());
+      assert!(rule.validate_async(Some(false)).await.is_err());
+      assert!(rule.validate_ref_async(&Some(false)).await.is_err());
+    }
+
+    // --- char ---
+
+    #[tokio::test]
+    async fn test_async_validate_char() {
+      let rule = Rule::<char>::Range { min: 'a', max: 'z' };
+      assert!(rule.validate_async('m').await.is_ok());
+      assert!(rule.validate_async('A').await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_validate_ref_char() {
+      let rule = Rule::<char>::Range { min: 'a', max: 'z' };
+      assert!(rule.validate_ref_async(&'m').await.is_ok());
+      assert!(rule.validate_ref_async(&'A').await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_char_none_required() {
+      let rule = Rule::<char>::Required;
+      assert!(rule.validate_async(None::<char>).await.is_err());
+      assert!(rule.validate_ref_async(&None::<char>).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_char_none_not_required() {
+      let rule = Rule::<char>::Equals('a');
+      assert!(rule.validate_async(None::<char>).await.is_ok());
+      assert!(rule.validate_ref_async(&None::<char>).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_async_option_char_some() {
+      let rule = Rule::<char>::Equals('a');
+      assert!(rule.validate_async(Some('a')).await.is_ok());
+      assert!(rule.validate_ref_async(&Some('a')).await.is_ok());
+      assert!(rule.validate_async(Some('b')).await.is_err());
+      assert!(rule.validate_ref_async(&Some('b')).await.is_err());
+    }
   }
 }

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -101,10 +101,14 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
       #[cfg(feature = "async")]
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
-      Rule::WithMessage { rule, message, locale } => {
+      Rule::WithMessage {
+        rule,
+        message,
+        locale,
+      } => {
         let eff = locale.as_deref().or(inherited_locale);
         message.wrap_result(rule.validate_step_inner(value, eff), &value, eff)
-      },
+      }
       // String rules don't apply to numbers - pass through
       Rule::MinLength(_)
       | Rule::MaxLength(_)
@@ -142,10 +146,7 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
 
   /// Validates an optional numeric value and collects all violations.
   #[allow(dead_code)] // Reserved for a future `validate_option_all` public API
-  pub(crate) fn validate_option_step_all(
-    &self,
-    value: Option<T>,
-  ) -> Result<(), crate::Violations> {
+  pub(crate) fn validate_option_step_all(&self, value: Option<T>) -> Result<(), crate::Violations> {
     match value {
       Some(v) => self.validate_step_all(v),
       None => Err(crate::Violations::from(Violation::value_missing())),
@@ -153,7 +154,12 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
   }
 
   /// Helper to collect all violations recursively.
-  fn collect_violations(&self, value: T, inherited_locale: Option<&str>, violations: &mut crate::Violations) {
+  fn collect_violations(
+    &self,
+    value: T,
+    inherited_locale: Option<&str>,
+    violations: &mut crate::Violations,
+  ) {
     match self {
       Rule::All(rules) => {
         for rule in rules {
@@ -170,10 +176,10 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
             any_passed = true;
             break;
           }
-          any_violations.extend(rule_violations.into_iter());
+          any_violations.extend(rule_violations);
         }
         if !any_passed && !rules.is_empty() {
-          violations.extend(any_violations.into_iter());
+          violations.extend(any_violations);
         }
       }
       Rule::When {
@@ -188,7 +194,11 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
           rule.collect_violations(value, inherited_locale, violations);
         }
       }
-      Rule::WithMessage { rule, message, locale } => {
+      Rule::WithMessage {
+        rule,
+        message,
+        locale,
+      } => {
         let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = crate::Violations::default();
         rule.collect_violations(value, eff, &mut inner_violations);
@@ -216,6 +226,12 @@ impl<T: SteppableValue + IsEmpty + Clone> Validate<Option<T>> for Rule<T> {
       None => Ok(()),
       Some(v) => self.validate(v),
     }
+  }
+}
+
+impl<T: SteppableValue + IsEmpty + Clone> ValidateRef<T> for Rule<T> {
+  fn validate_ref(&self, value: &T) -> crate::ValidatorResult {
+    self.validate(*value)
   }
 }
 
@@ -258,7 +274,9 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
 
         Rule::All(rules) => {
           for rule in rules {
-            rule.validate_step_async_inner(value, inherited_locale).await?;
+            rule
+              .validate_step_async_inner(value, inherited_locale)
+              .await?;
           }
           Ok(())
         }
@@ -268,7 +286,10 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
           }
           let mut last_err = None;
           for rule in rules {
-            match rule.validate_step_async_inner(value, inherited_locale).await {
+            match rule
+              .validate_step_async_inner(value, inherited_locale)
+              .await
+            {
               Ok(()) => return Ok(()),
               Err(e) => last_err = Some(e),
             }
@@ -276,7 +297,10 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
           Err(last_err.unwrap())
         }
         Rule::Not(inner) => {
-          match inner.validate_step_async_inner(value, inherited_locale).await {
+          match inner
+            .validate_step_async_inner(value, inherited_locale)
+            .await
+          {
             Ok(()) => Err(Violation::negation_failed()),
             Err(_) => Ok(()),
           }
@@ -287,17 +311,31 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
           else_rule,
         } => {
           if condition.evaluate(&value) {
-            then_rule.validate_step_async_inner(value, inherited_locale).await
+            then_rule
+              .validate_step_async_inner(value, inherited_locale)
+              .await
           } else {
             match else_rule {
-              Some(rule) => rule.validate_step_async_inner(value, inherited_locale).await,
+              Some(rule) => {
+                rule
+                  .validate_step_async_inner(value, inherited_locale)
+                  .await
+              }
               None => Ok(()),
             }
           }
         }
-        Rule::WithMessage { rule, message, locale } => {
+        Rule::WithMessage {
+          rule,
+          message,
+          locale,
+        } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(rule.validate_step_async_inner(value, eff).await, &value, eff)
+          message.wrap_result(
+            rule.validate_step_async_inner(value, eff).await,
+            &value,
+            eff,
+          )
         }
 
         // All sync rules — delegate to sync validation
@@ -315,7 +353,9 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<T> 
 }
 
 #[cfg(feature = "async")]
-impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<Option<T>> for Rule<T> {
+impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<Option<T>>
+  for Rule<T>
+{
   async fn validate_async(&self, value: Option<T>) -> crate::ValidatorResult {
     match value {
       None if self.requires_value() => Err(Violation::value_missing()),
@@ -326,7 +366,16 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateAsync<Opt
 }
 
 #[cfg(feature = "async")]
-impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateRefAsync<Option<T>> for Rule<T> {
+impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateRefAsync<T> for Rule<T> {
+  async fn validate_ref_async(&self, value: &T) -> crate::ValidatorResult {
+    self.validate_step_async(*value).await
+  }
+}
+
+#[cfg(feature = "async")]
+impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> crate::ValidateRefAsync<Option<T>>
+  for Rule<T>
+{
   async fn validate_ref_async(&self, value: &Option<T>) -> crate::ValidatorResult {
     match value {
       None if self.requires_value() => Err(Violation::value_missing()),
@@ -511,6 +560,34 @@ mod tests {
   }
 
   // ========================================================================
+  // ValidateRef<T> (non-Option) Tests
+  // ========================================================================
+
+  #[test]
+  fn test_validate_ref_i32() {
+    let rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+    assert!(rule.validate_ref(&50).is_ok());
+    assert!(rule.validate_ref(&0).is_ok());
+    assert!(rule.validate_ref(&(-1)).is_err());
+    assert!(rule.validate_ref(&101).is_err());
+  }
+
+  #[test]
+  fn test_validate_ref_f64() {
+    let rule = Rule::<f64>::Min(0.0).and(Rule::Max(1.0));
+    assert!(rule.validate_ref(&0.5).is_ok());
+    assert!(rule.validate_ref(&(-0.1)).is_err());
+    assert!(rule.validate_ref(&1.1).is_err());
+  }
+
+  #[test]
+  fn test_validate_ref_u64() {
+    let rule = Rule::<u64>::Min(10).and(Rule::Max(20));
+    assert!(rule.validate_ref(&15).is_ok());
+    assert!(rule.validate_ref(&5).is_err());
+  }
+
+  // ========================================================================
   // Option<T> Validation (Numeric)
   // ========================================================================
 
@@ -593,6 +670,27 @@ mod tests {
       assert!(rule.validate_async(Some(5)).await.is_ok());
       assert!(rule.validate_ref_async(&Some(5)).await.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_async_validate_ref_i32() {
+      let rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+      assert!(rule.validate_ref_async(&50).await.is_ok());
+      assert!(rule.validate_ref_async(&(-1)).await.is_err());
+      assert!(rule.validate_ref_async(&101).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_validate_ref_f64() {
+      let rule = Rule::<f64>::Min(0.0).and(Rule::Max(1.0));
+      assert!(rule.validate_ref_async(&0.5).await.is_ok());
+      assert!(rule.validate_ref_async(&(-0.1)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_async_validate_i32() {
+      let rule = Rule::<i32>::Min(0).and(Rule::Max(100));
+      assert!(rule.validate_async(50).await.is_ok());
+      assert!(rule.validate_async(-1).await.is_err());
+    }
   }
 }
-


### PR DESCRIPTION
## Summary

Closes #135

Adds all missing `ValidateRef<T>` and `*Async` trait implementations for scalar/numeric `Rule<T>` types, ensuring full API consistency across all supported types.

## Changes

### `steppable.rs` — SteppableValue types (i8–i128, u8–u128, isize, usize, f32, f64)
- **Added** `ValidateRef<T>` blanket impl (sync, non-Option)
- **Added** `ValidateRefAsync<T>` blanket impl (async, non-Option)

### `scalar.rs` — bool / char
- **Added** `ValidateRef<bool>` and `ValidateRef<char>` (sync, non-Option)
- **Added** `validate_scalar_async` / `validate_scalar_async_inner` methods for `Rule<T: ScalarValue>`
- **Added** all 4 async trait impls for each:
  - `ValidateAsync<T>`, `ValidateRefAsync<T>`, `ValidateAsync<Option<T>>`, `ValidateRefAsync<Option<T>>`

### `.gitignore`
- **Added** `claude/worktrees/` ignore rule

## Tests Added

- 5 new sync tests: `validate_ref` for `i32`, `f64`, `u64`, `bool`, `char`
- 13 new async tests: `validate_async`/`validate_ref_async` for `i32`, `f64`, `bool`, `char`, plus Option variants

## Verification

- `cargo test -p walrs_validation` — 354 tests pass
- `cargo test -p walrs_validation --features async` — 370 tests pass
- `cargo test --workspace` — all pass
- `cargo doc -p walrs_validation --no-deps` — no warnings
- `cargo clippy` — no new warnings