### PR TITLE
chore: #140 Rename and parameterize coverage scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also depend on individual sub-crates directly (e.g., `walrs_inputfilter 
 ### Code coverage with `cargo-llvm-cov`
 
 1.  Install `cargo-llvm-cov`: `cargo install cargo-llvm-cov`
-2.  Run tests with coverage and generate HTML report: `sh ./test.sh` or the command directly: `cargo llvm-cov --html --workspace --branch`
+2.  Run tests with coverage and generate HTML report: `sh ./llvm-cov-all.sh` or the command directly: `cargo llvm-cov --html --workspace --branch`
 3.  Open the generated report at `target/llvm-cov/html/index.html` in your web browser.
 
 Cargo llvm-cov reference: https://github.com/taiki-e/cargo-llvm-cov
@@ -62,7 +62,7 @@ Note: branch and functions tracking is not supported with this method (currently
 
 1. Install `llvm-tools`: `$ rustup component add llvm-tools-preview`
 2. Install grcov: `cargo install grcov`.
-3. Run `sh ./grcov-coverage.sh` (builds project with instrumentation and runs tests).
+3. Run `sh ./grcov-all.sh` (builds project with instrumentation and runs tests).
 4. Run the coverage "index.html" file (target/coverage/html/index.html) in the browser.
 
 Reference: https://github.com/mozilla/grcov?tab=readme-ov-file#how-to-get-grcov

--- a/grcov-all.sh
+++ b/grcov-all.sh
@@ -1,0 +1,4 @@
+rm -rf target/.profraw target/coverage & \
+CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='target/.profraw/cargo-test-%p-%m.profraw' cargo test --workspace "$@" -- --test-threads 32 && \
+grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" --ignore "**/target/**" -o ./target/coverage/html && \
+echo "Process completed successfully.\nCoverage generated to ./target/coverage/html\n"

--- a/llvm-cov-all.sh
+++ b/llvm-cov-all.sh
@@ -1,0 +1,1 @@
+cargo llvm-cov --html --workspace --branch "$@"

--- a/run-coverage.sh
+++ b/run-coverage.sh
@@ -1,4 +1,0 @@
-rm -rf target/.profraw target/coverage & \
-CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='target/.profraw/cargo-test-%p-%m.profraw' cargo test --workspace -- --test-threads 32 && \
-grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" --ignore "**/target/**" -o ./target/coverage/html && \
-echo "Process completed successfully.\nCoverage generated to ./target/coverage/html\n"

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,0 @@
-cargo llvm-cov --html --workspace --branch


### PR DESCRIPTION
Closes #140

## Changes

- **`test.sh` → `llvm-cov-all.sh`**: Keeps `--html --workspace --branch` defaults, adds `"\$@"` for pass-through.
- **`run-coverage.sh` → `grcov-all.sh`**: Keeps all existing defaults (env vars, `--test-threads 32`, grcov options), adds `"\$@"` for pass-through.
- **README.md**: Updated script references (also fixed pre-existing stale `grcov-coverage.sh` reference).

Scripts represent the "run full-repo coverage" workflow. No-args invocation behaves identically to the old scripts.

## Usage

```bash
# Full-repo llvm-cov (same as old test.sh)
sh ./llvm-cov-all.sh

# Full-repo grcov (same as old run-coverage.sh)
sh ./grcov-all.sh

# With extra flags
sh ./llvm-cov-all.sh --lcov --output-path lcov.info
sh ./grcov-all.sh -p walrs_filter
```
