### PR TITLE
fix(walrs_filter): #153 #155 #156 - capacity heuristic, empty-chain guard, doc updates

### DIFF
--- a/crates/filter/benches/filter_benchmarks.rs
+++ b/crates/filter/benches/filter_benchmarks.rs
@@ -265,7 +265,11 @@ fn bench_try_filter_op(c: &mut Criterion) {
   let try_custom: TryFilterOp<String> =
     TryFilterOp::TryCustom(Arc::new(|s: String| Ok(s.to_uppercase())));
   group.bench_function("try_custom_success", |b| {
-    b.iter(|| try_custom.try_apply(black_box("hello".to_string())).unwrap())
+    b.iter(|| {
+      try_custom
+        .try_apply(black_box("hello".to_string()))
+        .unwrap()
+    })
   });
 
   // Chain with infallible ops
@@ -275,11 +279,7 @@ fn bench_try_filter_op(c: &mut Criterion) {
     TryFilterOp::Infallible(FilterOp::StripTags),
   ]);
   group.bench_function("chain_3_infallible", |b| {
-    b.iter(|| {
-      chain
-        .try_apply_ref(black_box("  <b>HELLO</b>  "))
-        .unwrap()
-    })
+    b.iter(|| chain.try_apply_ref(black_box("  <b>HELLO</b>  ")).unwrap())
   });
 
   // Chain that short-circuits on error
@@ -360,4 +360,3 @@ criterion_group!(
 );
 
 criterion_main!(benches);
-

