### PR TITLE
perf(walrs_filter): #154 - use input-tied lifetime for Cow output

### DIFF
--- a/crates/filter/src/slug.rs
+++ b/crates/filter/src/slug.rs
@@ -26,7 +26,7 @@ pub fn get_dash_filter_regex() -> &'static Regex {
 ///
 /// assert_eq!(to_slug(Cow::Borrowed("Hello World")), "hello-world");
 /// ```
-pub fn to_slug(xs: Cow<'_, str>) -> Cow<'static, str> {
+pub fn to_slug<'a>(xs: Cow<'a, str>) -> Cow<'a, str> {
   _to_slug(get_slug_filter_regex(), 200, xs)
 }
 
@@ -38,7 +38,7 @@ pub fn to_slug(xs: Cow<'_, str>) -> Cow<'static, str> {
 ///
 /// assert_eq!(to_pretty_slug(Cow::Borrowed("%$Hello@#$@#!(World$$")), "hello-world");
 /// ```
-pub fn to_pretty_slug(xs: Cow<'_, str>) -> Cow<'static, str> {
+pub fn to_pretty_slug<'a>(xs: Cow<'a, str>) -> Cow<'a, str> {
   _to_pretty_slug(get_slug_filter_regex(), 200, xs)
 }
 
@@ -67,10 +67,10 @@ fn is_valid_slug(s: &str, max_length: usize, allow_duplicate_dashes: bool) -> bo
   true
 }
 
-fn _to_slug(pattern: &Regex, max_length: usize, xs: Cow<'_, str>) -> Cow<'static, str> {
-  // Fast path: if already a valid slug, return as-is
+fn _to_slug<'a>(pattern: &Regex, max_length: usize, xs: Cow<'a, str>) -> Cow<'a, str> {
+  // Fast path: if already a valid slug, return as-is (zero-copy)
   if is_valid_slug(&xs, max_length, true) {
-    return Cow::Owned(xs.into_owned());
+    return xs;
   }
 
   let rslt = pattern
@@ -91,14 +91,14 @@ fn _to_slug(pattern: &Regex, max_length: usize, xs: Cow<'_, str>) -> Cow<'static
   }
 }
 
-fn _to_pretty_slug(pattern: &Regex, max_length: usize, xs: Cow<'_, str>) -> Cow<'static, str> {
+fn _to_pretty_slug<'a>(pattern: &Regex, max_length: usize, xs: Cow<'a, str>) -> Cow<'a, str> {
   if xs.is_empty() {
-    return Cow::Owned(String::new());
+    return xs;
   }
 
-  // Fast path: if already a valid pretty slug, return as-is
+  // Fast path: if already a valid pretty slug, return as-is (zero-copy)
   if is_valid_slug(&xs, max_length, false) {
-    return Cow::Owned(xs.into_owned());
+    return xs;
   }
 
   get_dash_filter_regex()
@@ -127,10 +127,10 @@ impl SlugFilter {
   }
 }
 
-impl Filter<Cow<'_, str>> for SlugFilter {
-  type Output = Cow<'static, str>;
+impl<'a> Filter<Cow<'a, str>> for SlugFilter {
+  type Output = Cow<'a, str>;
 
-  fn filter(&self, xs: Cow<'_, str>) -> Self::Output {
+  fn filter(&self, xs: Cow<'a, str>) -> Self::Output {
     if self.allow_duplicate_dashes {
       _to_slug(get_slug_filter_regex(), self.max_length, xs)
     } else {
@@ -140,24 +140,24 @@ impl Filter<Cow<'_, str>> for SlugFilter {
 }
 
 #[cfg(feature = "fn_traits")]
-impl FnOnce<(Cow<'_, str>,)> for SlugFilter {
-  type Output = Cow<'static, str>;
+impl<'a> FnOnce<(Cow<'a, str>,)> for SlugFilter {
+  type Output = Cow<'a, str>;
 
-  extern "rust-call" fn call_once(self, args: (Cow<'_, str>,)) -> Self::Output {
+  extern "rust-call" fn call_once(self, args: (Cow<'a, str>,)) -> Self::Output {
     Filter::filter(&self, args.0)
   }
 }
 
 #[cfg(feature = "fn_traits")]
-impl Fn<(Cow<'_, str>,)> for SlugFilter {
-  extern "rust-call" fn call(&self, args: (Cow<'_, str>,)) -> Self::Output {
+impl<'a> Fn<(Cow<'a, str>,)> for SlugFilter {
+  extern "rust-call" fn call(&self, args: (Cow<'a, str>,)) -> Self::Output {
     Filter::filter(self, args.0)
   }
 }
 
 #[cfg(feature = "fn_traits")]
-impl FnMut<(Cow<'_, str>,)> for SlugFilter {
-  extern "rust-call" fn call_mut(&mut self, args: (Cow<'_, str>,)) -> Self::Output {
+impl<'a> FnMut<(Cow<'a, str>,)> for SlugFilter {
+  extern "rust-call" fn call_mut(&mut self, args: (Cow<'a, str>,)) -> Self::Output {
     Filter::filter(self, args.0)
   }
 }
@@ -237,19 +237,29 @@ mod test {
 
   #[test]
   fn test_slug_noop_already_valid() {
-    // These are already valid slugs — should be no-op
+    // These are already valid slugs — should be zero-copy no-op
     for input in ["hello-world", "abc123", "test_slug", "a"] {
       let result = to_slug(Cow::Borrowed(input));
       assert_eq!(result, input);
+      assert!(
+        matches!(result, Cow::Borrowed(_)),
+        "Expected Cow::Borrowed for no-op slug input {:?}",
+        input
+      );
     }
   }
 
   #[test]
   fn test_pretty_slug_noop_already_valid() {
-    // These are already valid pretty slugs (no duplicate dashes)
+    // These are already valid pretty slugs (no duplicate dashes) — should be zero-copy no-op
     for input in ["hello-world", "abc123", "test_slug", "a"] {
       let result = to_pretty_slug(Cow::Borrowed(input));
       assert_eq!(result, input);
+      assert!(
+        matches!(result, Cow::Borrowed(_)),
+        "Expected Cow::Borrowed for no-op pretty slug input {:?}",
+        input
+      );
     }
   }
 
@@ -257,9 +267,10 @@ mod test {
   fn test_slug_filter_noop() {
     let filter = SlugFilter::new(200, false);
 
-    // Already a valid pretty slug
+    // Already a valid pretty slug — should be zero-copy no-op
     let result = filter.filter(Cow::Borrowed("hello-world"));
     assert_eq!(result, "hello-world");
+    assert!(matches!(result, Cow::Borrowed(_)));
   }
 
   #[test]
@@ -270,6 +281,7 @@ mod test {
     let input = "hello-world".to_string();
     let result = filter.filter(Cow::Owned(input));
     assert_eq!(result, "hello-world");
+    assert!(matches!(result, Cow::Owned(_)));
   }
 
   #[test]

--- a/crates/filter/src/xml_entities.rs
+++ b/crates/filter/src/xml_entities.rs
@@ -51,8 +51,8 @@ impl XmlEntitiesFilter<'_> {
   }
 }
 
-impl Filter<Cow<'_, str>> for XmlEntitiesFilter<'_> {
-  type Output = Cow<'static, str>;
+impl<'a> Filter<Cow<'a, str>> for XmlEntitiesFilter<'_> {
+  type Output = Cow<'a, str>;
 
   /// Uses contained character association map to encode characters matching contained characters as
   /// xml entities.
@@ -76,10 +76,10 @@ impl Filter<Cow<'_, str>> for XmlEntitiesFilter<'_> {
   ///   assert_eq!(filter.filter(incoming_src.into()), expected_src.to_string());
   /// }
   ///```
-  fn filter(&self, input: Cow<'_, str>) -> Self::Output {
-    // Fast path: if no characters need encoding, return input as-is
+  fn filter(&self, input: Cow<'a, str>) -> Self::Output {
+    // Fast path: if no characters need encoding, return input as-is (zero-copy)
     if !input.chars().any(|c| self.chars_assoc_map.contains_key(&c)) {
-      return Cow::Owned(input.into_owned());
+      return input;
     }
 
     let mut output = String::with_capacity(input.len());
@@ -101,24 +101,24 @@ impl Default for XmlEntitiesFilter<'_> {
 }
 
 #[cfg(feature = "fn_traits")]
-impl FnOnce<(Cow<'_, str>,)> for XmlEntitiesFilter<'_> {
-  type Output = Cow<'static, str>;
+impl<'a> FnOnce<(Cow<'a, str>,)> for XmlEntitiesFilter<'_> {
+  type Output = Cow<'a, str>;
 
-  extern "rust-call" fn call_once(self, args: (Cow<'_, str>,)) -> Self::Output {
+  extern "rust-call" fn call_once(self, args: (Cow<'a, str>,)) -> Self::Output {
     Filter::filter(&self, args.0)
   }
 }
 
 #[cfg(feature = "fn_traits")]
-impl FnMut<(Cow<'_, str>,)> for XmlEntitiesFilter<'_> {
-  extern "rust-call" fn call_mut(&mut self, args: (Cow<'_, str>,)) -> Self::Output {
+impl<'a> FnMut<(Cow<'a, str>,)> for XmlEntitiesFilter<'_> {
+  extern "rust-call" fn call_mut(&mut self, args: (Cow<'a, str>,)) -> Self::Output {
     Filter::filter(self, args.0)
   }
 }
 
 #[cfg(feature = "fn_traits")]
-impl Fn<(Cow<'_, str>,)> for XmlEntitiesFilter<'_> {
-  extern "rust-call" fn call(&self, args: (Cow<'_, str>,)) -> Self::Output {
+impl<'a> Fn<(Cow<'a, str>,)> for XmlEntitiesFilter<'_> {
+  extern "rust-call" fn call(&self, args: (Cow<'a, str>,)) -> Self::Output {
     Filter::filter(self, args.0)
   }
 }
@@ -157,11 +157,16 @@ mod test {
   fn test_noop_no_encodable_chars() {
     let filter = super::XmlEntitiesFilter::new();
 
-    // These inputs have no encodable characters — should be no-op
+    // These inputs have no encodable characters — should be zero-copy no-op
     for input in ["Hello", "Hello World", "abc123", "", " "] {
       let cow_input = std::borrow::Cow::Borrowed(input);
       let result = filter.filter(cow_input);
       assert_eq!(result, input);
+      assert!(
+        matches!(result, std::borrow::Cow::Borrowed(_)),
+        "Expected Cow::Borrowed for no-op input {:?}",
+        input
+      );
     }
   }
 
@@ -173,6 +178,7 @@ mod test {
     let input = "Hello World".to_string();
     let result = filter.filter(std::borrow::Cow::Owned(input));
     assert_eq!(result, "Hello World");
+    assert!(matches!(result, std::borrow::Cow::Owned(_)));
   }
 
   #[cfg(feature = "fn_traits")]


### PR DESCRIPTION
## Summary

Closes #154.

### Breaking Change
Changed `Filter` output type from `Cow<'static, str>` to `Cow<'a, str>` for:
- `XmlEntitiesFilter`
- `SlugFilter`
- `to_slug()` / `to_pretty_slug()` functions

### Motivation
The previous `Cow<'static, str>` output forced `into_owned()` allocation even on no-op fast paths (when no transformation was needed). By tying the output lifetime to the input, no-op paths can return the input directly without allocation.

### Impact
Downstream code that explicitly annotates the output as `Cow<'static, str>` will need to update lifetime annotations. Code using type inference or `.into_owned()` is unaffected.