### PR TITLE
fix(walrs_navigation): #166 handle fragment-only pages in Page::href()

### DIFF
--- a/crates/navigation/src/page.rs
+++ b/crates/navigation/src/page.rs
@@ -310,6 +310,11 @@ impl Page {
 
   /// Returns the full URI including fragment if present.
   ///
+  /// If both `uri` and `fragment` are set, returns `"uri#fragment"`.
+  /// If only `uri` is set, returns the URI.
+  /// If only `fragment` is set, returns `"#fragment"`.
+  /// If neither is set, returns `None`.
+  ///
   /// # Examples
   ///
   /// ```
@@ -320,15 +325,17 @@ impl Page {
   ///     .fragment("team")
   ///     .build();
   /// assert_eq!(page.href(), Some("/about#team".to_string()));
+  ///
+  /// let fragment_only = Page::builder().fragment("section1").build();
+  /// assert_eq!(fragment_only.href(), Some("#section1".to_string()));
   /// ```
   pub fn href(&self) -> Option<String> {
-    self.uri.as_ref().map(|uri| {
-      if let Some(fragment) = &self.fragment {
-        format!("{}#{}", uri, fragment)
-      } else {
-        uri.clone()
-      }
-    })
+    match (&self.uri, &self.fragment) {
+      (Some(uri), Some(fragment)) => Some(format!("{}#{}", uri, fragment)),
+      (Some(uri), None) => Some(uri.clone()),
+      (None, Some(fragment)) => Some(format!("#{}", fragment)),
+      (None, None) => None,
+    }
   }
 
   /// Checks whether this page or any descendant is active.
@@ -1207,7 +1214,11 @@ mod tests {
     let page = Page::builder().uri("/about").build();
     assert_eq!(page.href(), Some("/about".to_string()));
 
-    // No URI
+    // Fragment only (no URI)
+    let page = Page::builder().fragment("section1").build();
+    assert_eq!(page.href(), Some("#section1".to_string()));
+
+    // Neither URI nor fragment
     let page = Page::new();
     assert_eq!(page.href(), None);
   }

--- a/crates/navigation/src/view.rs
+++ b/crates/navigation/src/view.rs
@@ -429,6 +429,19 @@ mod tests {
   }
 
   #[test]
+  fn test_render_menu_fragment_only() {
+    let mut nav = Container::new();
+    nav.add_page(
+      Page::builder()
+        .label("Section")
+        .fragment("section1")
+        .build(),
+    );
+    let html = render_menu(&nav);
+    assert!(html.contains("href=\"#section1\""));
+  }
+
+  #[test]
   fn test_render_menu_no_label() {
     let mut nav = Container::new();
     nav.add_page(Page::builder().uri("/").build());


### PR DESCRIPTION
## Summary

Fixes #166 — Review walrs\_navigation crate for correctness and soundness.

### Review Findings

Audited all six source files per the checklist:

| Area | Status | Notes |
|------|--------|-------|
| **Correctness** | ✅ Fixed | `Page::href()` now handles fragment-only pages |
| **Soundness** | ✅ Pass | No infinite recursion (owned `Vec<Page>` prevents cycles), no dangling refs, no silent data loss |
| **Serialization** | ✅ Pass | JSON/YAML round-trips tested and correct |
| **Error handling** | ✅ Pass | `NavigationError` is complete with `Display`, `Debug`, `Error`, `Clone`, `PartialEq`, `Eq` |
| **Feature gates** | ✅ Pass | `json`/`yaml` correctly gate `serde_json`/`serde_yaml` |
| **View logic** | ✅ Pass | XSS-safe rendering, visibility filtering correct |
| **Edge cases** | ✅ Fixed | Fragment-only pages now work; empty containers, single-page, special chars all handled |
| **Test coverage** | ✅ 98.80% | 121 unit + 61 doc tests |
| **Documentation** | ✅ Pass | All public API items have doc comments |

### Bug Fix: `Page::href()` fragment-only pages

**Before:** `Page::href()` returned `None` when `uri` was `None`, even if `fragment` was set. This caused fragment-only pages to render as `href="#"` in view helpers.

**After:** Uses match on `(uri, fragment)` tuple to handle all four cases:
- `(Some, Some)` → `"uri#fragment"`
- `(Some, None)` → `"uri"`
- `(None, Some)` → `"#fragment"`
- `(None, None)` → `None`

### Changes
- `page.rs`: Fix `href()` logic + expanded doc comment with fragment-only example + test
- `view.rs`: Add `test_render_menu_fragment_only` test

### Verification
- `cargo fmt` ✅
- `cargo clippy --all-features` ✅ (no warnings)
- `cargo test -p walrs_navigation --all-features` ✅ (121 unit + 61 doc tests)
- `cargo build --workspace` ✅
- `cargo build --examples -p walrs_navigation --all-features` ✅
- Coverage: 98.80% line coverage