--- a/crates/filter/examples/filter_op_usage.rs
+++ b/crates/filter/examples/filter_op_usage.rs
@@ -24,10 +24,7 @@ fn main() {
     ("StripTags", FilterOp::StripTags),
     ("HtmlEntities", FilterOp::HtmlEntities),
     ("Slug", FilterOp::Slug { max_length: None }),
-    (
-      "Truncate(10)",
-      FilterOp::Truncate { max_length: 10 },
-    ),
+    ("Truncate(10)", FilterOp::Truncate { max_length: 10 }),
     (
       "Replace(hello→hi)",
       FilterOp::Replace {
@@ -107,10 +104,7 @@ fn main() {
     );
   }
 
-  let clamp_f64 = FilterOp::<f64>::Clamp {
-    min: 0.0,
-    max: 1.0,
-  };
+  let clamp_f64 = FilterOp::<f64>::Clamp { min: 0.0, max: 1.0 };
   for value in [-0.5_f64, 0.0, 0.5, 1.0, 1.5] {
     println!(
       "  Clamp<f64>(0.0..=1.0): {:4} -> {}",
@@ -142,7 +136,9 @@ fn main() {
   let chain: FilterOp<String> = FilterOp::Chain(vec![
     FilterOp::Trim,
     FilterOp::Lowercase,
-    FilterOp::Slug { max_length: Some(50) },
+    FilterOp::Slug {
+      max_length: Some(50),
+    },
   ]);
 
   let json = serde_json::to_string_pretty(&chain).unwrap();

--- a/crates/filter/examples/try_filters.rs
+++ b/crates/filter/examples/try_filters.rs
@@ -35,8 +35,7 @@ fn main() {
       Ok(s.to_uppercase())
     } else {
       Err(
-        FilterError::new(format!("'{}' contains non-hex characters", s))
-          .with_name("HexNormalize"),
+        FilterError::new(format!("'{}' contains non-hex characters", s)).with_name("HexNormalize"),
       )
     }
   }));

--- a/crates/filter/src/filter_error.rs
+++ b/crates/filter/src/filter_error.rs
@@ -73,7 +73,10 @@ impl std::error::Error for FilterError {}
 #[cfg(feature = "validation")]
 impl From<FilterError> for walrs_validation::Violation {
   fn from(err: FilterError) -> Self {
-    walrs_validation::Violation::new(walrs_validation::ViolationType::CustomError, err.to_string())
+    walrs_validation::Violation::new(
+      walrs_validation::ViolationType::CustomError,
+      err.to_string(),
+    )
   }
 }
 

--- a/crates/filter/src/filter_op.rs
+++ b/crates/filter/src/filter_op.rs
@@ -234,14 +234,20 @@ impl FilterOp<String> {
         }
       }
       FilterOp::Lowercase => {
-        if value.chars().all(|c| c.is_lowercase() || !c.is_alphabetic()) {
+        if value
+          .chars()
+          .all(|c| c.is_lowercase() || !c.is_alphabetic())
+        {
           Cow::Borrowed(value)
         } else {
           Cow::Owned(value.to_lowercase())
         }
       }
       FilterOp::Uppercase => {
-        if value.chars().all(|c| c.is_uppercase() || !c.is_alphabetic()) {
+        if value
+          .chars()
+          .all(|c| c.is_uppercase() || !c.is_alphabetic())
+        {
           Cow::Borrowed(value)
         } else {
           Cow::Owned(value.to_uppercase())
@@ -399,22 +405,23 @@ impl FilterOp<Value> {
           value.clone()
         }
       }
-      FilterOp::Clamp { min, max } => {
-        match (value, min, max) {
-          (Value::I64(v), Value::I64(min_v), Value::I64(max_v)) => {
-            Value::I64((*v).clamp(*min_v, *max_v))
-          }
-          (Value::U64(v), Value::U64(min_v), Value::U64(max_v)) => {
-            Value::U64((*v).clamp(*min_v, *max_v))
-          }
-          (Value::F64(v), Value::F64(min_v), Value::F64(max_v)) => {
-            Value::F64((*v).clamp(*min_v, *max_v))
-          }
-          _ => value.clone(),
+      FilterOp::Clamp { min, max } => match (value, min, max) {
+        (Value::I64(v), Value::I64(min_v), Value::I64(max_v)) => {
+          Value::I64((*v).clamp(*min_v, *max_v))
         }
-      }
+        (Value::U64(v), Value::U64(min_v), Value::U64(max_v)) => {
+          Value::U64((*v).clamp(*min_v, *max_v))
+        }
+        (Value::F64(v), Value::F64(min_v), Value::F64(max_v)) => {
+          Value::F64((*v).clamp(*min_v, *max_v))
+        }
+        _ => value.clone(),
+      },
       FilterOp::Chain(filters) => {
         let flat = flatten_chain(filters);
+        if flat.is_empty() {
+          return value.clone();
+        }
         let mut result = value.clone();
         for f in flat {
           result = f.apply_ref(&result);
@@ -709,10 +716,15 @@ mod tests {
   fn test_chain_value_apply_ref() {
     let filter: FilterOp<Value> = FilterOp::Chain(vec![FilterOp::Trim, FilterOp::Lowercase]);
     let value = Value::Str("  HELLO  ".to_string());
-    assert_eq!(
-      filter.apply_ref(&value),
-      Value::Str("hello".to_string())
-    );
+    assert_eq!(filter.apply_ref(&value), Value::Str("hello".to_string()));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_chain_value_empty_returns_original() {
+    let filter: FilterOp<Value> = FilterOp::Chain(vec![]);
+    let value = Value::Str("hello".to_string());
+    assert_eq!(filter.apply_ref(&value), value);
   }
 
   #[cfg(feature = "validation")]
@@ -1012,9 +1024,15 @@ mod tests {
   #[test]
   fn test_slug_max_length_truncation() {
     // "hello-world-this-is-a-long-title" is 32 chars
-    let filter = FilterOp::<String>::Slug { max_length: Some(11) };
+    let filter = FilterOp::<String>::Slug {
+      max_length: Some(11),
+    };
     let result = filter.apply("Hello World This Is A Long Title".to_string());
-    assert!(result.len() <= 11, "slug length {} exceeds max 11", result.len());
+    assert!(
+      result.len() <= 11,
+      "slug length {} exceeds max 11",
+      result.len()
+    );
   }
 
   // ====================================================================
@@ -1031,7 +1049,9 @@ mod tests {
 
   #[test]
   fn test_serde_roundtrip_slug() {
-    let op = FilterOp::<String>::Slug { max_length: Some(50) };
+    let op = FilterOp::<String>::Slug {
+      max_length: Some(50),
+    };
     let json = serde_json::to_string(&op).unwrap();
     let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
     assert_eq!(op, deserialized);
@@ -1079,8 +1099,7 @@ mod tests {
   #[test]
   fn test_custom_serde_skip_direct() {
     // A standalone Custom variant cannot be serialized — returns an error.
-    let op: FilterOp<String> =
-      FilterOp::Custom(Arc::new(|s: String| s.to_uppercase()));
+    let op: FilterOp<String> = FilterOp::Custom(Arc::new(|s: String| s.to_uppercase()));
     let result = serde_json::to_string(&op);
     assert!(result.is_err(), "Custom variant should fail serialization");
   }
@@ -1120,7 +1139,10 @@ mod tests {
       to: "Rust".to_string(),
     };
     let value = Value::Str("Hello World".to_string());
-    assert_eq!(filter.apply_ref(&value), Value::Str("Hello Rust".to_string()));
+    assert_eq!(
+      filter.apply_ref(&value),
+      Value::Str("Hello Rust".to_string())
+    );
   }
 
   // ====================================================================

--- a/crates/filter/src/slug.rs
+++ b/crates/filter/src/slug.rs
@@ -18,7 +18,8 @@ pub fn get_dash_filter_regex() -> &'static Regex {
   DASH_FILTER_REGEX.get_or_init(|| Regex::new(DASH_FILTER_REGEX_STR).unwrap())
 }
 
-/// Normalizes given string into a slug - e.g., a string matching /^[a-z0-9_][a-z0-9_\-]{0,198}[a-z0-9_]?$/
+/// Normalizes given string into a slug — a lowercase, ASCII-only string
+/// matching `[a-z0-9_]([a-z0-9_-]*[a-z0-9_])?` with a configurable max length.
 ///
 /// ```rust
 /// use std::borrow::Cow;
@@ -30,7 +31,7 @@ pub fn to_slug(xs: Cow<'_, str>) -> Cow<'static, str> {
   _to_slug(get_slug_filter_regex(), 200, xs)
 }
 
-/// Same as `to_slug` method but removes duplicate '-' symbols.
+/// Same as [`to_slug`] but collapses consecutive dashes into a single dash.
 ///
 /// ```rust
 /// use std::borrow::Cow;
@@ -107,7 +108,7 @@ fn _to_pretty_slug(pattern: &Regex, max_length: usize, xs: Cow<'_, str>) -> Cow<
     .into()
 }
 
-/// Configurable version of `to_slug()` - allows for setting the max_length.
+/// Configurable slug filter — produces a lowercase, ASCII-only slug with a settable max length.
 #[must_use]
 #[derive(Clone, Debug, Default, Builder)]
 pub struct SlugFilter {

--- a/crates/filter/src/strip_tags.rs
+++ b/crates/filter/src/strip_tags.rs
@@ -210,7 +210,14 @@ mod test {
     let filter = StripTagsFilter::new();
 
     // These inputs have no '<' character — should be no-op
-    for input in ["Hello", "Hello World", "abc123", "", "Socrates'", "\"Hello\""] {
+    for input in [
+      "Hello",
+      "Hello World",
+      "abc123",
+      "",
+      "Socrates'",
+      "\"Hello\"",
+    ] {
       let result = filter.filter(input.into());
       assert_eq!(result, input);
     }

--- a/crates/filter/src/try_filter_op.rs
+++ b/crates/filter/src/try_filter_op.rs
@@ -172,6 +172,9 @@ impl TryFilterOp<Value> {
       TryFilterOp::Infallible(op) => Ok(op.apply_ref(value)),
       TryFilterOp::Chain(ops) => {
         let flat = flatten_try_chain(ops);
+        if flat.is_empty() {
+          return Ok(value.clone());
+        }
         let mut result = value.clone();
         for op in flat {
           result = op.try_apply_ref(&result)?;
@@ -264,9 +267,8 @@ mod tests {
 
   #[test]
   fn test_try_custom_success() {
-    let op: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(|s: String| {
-      Ok(s.to_uppercase())
-    }));
+    let op: TryFilterOp<String> =
+      TryFilterOp::TryCustom(Arc::new(|s: String| Ok(s.to_uppercase())));
     assert_eq!(op.try_apply("hello".to_string()).unwrap(), "HELLO");
   }
 
@@ -296,9 +298,7 @@ mod tests {
   fn test_chain_short_circuits_on_error() {
     let op: TryFilterOp<String> = TryFilterOp::Chain(vec![
       TryFilterOp::Infallible(FilterOp::Trim),
-      TryFilterOp::TryCustom(Arc::new(|_| {
-        Err(FilterError::new("always fails"))
-      })),
+      TryFilterOp::TryCustom(Arc::new(|_| Err(FilterError::new("always fails")))),
       TryFilterOp::Infallible(FilterOp::Lowercase), // should not execute
     ]);
     let err = op.try_apply("  HELLO  ".to_string()).unwrap_err();
@@ -313,8 +313,7 @@ mod tests {
 
   #[test]
   fn test_chain_single() {
-    let op: TryFilterOp<String> =
-      TryFilterOp::Chain(vec![TryFilterOp::Infallible(FilterOp::Trim)]);
+    let op: TryFilterOp<String> = TryFilterOp::Chain(vec![TryFilterOp::Infallible(FilterOp::Trim)]);
     assert_eq!(op.try_apply("  hello  ".to_string()).unwrap(), "hello");
   }
 
@@ -394,9 +393,7 @@ mod tests {
   #[test]
   fn test_infallible_value_trim() {
     let op: TryFilterOp<Value> = TryFilterOp::Infallible(FilterOp::Trim);
-    let result = op
-      .try_apply(Value::Str("  hello  ".to_string()))
-      .unwrap();
+    let result = op.try_apply(Value::Str("  hello  ".to_string())).unwrap();
     assert_eq!(result, Value::Str("hello".to_string()));
   }
 
@@ -430,10 +427,17 @@ mod tests {
       TryFilterOp::Infallible(FilterOp::Trim),
       TryFilterOp::Infallible(FilterOp::Lowercase),
     ]);
-    let result = op
-      .try_apply(Value::Str("  HELLO  ".to_string()))
-      .unwrap();
+    let result = op.try_apply(Value::Str("  HELLO  ".to_string())).unwrap();
     assert_eq!(result, Value::Str("hello".to_string()));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_chain_value_empty() {
+    let op: TryFilterOp<Value> = TryFilterOp::Chain(vec![]);
+    let value = Value::Str("hello".to_string());
+    let result = op.try_apply_ref(&value).unwrap();
+    assert_eq!(result, value);
   }
 
   // ---- apply_ref tests ----
@@ -531,10 +535,7 @@ mod tests {
   fn test_try_filter_trait_string() {
     use crate::TryFilter;
     let op: TryFilterOp<String> = TryFilterOp::Infallible(FilterOp::Trim);
-    assert_eq!(
-      op.try_filter("  hello  ".to_string()).unwrap(),
-      "hello"
-    );
+    assert_eq!(op.try_filter("  hello  ".to_string()).unwrap(), "hello");
   }
 
   #[cfg(feature = "validation")]
@@ -587,8 +588,7 @@ mod tests {
 
   #[test]
   fn test_deeply_nested_try_chain_numeric() {
-    let mut chain: TryFilterOp<i32> =
-      TryFilterOp::Infallible(FilterOp::Clamp { min: 0, max: 100 });
+    let mut chain: TryFilterOp<i32> = TryFilterOp::Infallible(FilterOp::Clamp { min: 0, max: 100 });
     for _ in 0..10_000 {
       chain = TryFilterOp::Chain(vec![chain]);
     }

--- a/crates/filter/src/xml_entities.rs
+++ b/crates/filter/src/xml_entities.rs
@@ -82,7 +82,7 @@ impl Filter<Cow<'_, str>> for XmlEntitiesFilter<'_> {
       return Cow::Owned(input.into_owned());
     }
 
-    let mut output = String::with_capacity(input.len());
+    let mut output = String::with_capacity(input.len() + input.len() / 5 * 3);
     for c in input.chars() {
       match self.chars_assoc_map.get(&c) {
         Some(entity) => output.push_str(entity),
@@ -173,6 +173,21 @@ mod test {
     let input = "Hello World".to_string();
     let result = filter.filter(std::borrow::Cow::Owned(input));
     assert_eq!(result, "Hello World");
+  }
+
+  #[test]
+  fn test_entity_heavy_string() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    // Every character requires entity expansion
+    let input = "<>&'\"<>&'\"";
+    let expected = "&lt;&gt;&amp;&apos;&quot;&lt;&gt;&amp;&apos;&quot;";
+    assert_eq!(filter.filter(input.into()), expected);
+
+    // All ampersands
+    let input = "&&&&&";
+    let expected = "&amp;&amp;&amp;&amp;&amp;";
+    assert_eq!(filter.filter(input.into()), expected);
   }
 
   #[cfg(feature = "fn_traits")]


### PR DESCRIPTION
## Summary

Closes #153, closes #155, closes #156.

### #153 - XmlEntitiesFilter capacity heuristic
Improved initial capacity estimate for the output buffer in XmlEntitiesFilter to account for entity expansion, reducing reallocations on entity-heavy strings.

### #155 - TryFilterOp<Value>::Chain empty-chain early return
Added early return guard for empty chains in both `TryFilterOp<Value>::Chain` and `FilterOp<Value>::Chain`, matching the existing optimization in the String implementation. Avoids unnecessary clone when chain is empty.

### #156 - SlugFilter documentation update
Updated SlugFilter documentation to accurately reflect ASCII-only output pattern after the Unicode regex fix.