### PR TITLE
test(walrs_validation): #144 Add NaN and infinity assertion tests for float rules

### DIFF
--- a/crates/validation/benches/validation_benchmarks.rs
+++ b/crates/validation/benches/validation_benchmarks.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use walrs_validation::{Rule, Validate, ValidateRef};
 
 // ============================================================================
@@ -6,53 +6,53 @@ use walrs_validation::{Rule, Validate, ValidateRef};
 // ============================================================================
 
 fn bench_string_email(c: &mut Criterion) {
-    use walrs_validation::options::EmailOptions;
-    let rule = Rule::<String>::Email(EmailOptions::default());
-    c.bench_function("email valid", |b| {
-        b.iter(|| rule.validate_ref("user@example.com"))
-    });
-    c.bench_function("email invalid", |b| {
-        b.iter(|| rule.validate_ref("not-an-email"))
-    });
+  use walrs_validation::options::EmailOptions;
+  let rule = Rule::<String>::Email(EmailOptions::default());
+  c.bench_function("email valid", |b| {
+    b.iter(|| rule.validate_ref("user@example.com"))
+  });
+  c.bench_function("email invalid", |b| {
+    b.iter(|| rule.validate_ref("not-an-email"))
+  });
 }
 
 fn bench_string_pattern(c: &mut Criterion) {
-    let rule = Rule::<String>::pattern(r"^[a-zA-Z0-9_\-]{3,30}$").unwrap();
+  let rule = Rule::<String>::pattern(r"^[a-zA-Z0-9_\-]{3,30}$").unwrap();
 
-    c.bench_function("pattern rule", |b| {
-        b.iter(|| rule.validate_ref("hello_world"))
-    });
+  c.bench_function("pattern rule", |b| {
+    b.iter(|| rule.validate_ref("hello_world"))
+  });
 }
 
 fn bench_string_length(c: &mut Criterion) {
-    let rule = Rule::<String>::MinLength(3).and(Rule::MaxLength(50));
-    c.bench_function("string length check", |b| {
-        b.iter(|| rule.validate_ref("hello world"))
-    });
+  let rule = Rule::<String>::MinLength(3).and(Rule::MaxLength(50));
+  c.bench_function("string length check", |b| {
+    b.iter(|| rule.validate_ref("hello world"))
+  });
 }
 
 fn bench_string_url(c: &mut Criterion) {
-    use walrs_validation::options::UrlOptions;
-    let rule = Rule::<String>::Url(UrlOptions::default());
-    c.bench_function("url valid", |b| {
-        b.iter(|| rule.validate_ref("https://www.example.com/path?query=1"))
-    });
+  use walrs_validation::options::UrlOptions;
+  let rule = Rule::<String>::Url(UrlOptions::default());
+  c.bench_function("url valid", |b| {
+    b.iter(|| rule.validate_ref("https://www.example.com/path?query=1"))
+  });
 }
 
 fn bench_string_ip(c: &mut Criterion) {
-    use walrs_validation::options::IpOptions;
-    let rule = Rule::<String>::Ip(IpOptions::default());
-    c.bench_function("ipv4 valid", |b| {
-        b.iter(|| rule.validate_ref("192.168.1.1"))
-    });
+  use walrs_validation::options::IpOptions;
+  let rule = Rule::<String>::Ip(IpOptions::default());
+  c.bench_function("ipv4 valid", |b| {
+    b.iter(|| rule.validate_ref("192.168.1.1"))
+  });
 }
 
 fn bench_string_hostname(c: &mut Criterion) {
-    use walrs_validation::options::HostnameOptions;
-    let rule = Rule::<String>::Hostname(HostnameOptions::default());
-    c.bench_function("hostname valid", |b| {
-        b.iter(|| rule.validate_ref("example.com"))
-    });
+  use walrs_validation::options::HostnameOptions;
+  let rule = Rule::<String>::Hostname(HostnameOptions::default());
+  c.bench_function("hostname valid", |b| {
+    b.iter(|| rule.validate_ref("example.com"))
+  });
 }
 
 // ============================================================================
@@ -60,27 +60,19 @@ fn bench_string_hostname(c: &mut Criterion) {
 // ============================================================================
 
 fn bench_numeric_min_max(c: &mut Criterion) {
-    let rule = Rule::<i32>::Min(0).and(Rule::Max(1000));
-    c.bench_function("numeric min/max valid", |b| {
-        b.iter(|| rule.validate(500))
-    });
-    c.bench_function("numeric min/max invalid", |b| {
-        b.iter(|| rule.validate(-1))
-    });
+  let rule = Rule::<i32>::Min(0).and(Rule::Max(1000));
+  c.bench_function("numeric min/max valid", |b| b.iter(|| rule.validate(500)));
+  c.bench_function("numeric min/max invalid", |b| b.iter(|| rule.validate(-1)));
 }
 
 fn bench_numeric_range(c: &mut Criterion) {
-    let rule = Rule::<i32>::Range { min: 0, max: 1000 };
-    c.bench_function("numeric range valid", |b| {
-        b.iter(|| rule.validate(500))
-    });
+  let rule = Rule::<i32>::Range { min: 0, max: 1000 };
+  c.bench_function("numeric range valid", |b| b.iter(|| rule.validate(500)));
 }
 
 fn bench_numeric_step(c: &mut Criterion) {
-    let rule = Rule::<i32>::Step(5);
-    c.bench_function("numeric step valid", |b| {
-        b.iter(|| rule.validate(25))
-    });
+  let rule = Rule::<i32>::Step(5);
+  c.bench_function("numeric step valid", |b| b.iter(|| rule.validate(25)));
 }
 
 // ============================================================================
@@ -88,53 +80,49 @@ fn bench_numeric_step(c: &mut Criterion) {
 // ============================================================================
 
 fn bench_composite_all(c: &mut Criterion) {
-    let rule = Rule::<String>::Required
-        .and(Rule::MinLength(3))
-        .and(Rule::MaxLength(50))
-        .and(Rule::pattern(r"^[a-zA-Z0-9_]+$").unwrap());
+  let rule = Rule::<String>::Required
+    .and(Rule::MinLength(3))
+    .and(Rule::MaxLength(50))
+    .and(Rule::pattern(r"^[a-zA-Z0-9_]+$").unwrap());
 
-    c.bench_function("composite All (4 rules) valid", |b| {
-        b.iter(|| rule.validate_ref("hello_world"))
-    });
-    c.bench_function("composite All (4 rules) invalid", |b| {
-        b.iter(|| rule.validate_ref("hi"))
-    });
+  c.bench_function("composite All (4 rules) valid", |b| {
+    b.iter(|| rule.validate_ref("hello_world"))
+  });
+  c.bench_function("composite All (4 rules) invalid", |b| {
+    b.iter(|| rule.validate_ref("hi"))
+  });
 }
 
 fn bench_composite_any(c: &mut Criterion) {
-    let rule = Rule::<i32>::Equals(0)
-        .or(Rule::Equals(100))
-        .or(Rule::Equals(200));
+  let rule = Rule::<i32>::Equals(0)
+    .or(Rule::Equals(100))
+    .or(Rule::Equals(200));
 
-    c.bench_function("composite Any (3 rules) first match", |b| {
-        b.iter(|| rule.validate(0))
-    });
-    c.bench_function("composite Any (3 rules) last match", |b| {
-        b.iter(|| rule.validate(200))
-    });
+  c.bench_function("composite Any (3 rules) first match", |b| {
+    b.iter(|| rule.validate(0))
+  });
+  c.bench_function("composite Any (3 rules) last match", |b| {
+    b.iter(|| rule.validate(200))
+  });
 }
 
 criterion_group!(
-    string_benches,
-    bench_string_email,
-    bench_string_pattern,
-    bench_string_length,
-    bench_string_url,
-    bench_string_ip,
-    bench_string_hostname,
+  string_benches,
+  bench_string_email,
+  bench_string_pattern,
+  bench_string_length,
+  bench_string_url,
+  bench_string_ip,
+  bench_string_hostname,
 );
 
 criterion_group!(
-    numeric_benches,
-    bench_numeric_min_max,
-    bench_numeric_range,
-    bench_numeric_step,
+  numeric_benches,
+  bench_numeric_min_max,
+  bench_numeric_range,
+  bench_numeric_step,
 );
 
-criterion_group!(
-    composite_benches,
-    bench_composite_all,
-    bench_composite_any,
-);
+criterion_group!(composite_benches, bench_composite_all, bench_composite_any,);
 
 criterion_main!(string_benches, numeric_benches, composite_benches);

--- a/crates/validation/examples/basic_validation.rs
+++ b/crates/validation/examples/basic_validation.rs
@@ -6,79 +6,86 @@
 use walrs_validation::{Rule, Validate, ValidateRef};
 
 fn main() {
-    // -------------------------------------------------------------------------
-    // String length validation
-    // -------------------------------------------------------------------------
-    let username_rule = Rule::<String>::MinLength(3).and(Rule::MaxLength(20));
+  // -------------------------------------------------------------------------
+  // String length validation
+  // -------------------------------------------------------------------------
+  let username_rule = Rule::<String>::MinLength(3).and(Rule::MaxLength(20));
 
-    assert!(username_rule.validate_ref("alice").is_ok());
-    assert!(username_rule.validate_ref("ab").is_err());
-    assert!(username_rule.validate_ref("this_username_is_way_too_long_for_our_system").is_err());
+  assert!(username_rule.validate_ref("alice").is_ok());
+  assert!(username_rule.validate_ref("ab").is_err());
+  assert!(
+    username_rule
+      .validate_ref("this_username_is_way_too_long_for_our_system")
+      .is_err()
+  );
 
-    println!("String length validation: OK");
+  println!("String length validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Exact length
-    // -------------------------------------------------------------------------
-    let pin_rule = Rule::<String>::ExactLength(4);
-    assert!(pin_rule.validate_ref("1234").is_ok());
-    assert!(pin_rule.validate_ref("12345").is_err());
+  // -------------------------------------------------------------------------
+  // Exact length
+  // -------------------------------------------------------------------------
+  let pin_rule = Rule::<String>::ExactLength(4);
+  assert!(pin_rule.validate_ref("1234").is_ok());
+  assert!(pin_rule.validate_ref("12345").is_err());
 
-    println!("Exact length validation: OK");
+  println!("Exact length validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Required (non-empty)
-    // -------------------------------------------------------------------------
-    let required_rule = Rule::<String>::Required;
-    assert!(required_rule.validate_ref("hello").is_ok());
-    assert!(required_rule.validate_ref("").is_err());
-    assert!(required_rule.validate_ref("   ").is_err()); // whitespace-only is empty
+  // -------------------------------------------------------------------------
+  // Required (non-empty)
+  // -------------------------------------------------------------------------
+  let required_rule = Rule::<String>::Required;
+  assert!(required_rule.validate_ref("hello").is_ok());
+  assert!(required_rule.validate_ref("").is_err());
+  assert!(required_rule.validate_ref("   ").is_err()); // whitespace-only is empty
 
-    println!("Required validation: OK");
+  println!("Required validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Regex pattern matching
-    // -------------------------------------------------------------------------
-    let slug_rule = Rule::<String>::pattern(r"(?i)^[\w\-]{1,100}$").unwrap();
-    assert!(slug_rule.validate_ref("my-article-title").is_ok());
-    assert!(slug_rule.validate_ref("invalid slug!").is_err());
+  // -------------------------------------------------------------------------
+  // Regex pattern matching
+  // -------------------------------------------------------------------------
+  let slug_rule = Rule::<String>::pattern(r"(?i)^[\w\-]{1,100}$").unwrap();
+  assert!(slug_rule.validate_ref("my-article-title").is_ok());
+  assert!(slug_rule.validate_ref("invalid slug!").is_err());
 
-    println!("Pattern validation: OK");
+  println!("Pattern validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Numeric range
-    // -------------------------------------------------------------------------
-    let age_rule = Rule::<u32>::Min(0).and(Rule::Max(150));
-    assert!(age_rule.validate(25).is_ok());
-    assert!(age_rule.validate(200).is_err());
+  // -------------------------------------------------------------------------
+  // Numeric range
+  // -------------------------------------------------------------------------
+  let age_rule = Rule::<u32>::Min(0).and(Rule::Max(150));
+  assert!(age_rule.validate(25).is_ok());
+  assert!(age_rule.validate(200).is_err());
 
-    let score_rule = Rule::<f64>::Range { min: 0.0, max: 100.0 };
-    assert!(score_rule.validate(85.5).is_ok());
-    assert!(score_rule.validate(-1.0).is_err());
+  let score_rule = Rule::<f64>::Range {
+    min: 0.0,
+    max: 100.0,
+  };
+  assert!(score_rule.validate(85.5).is_ok());
+  assert!(score_rule.validate(-1.0).is_err());
 
-    println!("Numeric range validation: OK");
+  println!("Numeric range validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Step validation
-    // -------------------------------------------------------------------------
-    let step_rule = Rule::<i32>::Step(5);
-    assert!(step_rule.validate(15).is_ok());
-    assert!(step_rule.validate(7).is_err());
+  // -------------------------------------------------------------------------
+  // Step validation
+  // -------------------------------------------------------------------------
+  let step_rule = Rule::<i32>::Step(5);
+  assert!(step_rule.validate(15).is_ok());
+  assert!(step_rule.validate(7).is_err());
 
-    println!("Step validation: OK");
+  println!("Step validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Equals / OneOf
-    // -------------------------------------------------------------------------
-    let status_rule = Rule::<i32>::OneOf(vec![0, 1, 2]);
-    assert!(status_rule.validate(1).is_ok());
-    assert!(status_rule.validate(99).is_err());
+  // -------------------------------------------------------------------------
+  // Equals / OneOf
+  // -------------------------------------------------------------------------
+  let status_rule = Rule::<i32>::OneOf(vec![0, 1, 2]);
+  assert!(status_rule.validate(1).is_ok());
+  assert!(status_rule.validate(99).is_err());
 
-    let exact_rule = Rule::<i32>::Equals(42);
-    assert!(exact_rule.validate(42).is_ok());
-    assert!(exact_rule.validate(0).is_err());
+  let exact_rule = Rule::<i32>::Equals(42);
+  assert!(exact_rule.validate(42).is_ok());
+  assert!(exact_rule.validate(0).is_err());
 
-    println!("Equals / OneOf validation: OK");
+  println!("Equals / OneOf validation: OK");
 
-    println!("\nAll basic validation examples passed!");
+  println!("\nAll basic validation examples passed!");
 }

--- a/crates/validation/examples/composable_rules.rs
+++ b/crates/validation/examples/composable_rules.rs
@@ -3,105 +3,99 @@
 //! Demonstrates rule composition using `.and()`, `.or()`, `.not()`,
 //! `.when()`, and `.when_else()` combinators.
 
-use walrs_validation::{Rule, Validate, ValidateRef};
 use walrs_validation::rule::Condition;
+use walrs_validation::{Rule, Validate, ValidateRef};
 
 fn main() {
-    // -------------------------------------------------------------------------
-    // `.and()` — both rules must pass (fail-fast)
-    // -------------------------------------------------------------------------
-    let password_rule = Rule::<String>::MinLength(8)
-        .and(Rule::MaxLength(64))
-        .and(Rule::pattern(r"[A-Z]").unwrap())  // must contain uppercase
-        .and(Rule::pattern(r"[0-9]").unwrap()); // must contain digit
+  // -------------------------------------------------------------------------
+  // `.and()` — both rules must pass (fail-fast)
+  // -------------------------------------------------------------------------
+  let password_rule = Rule::<String>::MinLength(8)
+    .and(Rule::MaxLength(64))
+    .and(Rule::pattern(r"[A-Z]").unwrap()) // must contain uppercase
+    .and(Rule::pattern(r"[0-9]").unwrap()); // must contain digit
 
-    assert!(password_rule.validate_ref("SecurePass1").is_ok());
-    assert!(password_rule.validate_ref("short1A").is_err());   // too short
-    assert!(password_rule.validate_ref("alllowercase1").is_err()); // no uppercase
-    assert!(password_rule.validate_ref("NoDigitsHere").is_err()); // no digit
+  assert!(password_rule.validate_ref("SecurePass1").is_ok());
+  assert!(password_rule.validate_ref("short1A").is_err()); // too short
+  assert!(password_rule.validate_ref("alllowercase1").is_err()); // no uppercase
+  assert!(password_rule.validate_ref("NoDigitsHere").is_err()); // no digit
 
-    println!(".and() combinator: OK");
+  println!(".and() combinator: OK");
 
-    // -------------------------------------------------------------------------
-    // `.or()` — at least one rule must pass
-    // -------------------------------------------------------------------------
-    // Accept either a US phone (+1...) or an international phone (+44...)
-    let phone_rule = Rule::<String>::pattern(r"^\+1\d{10}$").unwrap()
-        .or(Rule::pattern(r"^\+44\d{10}$").unwrap());
+  // -------------------------------------------------------------------------
+  // `.or()` — at least one rule must pass
+  // -------------------------------------------------------------------------
+  // Accept either a US phone (+1...) or an international phone (+44...)
+  let phone_rule = Rule::<String>::pattern(r"^\+1\d{10}$")
+    .unwrap()
+    .or(Rule::pattern(r"^\+44\d{10}$").unwrap());
 
-    assert!(phone_rule.validate_ref("+12345678901").is_ok());
-    assert!(phone_rule.validate_ref("+44123456789_").is_err()); // wrong length
-    assert!(phone_rule.validate_ref("+49000000000").is_err());  // neither pattern
+  assert!(phone_rule.validate_ref("+12345678901").is_ok());
+  assert!(phone_rule.validate_ref("+44123456789_").is_err()); // wrong length
+  assert!(phone_rule.validate_ref("+49000000000").is_err()); // neither pattern
 
-    println!(".or() combinator: OK");
+  println!(".or() combinator: OK");
 
-    // -------------------------------------------------------------------------
-    // `.not()` — negates the inner rule
-    // -------------------------------------------------------------------------
-    let no_reserved_rule = Rule::<String>::OneOf(vec![
-        "admin".to_string(),
-        "root".to_string(),
-        "system".to_string(),
-    ])
-    .not();
+  // -------------------------------------------------------------------------
+  // `.not()` — negates the inner rule
+  // -------------------------------------------------------------------------
+  let no_reserved_rule = Rule::<String>::OneOf(vec![
+    "admin".to_string(),
+    "root".to_string(),
+    "system".to_string(),
+  ])
+  .not();
 
-    assert!(no_reserved_rule.validate_ref("alice").is_ok());
-    assert!(no_reserved_rule.validate_ref("admin").is_err());
+  assert!(no_reserved_rule.validate_ref("alice").is_ok());
+  assert!(no_reserved_rule.validate_ref("admin").is_err());
 
-    println!(".not() combinator: OK");
+  println!(".not() combinator: OK");
 
-    // -------------------------------------------------------------------------
-    // `.when()` — apply a rule only when a condition holds
-    // -------------------------------------------------------------------------
-    // When the value is > 0, it must also be a multiple of 10.
-    let conditional_rule = Rule::<i32>::Step(10).when(Condition::GreaterThan(0));
+  // -------------------------------------------------------------------------
+  // `.when()` — apply a rule only when a condition holds
+  // -------------------------------------------------------------------------
+  // When the value is > 0, it must also be a multiple of 10.
+  let conditional_rule = Rule::<i32>::Step(10).when(Condition::GreaterThan(0));
 
-    assert!(conditional_rule.validate(0).is_ok());   // condition false → skip
-    assert!(conditional_rule.validate(10).is_ok());  // condition true, 10 % 10 == 0
-    assert!(conditional_rule.validate(7).is_err());  // condition true, 7 % 10 != 0
-    assert!(conditional_rule.validate(-5).is_ok());  // condition false (-5 > 0 is false) → skip
+  assert!(conditional_rule.validate(0).is_ok()); // condition false → skip
+  assert!(conditional_rule.validate(10).is_ok()); // condition true, 10 % 10 == 0
+  assert!(conditional_rule.validate(7).is_err()); // condition true, 7 % 10 != 0
+  assert!(conditional_rule.validate(-5).is_ok()); // condition false (-5 > 0 is false) → skip
 
-    println!(".when() combinator: OK");
+  println!(".when() combinator: OK");
 
-    // -------------------------------------------------------------------------
-    // `.when_else()` — conditional with an else branch
-    // -------------------------------------------------------------------------
-    // If value >= 18: must be <= 65 (adult working age).
-    // Otherwise (< 18): must equal 16 or 17 (older minors only allowed).
-    let age_rule = Rule::<u32>::Range { min: 18, max: 65 }
-        .when_else(
-            Condition::Custom(std::sync::Arc::new(|v: &u32| *v >= 18)),
-            Rule::OneOf(vec![16, 17]),
-        );
+  // -------------------------------------------------------------------------
+  // `.when_else()` — conditional with an else branch
+  // -------------------------------------------------------------------------
+  // If value >= 18: must be <= 65 (adult working age).
+  // Otherwise (< 18): must equal 16 or 17 (older minors only allowed).
+  let age_rule = Rule::<u32>::Range { min: 18, max: 65 }.when_else(
+    Condition::Custom(std::sync::Arc::new(|v: &u32| *v >= 18)),
+    Rule::OneOf(vec![16, 17]),
+  );
 
-    assert!(age_rule.validate(25).is_ok());  // adult: 18 ≤ 25 ≤ 65
-    assert!(age_rule.validate(70).is_err()); // adult: 70 > 65
-    assert!(age_rule.validate(17).is_ok());  // minor: allowed
-    assert!(age_rule.validate(15).is_err()); // minor: not in [16, 17]
+  assert!(age_rule.validate(25).is_ok()); // adult: 18 ≤ 25 ≤ 65
+  assert!(age_rule.validate(70).is_err()); // adult: 70 > 65
+  assert!(age_rule.validate(17).is_ok()); // minor: allowed
+  assert!(age_rule.validate(15).is_err()); // minor: not in [16, 17]
 
-    println!(".when_else() combinator: OK");
+  println!(".when_else() combinator: OK");
 
-    // -------------------------------------------------------------------------
-    // Complex composition: username validation
-    // -------------------------------------------------------------------------
-    let username_rule = Rule::<String>::Required
-        .and(Rule::MinLength(3))
-        .and(Rule::MaxLength(30))
-        .and(Rule::pattern(r"^[a-zA-Z][a-zA-Z0-9_\-]*$").unwrap())
-        .and(
-            Rule::OneOf(vec![
-                "admin".to_string(),
-                "root".to_string(),
-            ])
-            .not(),
-        );
+  // -------------------------------------------------------------------------
+  // Complex composition: username validation
+  // -------------------------------------------------------------------------
+  let username_rule = Rule::<String>::Required
+    .and(Rule::MinLength(3))
+    .and(Rule::MaxLength(30))
+    .and(Rule::pattern(r"^[a-zA-Z][a-zA-Z0-9_\-]*$").unwrap())
+    .and(Rule::OneOf(vec!["admin".to_string(), "root".to_string()]).not());
 
-    assert!(username_rule.validate_ref("alice_dev").is_ok());
-    assert!(username_rule.validate_ref("admin").is_err());   // reserved
-    assert!(username_rule.validate_ref("12abc").is_err());   // must start with letter
-    assert!(username_rule.validate_ref("").is_err());        // required
+  assert!(username_rule.validate_ref("alice_dev").is_ok());
+  assert!(username_rule.validate_ref("admin").is_err()); // reserved
+  assert!(username_rule.validate_ref("12abc").is_err()); // must start with letter
+  assert!(username_rule.validate_ref("").is_err()); // required
 
-    println!("Complex composition: OK");
+  println!("Complex composition: OK");
 
-    println!("\nAll composable rules examples passed!");
+  println!("\nAll composable rules examples passed!");
 }

--- a/crates/validation/examples/custom_validators.rs
+++ b/crates/validation/examples/custom_validators.rs
@@ -4,108 +4,108 @@
 //! messages, and locale-aware message providers.
 
 use std::sync::Arc;
-use walrs_validation::{Rule, ValidateRef, Validate, Violation, ViolationType};
+use walrs_validation::{Rule, Validate, ValidateRef, Violation, ViolationType};
 
 fn main() {
-    // -------------------------------------------------------------------------
-    // Rule::Custom — closure-based validation
-    // -------------------------------------------------------------------------
-    let no_spaces_rule = Rule::<String>::custom(Arc::new(|value: &String| {
-        if value.contains(' ') {
-            Err(Violation::new(
-                ViolationType::PatternMismatch,
-                "Value must not contain spaces.",
-            ))
-        } else {
-            Ok(())
-        }
-    }));
+  // -------------------------------------------------------------------------
+  // Rule::Custom — closure-based validation
+  // -------------------------------------------------------------------------
+  let no_spaces_rule = Rule::<String>::custom(Arc::new(|value: &String| {
+    if value.contains(' ') {
+      Err(Violation::new(
+        ViolationType::PatternMismatch,
+        "Value must not contain spaces.",
+      ))
+    } else {
+      Ok(())
+    }
+  }));
 
-    assert!(no_spaces_rule.validate_ref("hello").is_ok());
-    assert!(no_spaces_rule.validate_ref("hello world").is_err());
+  assert!(no_spaces_rule.validate_ref("hello").is_ok());
+  assert!(no_spaces_rule.validate_ref("hello world").is_err());
 
-    println!("Rule::Custom (no spaces): OK");
+  println!("Rule::Custom (no spaces): OK");
 
-    // -------------------------------------------------------------------------
-    // Custom numeric validator
-    // -------------------------------------------------------------------------
-    let even_rule = Rule::<i32>::custom(Arc::new(|&value: &i32| {
-        if value % 2 == 0 {
-            Ok(())
-        } else {
-            Err(Violation::new(
-                ViolationType::StepMismatch,
-                "Value must be even.",
-            ))
-        }
-    }));
+  // -------------------------------------------------------------------------
+  // Custom numeric validator
+  // -------------------------------------------------------------------------
+  let even_rule = Rule::<i32>::custom(Arc::new(|&value: &i32| {
+    if value % 2 == 0 {
+      Ok(())
+    } else {
+      Err(Violation::new(
+        ViolationType::StepMismatch,
+        "Value must be even.",
+      ))
+    }
+  }));
 
-    assert!(even_rule.validate(4).is_ok());
-    assert!(even_rule.validate(3).is_err());
+  assert!(even_rule.validate(4).is_ok());
+  assert!(even_rule.validate(3).is_err());
 
-    println!("Rule::Custom (even numbers): OK");
+  println!("Rule::Custom (even numbers): OK");
 
-    // -------------------------------------------------------------------------
-    // `.with_message()` — override violation message
-    // -------------------------------------------------------------------------
-    let age_rule = Rule::<u32>::Min(18).with_message("You must be at least 18 years old.");
-    let result = age_rule.validate(16);
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().message(),
-        "You must be at least 18 years old."
-    );
+  // -------------------------------------------------------------------------
+  // `.with_message()` — override violation message
+  // -------------------------------------------------------------------------
+  let age_rule = Rule::<u32>::Min(18).with_message("You must be at least 18 years old.");
+  let result = age_rule.validate(16);
+  assert!(result.is_err());
+  assert_eq!(
+    result.unwrap_err().message(),
+    "You must be at least 18 years old."
+  );
 
-    println!(".with_message() override: OK");
+  println!(".with_message() override: OK");
 
-    // -------------------------------------------------------------------------
-    // `.with_message()` on composed rules
-    // -------------------------------------------------------------------------
-    let password_rule = Rule::<String>::MinLength(8)
-        .and(Rule::MaxLength(64))
-        .with_message("Password must be between 8 and 64 characters.");
+  // -------------------------------------------------------------------------
+  // `.with_message()` on composed rules
+  // -------------------------------------------------------------------------
+  let password_rule = Rule::<String>::MinLength(8)
+    .and(Rule::MaxLength(64))
+    .with_message("Password must be between 8 and 64 characters.");
 
-    let result = password_rule.validate_ref("short");
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().message(),
-        "Password must be between 8 and 64 characters."
-    );
+  let result = password_rule.validate_ref("short");
+  assert!(result.is_err());
+  assert_eq!(
+    result.unwrap_err().message(),
+    "Password must be between 8 and 64 characters."
+  );
 
-    println!(".with_message() on composed rules: OK");
+  println!(".with_message() on composed rules: OK");
 
-    // -------------------------------------------------------------------------
-    // `.with_message_provider()` — dynamic message based on value
-    // -------------------------------------------------------------------------
-    let len_rule = Rule::<String>::MinLength(5).with_message_provider(
-        |ctx: &walrs_validation::MessageContext<String>| {
-            format!(
-                "\"{}\" is too short — needs at least 5 characters, got {}.",
-                ctx.value,
-                ctx.value.chars().count()
-            )
-        },
-        None,
-    );
+  // -------------------------------------------------------------------------
+  // `.with_message_provider()` — dynamic message based on value
+  // -------------------------------------------------------------------------
+  let len_rule = Rule::<String>::MinLength(5).with_message_provider(
+    |ctx: &walrs_validation::MessageContext<String>| {
+      format!(
+        "\"{}\" is too short — needs at least 5 characters, got {}.",
+        ctx.value,
+        ctx.value.chars().count()
+      )
+    },
+    None,
+  );
 
-    let result = len_rule.validate_ref("hi");
-    assert!(result.is_err());
-    let msg = result.unwrap_err().message().to_string();
-    assert!(msg.contains("hi"), "message should contain the value");
-    assert!(msg.contains("2"), "message should contain actual length");
+  let result = len_rule.validate_ref("hi");
+  assert!(result.is_err());
+  let msg = result.unwrap_err().message().to_string();
+  assert!(msg.contains("hi"), "message should contain the value");
+  assert!(msg.contains("2"), "message should contain actual length");
 
-    println!(".with_message_provider() dynamic messages: OK");
+  println!(".with_message_provider() dynamic messages: OK");
 
-    // -------------------------------------------------------------------------
-    // `.with_locale()` — associate a locale with a rule
-    // -------------------------------------------------------------------------
-    let localized_rule = Rule::<String>::Required
-        .with_message("Este campo es obligatorio.")
-        .with_locale("es");
+  // -------------------------------------------------------------------------
+  // `.with_locale()` — associate a locale with a rule
+  // -------------------------------------------------------------------------
+  let localized_rule = Rule::<String>::Required
+    .with_message("Este campo es obligatorio.")
+    .with_locale("es");
 
-    assert!(localized_rule.validate_ref("").is_err());
+  assert!(localized_rule.validate_ref("").is_err());
 
-    println!(".with_locale() locale tagging: OK");
+  println!(".with_locale() locale tagging: OK");
 
-    println!("\nAll custom validator examples passed!");
+  println!("\nAll custom validator examples passed!");
 }

--- a/crates/validation/examples/value_validation.rs
+++ b/crates/validation/examples/value_validation.rs
@@ -9,95 +9,103 @@
 use walrs_validation::{Rule, Validate, ValidateRef, Value, value};
 
 fn main() {
-    // -------------------------------------------------------------------------
-    // Required — null / empty values are invalid
-    // -------------------------------------------------------------------------
-    let required = Rule::<Value>::Required;
+  // -------------------------------------------------------------------------
+  // Required — null / empty values are invalid
+  // -------------------------------------------------------------------------
+  let required = Rule::<Value>::Required;
 
-    assert!(required.validate(Value::Str("hello".into())).is_ok());
-    assert!(required.validate(Value::I64(0)).is_ok()); // zero is present
-    assert!(required.validate(Value::Null).is_err());
-    assert!(required.validate(Value::Str(String::new())).is_err()); // empty string
+  assert!(required.validate(Value::Str("hello".into())).is_ok());
+  assert!(required.validate(Value::I64(0)).is_ok()); // zero is present
+  assert!(required.validate(Value::Null).is_err());
+  assert!(required.validate(Value::Str(String::new())).is_err()); // empty string
 
-    println!("Required Value validation: OK");
+  println!("Required Value validation: OK");
 
-    // -------------------------------------------------------------------------
-    // MinLength / MaxLength on string values
-    // -------------------------------------------------------------------------
-    let len_rule = Rule::<Value>::MinLength(3).and(Rule::MaxLength(20));
+  // -------------------------------------------------------------------------
+  // MinLength / MaxLength on string values
+  // -------------------------------------------------------------------------
+  let len_rule = Rule::<Value>::MinLength(3).and(Rule::MaxLength(20));
 
-    assert!(len_rule.validate_ref(&Value::Str("hello".into())).is_ok());
-    assert!(len_rule.validate_ref(&Value::Str("hi".into())).is_err());
-    // Note: MinLength/MaxLength on non-string Values returns a TypeMismatch error
-    assert!(len_rule.validate_ref(&Value::I64(42)).is_err());
+  assert!(len_rule.validate_ref(&Value::Str("hello".into())).is_ok());
+  assert!(len_rule.validate_ref(&Value::Str("hi".into())).is_err());
+  // Note: MinLength/MaxLength on non-string Values returns a TypeMismatch error
+  assert!(len_rule.validate_ref(&Value::I64(42)).is_err());
 
-    println!("Value length validation: OK");
+  println!("Value length validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Min / Max on numeric values
-    // -------------------------------------------------------------------------
-    let range_rule = Rule::<Value>::Min(Value::I64(0)).and(Rule::Max(Value::I64(100)));
+  // -------------------------------------------------------------------------
+  // Min / Max on numeric values
+  // -------------------------------------------------------------------------
+  let range_rule = Rule::<Value>::Min(Value::I64(0)).and(Rule::Max(Value::I64(100)));
 
-    assert!(range_rule.validate(Value::I64(50)).is_ok());
-    assert!(range_rule.validate(Value::I64(-1)).is_err());
-    assert!(range_rule.validate(Value::I64(101)).is_err());
-    // Note: Numeric rules on non-numeric Values return a TypeMismatch error
-    assert!(range_rule.validate(Value::Str("hello".into())).is_err());
+  assert!(range_rule.validate(Value::I64(50)).is_ok());
+  assert!(range_rule.validate(Value::I64(-1)).is_err());
+  assert!(range_rule.validate(Value::I64(101)).is_err());
+  // Note: Numeric rules on non-numeric Values return a TypeMismatch error
+  assert!(range_rule.validate(Value::Str("hello".into())).is_err());
 
-    println!("Value numeric range validation: OK");
+  println!("Value numeric range validation: OK");
 
-    // -------------------------------------------------------------------------
-    // Pattern on string values
-    // -------------------------------------------------------------------------
-    let email_pattern = Rule::<Value>::pattern(r"^[^@\s]+@[^@\s]+\.[^@\s]+$").unwrap();
+  // -------------------------------------------------------------------------
+  // Pattern on string values
+  // -------------------------------------------------------------------------
+  let email_pattern = Rule::<Value>::pattern(r"^[^@\s]+@[^@\s]+\.[^@\s]+$").unwrap();
 
-    assert!(email_pattern.validate(Value::Str("user@example.com".into())).is_ok());
-    assert!(email_pattern.validate(Value::Str("not-an-email".into())).is_err());
+  assert!(
+    email_pattern
+      .validate(Value::Str("user@example.com".into()))
+      .is_ok()
+  );
+  assert!(
+    email_pattern
+      .validate(Value::Str("not-an-email".into()))
+      .is_err()
+  );
 
-    println!("Value pattern validation: OK");
+  println!("Value pattern validation: OK");
 
-    // -------------------------------------------------------------------------
-    // value! macro for convenient Value construction
-    // -------------------------------------------------------------------------
-    let v = value!("hello");
-    assert_eq!(v, Value::Str("hello".into()));
+  // -------------------------------------------------------------------------
+  // value! macro for convenient Value construction
+  // -------------------------------------------------------------------------
+  let v = value!("hello");
+  assert_eq!(v, Value::Str("hello".into()));
 
-    let n = value!(42_i64);
-    assert_eq!(n, Value::I64(42));
+  let n = value!(42_i64);
+  assert_eq!(n, Value::I64(42));
 
-    let b = value!(true);
-    assert_eq!(b, Value::Bool(true));
+  let b = value!(true);
+  assert_eq!(b, Value::Bool(true));
 
-    println!("value! macro: OK");
+  println!("value! macro: OK");
 
-    // -------------------------------------------------------------------------
-    // serde_json bridge — convert from serde_json::Value
-    // -------------------------------------------------------------------------
-    #[cfg(feature = "serde_json_bridge")]
-    {
-        let json_val: serde_json::Value = serde_json::json!("test string");
-        let native_val: Value = json_val.into();
-        assert_eq!(native_val, Value::Str("test string".into()));
+  // -------------------------------------------------------------------------
+  // serde_json bridge — convert from serde_json::Value
+  // -------------------------------------------------------------------------
+  #[cfg(feature = "serde_json_bridge")]
+  {
+    let json_val: serde_json::Value = serde_json::json!("test string");
+    let native_val: Value = json_val.into();
+    assert_eq!(native_val, Value::Str("test string".into()));
 
-        let json_num: serde_json::Value = serde_json::json!(42);
-        let native_num: Value = json_num.into();
-        assert_eq!(native_num, Value::I64(42));
+    let json_num: serde_json::Value = serde_json::json!(42);
+    let native_num: Value = json_num.into();
+    assert_eq!(native_num, Value::I64(42));
 
-        println!("serde_json bridge: OK");
-    }
+    println!("serde_json bridge: OK");
+  }
 
-    // -------------------------------------------------------------------------
-    // Composed rules on Value
-    // -------------------------------------------------------------------------
-    let form_field_rule = Rule::<Value>::Required
-        .and(Rule::MinLength(2))
-        .and(Rule::MaxLength(50));
+  // -------------------------------------------------------------------------
+  // Composed rules on Value
+  // -------------------------------------------------------------------------
+  let form_field_rule = Rule::<Value>::Required
+    .and(Rule::MinLength(2))
+    .and(Rule::MaxLength(50));
 
-    assert!(form_field_rule.validate(Value::Str("Alice".into())).is_ok());
-    assert!(form_field_rule.validate(Value::Null).is_err());
-    assert!(form_field_rule.validate(Value::Str("A".into())).is_err());
+  assert!(form_field_rule.validate(Value::Str("Alice".into())).is_ok());
+  assert!(form_field_rule.validate(Value::Null).is_err());
+  assert!(form_field_rule.validate(Value::Str("A".into())).is_err());
 
-    println!("Composed Value rules: OK");
+  println!("Composed Value rules: OK");
 
-    println!("\nAll value validation examples passed!");
+  println!("\nAll value validation examples passed!");
 }

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -87,10 +87,10 @@
 pub use indexmap;
 
 pub mod attributes;
-pub(crate) mod rule_impls;
 pub mod message;
 pub mod options;
 pub mod rule;
+pub(crate) mod rule_impls;
 pub mod traits;
 pub mod value;
 pub mod violation;

--- a/crates/validation/src/message.rs
+++ b/crates/validation/src/message.rs
@@ -786,7 +786,10 @@ mod tests {
     // Test English (default)
     let params_en = MessageParams::new("Custom");
     let ctx_en = MessageContext::with_locale("test", params_en, None);
-    assert_eq!(msg.resolve_with_context(&ctx_en), "Value 'test' is invalid.");
+    assert_eq!(
+      msg.resolve_with_context(&ctx_en),
+      "Value 'test' is invalid."
+    );
 
     // Test Spanish
     let params_es = MessageParams::new("Custom");
@@ -927,9 +930,10 @@ mod tests {
   #[test]
   fn test_wrap_violations_empty_static_preserves_originals() {
     let msg: Message<str> = Message::Static(String::new());
-    let inner = crate::Violations::new(vec![
-      crate::Violation::new(crate::ViolationType::TooShort, "original short"),
-    ]);
+    let inner = crate::Violations::new(vec![crate::Violation::new(
+      crate::ViolationType::TooShort,
+      "original short",
+    )]);
     let mut target = crate::Violations::default();
     msg.wrap_violations(inner, "value", None, &mut target);
 
@@ -943,9 +947,10 @@ mod tests {
       Some("fr") => format!("Erreur pour '{}'", ctx.value),
       _ => format!("Error for '{}'", ctx.value),
     });
-    let inner = crate::Violations::new(vec![
-      crate::Violation::new(crate::ViolationType::ValueMissing, "missing"),
-    ]);
+    let inner = crate::Violations::new(vec![crate::Violation::new(
+      crate::ViolationType::ValueMissing,
+      "missing",
+    )]);
     let mut target = crate::Violations::default();
     msg.wrap_violations(inner, "test", Some("fr"), &mut target);
 

--- a/crates/validation/src/options.rs
+++ b/crates/validation/src/options.rs
@@ -292,8 +292,10 @@ impl Default for EmailOptions {
 /// ```
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
+#[derive(Default)]
 pub enum DateFormat {
   /// ISO 8601 date: `2026-02-23` or datetime: `2026-02-23T18:00:00`
+  #[default]
   Iso8601,
   /// US-style date: `02/23/2026`
   UsDate,
@@ -305,11 +307,6 @@ pub enum DateFormat {
   Custom(String),
 }
 
-impl Default for DateFormat {
-  fn default() -> Self {
-    Self::Iso8601
-  }
-}
 
 /// Options for date validation (`Rule::Date`).
 ///

--- a/crates/validation/src/options.rs
+++ b/crates/validation/src/options.rs
@@ -307,7 +307,6 @@ pub enum DateFormat {
   Custom(String),
 }
 
-
 /// Options for date validation (`Rule::Date`).
 ///
 /// Controls the expected date format and whether a time component is accepted.

--- a/crates/validation/src/rule.rs
+++ b/crates/validation/src/rule.rs
@@ -37,9 +37,11 @@ use std::sync::Arc;
 #[cfg(feature = "async")]
 use std::pin::Pin;
 
-use crate::{Message, MessageContext, Violation};
-use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, IpOptions, UrlOptions, UriOptions};
+use crate::options::{
+  DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, IpOptions, UriOptions, UrlOptions,
+};
 use crate::traits::IsEmpty;
+use crate::{Message, MessageContext, Violation};
 
 // ============================================================================
 // CompiledPattern — pre-compiled regex wrapper
@@ -74,7 +76,9 @@ impl CompiledPattern {
 
 impl Debug for CompiledPattern {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_tuple("CompiledPattern").field(&self.0.as_str()).finish()
+    f.debug_tuple("CompiledPattern")
+      .field(&self.0.as_str())
+      .finish()
   }
 }
 
@@ -227,7 +231,6 @@ impl Condition<String> {
     }
   }
 }
-
 
 // ============================================================================
 // Rule Enum
@@ -418,7 +421,11 @@ impl<T: Debug> Debug for Rule<T> {
       #[cfg(feature = "async")]
       Self::CustomAsync(_) => write!(f, "CustomAsync(<async fn>)"),
       Self::Ref(name) => f.debug_tuple("Ref").field(name).finish(),
-      Self::WithMessage { rule, message, locale } => f
+      Self::WithMessage {
+        rule,
+        message,
+        locale,
+      } => f
         .debug_struct("WithMessage")
         .field("rule", rule)
         .field("message", message)
@@ -883,7 +890,6 @@ impl<T> Rule<T> {
 
 // Rule<Numeric> implementation moved to rule_impls/steppable.rs
 
-
 // Trait implementations moved to rule_impls modules
 
 // ToAttributesList implementation moved to rule_impls/attributes.rs
@@ -1064,8 +1070,8 @@ mod tests {
 
   #[test]
   fn test_rule_with_message_provider() {
-    let rule =
-      Rule::<i32>::Min(0).with_message_provider(|ctx| format!("Got {}, expected >= 0.", ctx.value), None);
+    let rule = Rule::<i32>::Min(0)
+      .with_message_provider(|ctx| format!("Got {}, expected >= 0.", ctx.value), None);
 
     match rule {
       Rule::WithMessage {
@@ -1143,7 +1149,10 @@ mod tests {
   fn test_e2e_only_rule_and_validators() {
     let slug = Rule::<String>::pattern(r"(?i)^[\w\-]{1,108}$").unwrap();
     let screen_name = Rule::<String>::pattern(r"(?i)^[a-z][\w\-]{7,55}$").unwrap();
-    let numeric_id = Rule::<usize>::Range { min: 1, max: usize::MAX };
+    let numeric_id = Rule::<usize>::Range {
+      min: 1,
+      max: usize::MAX,
+    };
 
     assert!(slug.validate_ref("hello-world").is_ok());
     assert!(slug.validate_ref("").is_err());

--- a/crates/validation/src/rule_impls/attributes.rs
+++ b/crates/validation/src/rule_impls/attributes.rs
@@ -150,8 +150,8 @@ impl<T: Serialize> ToAttributesList for Rule<T> {
 
 #[cfg(test)]
 mod tests {
-  use crate::rule::{Condition, Rule};
   use crate::message::Message;
+  use crate::rule::{Condition, Rule};
   use crate::traits::ToAttributesList;
 
   #[test]
@@ -348,4 +348,3 @@ mod tests {
     assert_eq!(attrs[0].1, serde_json::Value::from(0.1));
   }
 }
-

--- a/crates/validation/src/rule_impls/length.rs
+++ b/crates/validation/src/rule_impls/length.rs
@@ -1,6 +1,6 @@
+use crate::Violation;
 use crate::rule::{Rule, RuleResult};
 use crate::traits::WithLength;
-use crate::Violation;
 
 impl<T: WithLength> Rule<T> {
   /// Validates a collection's length against this rule.
@@ -170,10 +170,10 @@ impl<T: WithLength> Rule<T> {
             any_passed = true;
             break;
           }
-          any_violations.extend(rule_violations.into_iter());
+          any_violations.extend(rule_violations);
         }
         if !any_passed && !rules.is_empty() {
-          violations.extend(any_violations.into_iter());
+          violations.extend(any_violations);
         }
       }
       Rule::When {
@@ -424,8 +424,7 @@ mod tests {
 
   #[test]
   fn test_validate_len_with_message_static() {
-    let rule = Rule::<Vec<i32>>::MinLength(3)
-      .with_message("Too few items");
+    let rule = Rule::<Vec<i32>>::MinLength(3).with_message("Too few items");
 
     let result = rule.validate_len(&vec![1]);
     assert!(result.is_err());
@@ -437,15 +436,17 @@ mod tests {
 
   #[test]
   fn test_validate_len_with_message_provider_and_locale() {
-    let rule = Rule::<Vec<i32>>::MinLength(2)
-      .with_message_provider(
-        |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
-          Some("es") => format!("Se requieren al menos 2 elementos, recibidos: {}", ctx.value.len()),
-          Some("fr") => format!("Au moins 2 éléments requis, reçu : {}", ctx.value.len()),
-          _ => format!("At least 2 items required, got: {}", ctx.value.len()),
-        },
-        Some("es"),
-      );
+    let rule = Rule::<Vec<i32>>::MinLength(2).with_message_provider(
+      |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
+        Some("es") => format!(
+          "Se requieren al menos 2 elementos, recibidos: {}",
+          ctx.value.len()
+        ),
+        Some("fr") => format!("Au moins 2 éléments requis, reçu : {}", ctx.value.len()),
+        _ => format!("At least 2 items required, got: {}", ctx.value.len()),
+      },
+      Some("es"),
+    );
 
     let result = rule.validate_len(&vec![1]);
     assert!(result.is_err());
@@ -457,14 +458,13 @@ mod tests {
 
   #[test]
   fn test_validate_len_with_message_provider_default_locale() {
-    let rule = Rule::<Vec<i32>>::MinLength(2)
-      .with_message_provider(
-        |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
-          Some("es") => "Muy pocos".to_string(),
-          _ => format!("Need at least 2, got {}", ctx.value.len()),
-        },
-        None,
-      );
+    let rule = Rule::<Vec<i32>>::MinLength(2).with_message_provider(
+      |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
+        Some("es") => "Muy pocos".to_string(),
+        _ => format!("Need at least 2, got {}", ctx.value.len()),
+      },
+      None,
+    );
 
     // No locale set → default arm
     let result = rule.validate_len(&vec![1]);
@@ -500,30 +500,25 @@ mod tests {
   #[test]
   fn test_validate_len_nested_with_message_locale_inheritance() {
     // Inner WithMessage has a locale-aware provider, outer sets the locale
-    let inner = Rule::<Vec<i32>>::MinLength(2)
-      .with_message_provider(
-        |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
-          Some("fr") => format!("Besoin d'au moins 2, reçu {}", ctx.value.len()),
-          _ => format!("Need at least 2, got {}", ctx.value.len()),
-        },
-        None,
-      );
+    let inner = Rule::<Vec<i32>>::MinLength(2).with_message_provider(
+      |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
+        Some("fr") => format!("Besoin d'au moins 2, reçu {}", ctx.value.len()),
+        _ => format!("Need at least 2, got {}", ctx.value.len()),
+      },
+      None,
+    );
 
     let outer = inner.with_locale("fr".to_string());
 
     let result = outer.validate_len(&vec![1]);
     assert!(result.is_err());
-    assert_eq!(
-      result.unwrap_err().message(),
-      "Besoin d'au moins 2, reçu 1"
-    );
+    assert_eq!(result.unwrap_err().message(), "Besoin d'au moins 2, reçu 1");
   }
 
   #[test]
   fn test_validate_len_with_message_empty_static_uses_default() {
     // Empty static message should fall back to the default violation message
-    let rule = Rule::<Vec<i32>>::MinLength(3)
-      .with_locale("en".to_string());
+    let rule = Rule::<Vec<i32>>::MinLength(3).with_locale("en".to_string());
 
     let result = rule.validate_len(&vec![1]);
     assert!(result.is_err());

--- a/crates/validation/src/rule_impls/mod.rs
+++ b/crates/validation/src/rule_impls/mod.rs
@@ -5,8 +5,7 @@ pub(crate) mod date_chrono;
 #[cfg(feature = "jiff")]
 pub(crate) mod date_jiff;
 pub(crate) mod length;
+pub(crate) mod scalar;
 pub(crate) mod steppable;
 pub(crate) mod string;
-pub(crate) mod scalar;
 pub(crate) mod value;
-

--- a/crates/validation/src/rule_impls/scalar.rs
+++ b/crates/validation/src/rule_impls/scalar.rs
@@ -872,6 +872,212 @@ mod tests {
   }
 
   // ==========================================================================
+  // NaN Validation Tests — Step, Equals, OneOf (scalar path)
+  // ==========================================================================
+
+  #[test]
+  fn test_validate_scalar_nan_f64_step() {
+    let rule = Rule::<f64>::Step(5.0);
+    // Step is a pass-through in scalar validation
+    assert!(rule.validate_scalar(f64::NAN).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_nan_f32_step() {
+    let rule = Rule::<f32>::Step(5.0);
+    assert!(rule.validate_scalar(f32::NAN).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_nan_f64_equals() {
+    let rule = Rule::<f64>::Equals(42.0);
+    assert!(rule.validate_scalar(f64::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_nan_f32_equals() {
+    let rule = Rule::<f32>::Equals(42.0);
+    assert!(rule.validate_scalar(f32::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_nan_f64_one_of() {
+    let rule = Rule::<f64>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_scalar(f64::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_nan_f32_one_of() {
+    let rule = Rule::<f32>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_scalar(f32::NAN).is_err());
+  }
+
+  // ==========================================================================
+  // INFINITY Validation Tests (scalar path)
+  // ==========================================================================
+
+  #[test]
+  fn test_validate_scalar_inf_f64_min() {
+    let rule = Rule::<f64>::Min(0.0);
+    assert!(rule.validate_scalar(f64::INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f64_max() {
+    let rule = Rule::<f64>::Max(100.0);
+    assert!(rule.validate_scalar(f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f64_range() {
+    let rule = Rule::<f64>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_scalar(f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f64_step() {
+    let rule = Rule::<f64>::Step(5.0);
+    // Step is a pass-through in scalar validation
+    assert!(rule.validate_scalar(f64::INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f64_equals() {
+    let rule = Rule::<f64>::Equals(42.0);
+    assert!(rule.validate_scalar(f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f64_one_of() {
+    let rule = Rule::<f64>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_scalar(f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f32_min() {
+    let rule = Rule::<f32>::Min(0.0);
+    assert!(rule.validate_scalar(f32::INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f32_max() {
+    let rule = Rule::<f32>::Max(100.0);
+    assert!(rule.validate_scalar(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f32_range() {
+    let rule = Rule::<f32>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_scalar(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f32_step() {
+    let rule = Rule::<f32>::Step(5.0);
+    assert!(rule.validate_scalar(f32::INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f32_equals() {
+    let rule = Rule::<f32>::Equals(42.0);
+    assert!(rule.validate_scalar(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_inf_f32_one_of() {
+    let rule = Rule::<f32>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_scalar(f32::INFINITY).is_err());
+  }
+
+  // ==========================================================================
+  // NEG_INFINITY Validation Tests (scalar path)
+  // ==========================================================================
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f64_min() {
+    let rule = Rule::<f64>::Min(0.0);
+    assert!(rule.validate_scalar(f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f64_max() {
+    let rule = Rule::<f64>::Max(100.0);
+    assert!(rule.validate_scalar(f64::NEG_INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f64_range() {
+    let rule = Rule::<f64>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_scalar(f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f64_step() {
+    let rule = Rule::<f64>::Step(5.0);
+    assert!(rule.validate_scalar(f64::NEG_INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f64_equals() {
+    let rule = Rule::<f64>::Equals(42.0);
+    assert!(rule.validate_scalar(f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f64_one_of() {
+    let rule = Rule::<f64>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_scalar(f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f32_min() {
+    let rule = Rule::<f32>::Min(0.0);
+    assert!(rule.validate_scalar(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f32_max() {
+    let rule = Rule::<f32>::Max(100.0);
+    assert!(rule.validate_scalar(f32::NEG_INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f32_range() {
+    let rule = Rule::<f32>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_scalar(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f32_step() {
+    let rule = Rule::<f32>::Step(5.0);
+    assert!(rule.validate_scalar(f32::NEG_INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f32_equals() {
+    let rule = Rule::<f32>::Equals(42.0);
+    assert!(rule.validate_scalar(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_neg_inf_f32_one_of() {
+    let rule = Rule::<f32>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_scalar(f32::NEG_INFINITY).is_err());
+  }
+
+  // ==========================================================================
   // Async tests for bool / char
   // ==========================================================================
 

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -718,6 +718,255 @@ mod tests {
     assert!(rule.validate_ref(&Some(-0.1)).is_err());
   }
 
+  // ========================================================================
+  // NaN Validation Tests — Step, Equals, OneOf (f32 / f64)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_nan_f64_step() {
+    let rule = Rule::<f64>::Step(5.0);
+    assert!(rule.validate_step(f64::NAN).is_err());
+    assert!(rule.validate(f64::NAN).is_err());
+    assert!(rule.validate_ref(&f64::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_nan_f32_step() {
+    let rule = Rule::<f32>::Step(5.0);
+    assert!(rule.validate_step(f32::NAN).is_err());
+    assert!(rule.validate(f32::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_nan_f64_equals() {
+    let rule = Rule::<f64>::Equals(42.0);
+    assert!(rule.validate_step(f64::NAN).is_err());
+    assert!(rule.validate(f64::NAN).is_err());
+    assert!(rule.validate_ref(&f64::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_nan_f32_equals() {
+    let rule = Rule::<f32>::Equals(42.0);
+    assert!(rule.validate_step(f32::NAN).is_err());
+    assert!(rule.validate(f32::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_nan_f64_one_of() {
+    let rule = Rule::<f64>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_step(f64::NAN).is_err());
+    assert!(rule.validate(f64::NAN).is_err());
+    assert!(rule.validate_ref(&f64::NAN).is_err());
+  }
+
+  #[test]
+  fn test_validate_nan_f32_one_of() {
+    let rule = Rule::<f32>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_step(f32::NAN).is_err());
+    assert!(rule.validate(f32::NAN).is_err());
+  }
+
+  // ========================================================================
+  // INFINITY Validation Tests (f32 / f64)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_inf_f64_min() {
+    let rule = Rule::<f64>::Min(0.0);
+    assert!(rule.validate_step(f64::INFINITY).is_ok());
+    assert!(rule.validate(f64::INFINITY).is_ok());
+    assert!(rule.validate_ref(&f64::INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_inf_f64_max() {
+    let rule = Rule::<f64>::Max(100.0);
+    assert!(rule.validate_step(f64::INFINITY).is_err());
+    assert!(rule.validate(f64::INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f64_range() {
+    let rule = Rule::<f64>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_step(f64::INFINITY).is_err());
+    assert!(rule.validate(f64::INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f64_step() {
+    let rule = Rule::<f64>::Step(5.0);
+    assert!(rule.validate_step(f64::INFINITY).is_err());
+    assert!(rule.validate(f64::INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f64_equals() {
+    let rule = Rule::<f64>::Equals(42.0);
+    assert!(rule.validate_step(f64::INFINITY).is_err());
+    assert!(rule.validate(f64::INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f64_one_of() {
+    let rule = Rule::<f64>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_step(f64::INFINITY).is_err());
+    assert!(rule.validate(f64::INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f32_min() {
+    let rule = Rule::<f32>::Min(0.0);
+    assert!(rule.validate_step(f32::INFINITY).is_ok());
+    assert!(rule.validate(f32::INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_inf_f32_max() {
+    let rule = Rule::<f32>::Max(100.0);
+    assert!(rule.validate_step(f32::INFINITY).is_err());
+    assert!(rule.validate(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f32_range() {
+    let rule = Rule::<f32>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_step(f32::INFINITY).is_err());
+    assert!(rule.validate(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f32_step() {
+    let rule = Rule::<f32>::Step(5.0);
+    assert!(rule.validate_step(f32::INFINITY).is_err());
+    assert!(rule.validate(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f32_equals() {
+    let rule = Rule::<f32>::Equals(42.0);
+    assert!(rule.validate_step(f32::INFINITY).is_err());
+    assert!(rule.validate(f32::INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_inf_f32_one_of() {
+    let rule = Rule::<f32>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_step(f32::INFINITY).is_err());
+    assert!(rule.validate(f32::INFINITY).is_err());
+  }
+
+  // ========================================================================
+  // NEG_INFINITY Validation Tests (f32 / f64)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_neg_inf_f64_min() {
+    let rule = Rule::<f64>::Min(0.0);
+    assert!(rule.validate_step(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f64_max() {
+    let rule = Rule::<f64>::Max(100.0);
+    assert!(rule.validate_step(f64::NEG_INFINITY).is_ok());
+    assert!(rule.validate(f64::NEG_INFINITY).is_ok());
+    assert!(rule.validate_ref(&f64::NEG_INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f64_range() {
+    let rule = Rule::<f64>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_step(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f64_step() {
+    let rule = Rule::<f64>::Step(5.0);
+    assert!(rule.validate_step(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f64_equals() {
+    let rule = Rule::<f64>::Equals(42.0);
+    assert!(rule.validate_step(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f64_one_of() {
+    let rule = Rule::<f64>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_step(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate(f64::NEG_INFINITY).is_err());
+    assert!(rule.validate_ref(&f64::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f32_min() {
+    let rule = Rule::<f32>::Min(0.0);
+    assert!(rule.validate_step(f32::NEG_INFINITY).is_err());
+    assert!(rule.validate(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f32_max() {
+    let rule = Rule::<f32>::Max(100.0);
+    assert!(rule.validate_step(f32::NEG_INFINITY).is_ok());
+    assert!(rule.validate(f32::NEG_INFINITY).is_ok());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f32_range() {
+    let rule = Rule::<f32>::Range {
+      min: 0.0,
+      max: 100.0,
+    };
+    assert!(rule.validate_step(f32::NEG_INFINITY).is_err());
+    assert!(rule.validate(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f32_step() {
+    let rule = Rule::<f32>::Step(5.0);
+    assert!(rule.validate_step(f32::NEG_INFINITY).is_err());
+    assert!(rule.validate(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f32_equals() {
+    let rule = Rule::<f32>::Equals(42.0);
+    assert!(rule.validate_step(f32::NEG_INFINITY).is_err());
+    assert!(rule.validate(f32::NEG_INFINITY).is_err());
+  }
+
+  #[test]
+  fn test_validate_neg_inf_f32_one_of() {
+    let rule = Rule::<f32>::OneOf(vec![1.0, 2.0, 3.0]);
+    assert!(rule.validate_step(f32::NEG_INFINITY).is_err());
+    assert!(rule.validate(f32::NEG_INFINITY).is_err());
+  }
+
   #[cfg(feature = "async")]
   mod async_option_tests {
     use crate::rule::Rule;

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -1,7 +1,9 @@
-use crate::rule::{Rule, RuleResult};
 use crate::Violation;
+use crate::options::{
+  DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, IpOptions, UriOptions, UrlOptions,
+};
+use crate::rule::{Rule, RuleResult};
 use crate::traits::{Validate, ValidateRef};
-use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, UriOptions, UrlOptions, IpOptions};
 
 // ============================================================================
 // URI / IP Validation Helpers
@@ -33,7 +35,8 @@ fn validate_uri(value: &str, opts: &UriOptions) -> RuleResult {
       if opts.allow_relative && !value.is_empty() {
         // Validate as a relative reference using a fixed base URL.
         // This ensures syntactically invalid relative URIs are rejected.
-        let base = url::Url::parse("http://example.com/").expect("hard-coded base URL must be valid");
+        let base =
+          url::Url::parse("http://example.com/").expect("hard-coded base URL must be valid");
         match url::Url::options().base_url(Some(&base)).parse(value) {
           Ok(_) => Ok(()),
           Err(_) => Err(Violation::invalid_uri()),
@@ -80,14 +83,14 @@ fn validate_ip(value: &str, opts: &IpOptions) -> RuleResult {
 
   // Try IPv4
   if opts.allow_ipv4 {
-    if let Ok(_) = inner.parse::<std::net::Ipv4Addr>() {
+    if inner.parse::<std::net::Ipv4Addr>().is_ok() {
       return Ok(());
     }
   }
 
   // Try IPv6
   if opts.allow_ipv6 {
-    if let Ok(_) = inner.parse::<std::net::Ipv6Addr>() {
+    if inner.parse::<std::net::Ipv6Addr>().is_ok() {
       return Ok(());
     }
   }
@@ -121,10 +124,9 @@ fn is_ipvfuture(s: &str) -> bool {
   if dot_pos + 1 >= bytes.len() {
     return false;
   }
-  bytes[dot_pos + 1..].iter().all(|&b| {
-    b.is_ascii_alphanumeric()
-      || b"-._~!$&'()*+,;=:".contains(&b)
-  })
+  bytes[dot_pos + 1..]
+    .iter()
+    .all(|&b| b.is_ascii_alphanumeric() || b"-._~!$&'()*+,;=:".contains(&b))
 }
 
 // ============================================================================
@@ -178,7 +180,9 @@ fn is_valid_dns_label(label: &str) -> bool {
     return false;
   }
   // Interior characters: alphanumeric or hyphen
-  bytes.iter().all(|&b| b.is_ascii_alphanumeric() || b == b'-')
+  bytes
+    .iter()
+    .all(|&b| b.is_ascii_alphanumeric() || b == b'-')
 }
 
 /// Validates a hostname string according to the given options.
@@ -259,8 +263,7 @@ fn validate_hostname(value: &str, opts: &HostnameOptions) -> RuleResult {
 
 /// Characters allowed in the local part of an email address (RFC 5321/5322 simplified).
 fn is_valid_local_char(b: u8) -> bool {
-  b.is_ascii_alphanumeric()
-    || b"!#$%&'*+/=?^_`{|}~-.".contains(&b)
+  b.is_ascii_alphanumeric() || b"!#$%&'*+/=?^_`{|}~-.".contains(&b)
 }
 
 /// Validates an email address string according to the given options.
@@ -312,8 +315,7 @@ fn validate_email(value: &str, opts: &EmailOptions) -> RuleResult {
       allow_local: opts.allow_local,
       require_public_ipv4: false,
     };
-    validate_hostname(domain, &hostname_opts)
-      .map_err(|_| Violation::invalid_email())?;
+    validate_hostname(domain, &hostname_opts).map_err(|_| Violation::invalid_email())?;
   }
 
   Ok(())
@@ -427,12 +429,12 @@ impl Rule<String> {
         }
       }
       Rule::Pattern(cp) => {
-          if cp.0.is_match(value) {
-            Ok(())
-          } else {
-            Err(Violation::pattern_mismatch(cp.as_str()))
-          }
-      },
+        if cp.0.is_match(value) {
+          Ok(())
+        } else {
+          Err(Violation::pattern_mismatch(cp.as_str()))
+        }
+      }
       Rule::Email(opts) => validate_email(value, opts),
       Rule::Url(opts) => validate_url(value, opts),
       Rule::Uri(opts) => validate_uri(value, opts),
@@ -496,10 +498,14 @@ impl Rule<String> {
       #[cfg(feature = "async")]
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
-      Rule::WithMessage { rule, message, locale } => {
+      Rule::WithMessage {
+        rule,
+        message,
+        locale,
+      } => {
         let eff = locale.as_deref().or(inherited_locale);
         message.wrap_result(rule.validate_str_inner(value, eff), &value.to_string(), eff)
-      },
+      }
       // Numeric rules don't apply to strings - pass through
       Rule::Min(_) | Rule::Max(_) | Rule::Range { .. } | Rule::Step(_) => Ok(()),
     }
@@ -508,10 +514,7 @@ impl Rule<String> {
   /// Validates a string value and collects all violations.
   ///
   /// Returns `Ok(())` if validation passes, or `Err(Violations)` with all failures.
-  pub(crate) fn validate_str_all(
-    &self,
-    value: &str,
-  ) -> Result<(), crate::Violations> {
+  pub(crate) fn validate_str_all(&self, value: &str) -> Result<(), crate::Violations> {
     let mut violations = crate::Violations::default();
     self.collect_violations_str(value, None, &mut violations);
     if violations.is_empty() {
@@ -568,10 +571,10 @@ impl Rule<String> {
             any_passed = true;
             break;
           }
-          any_violations.extend(rule_violations.into_iter());
+          any_violations.extend(rule_violations);
         }
         if !any_passed && !rules.is_empty() {
-          violations.extend(any_violations.into_iter());
+          violations.extend(any_violations);
         }
       }
       Rule::When {
@@ -586,7 +589,11 @@ impl Rule<String> {
           rule.collect_violations_str(value, inherited_locale, violations);
         }
       }
-      Rule::WithMessage { rule, message, locale } => {
+      Rule::WithMessage {
+        rule,
+        message,
+        locale,
+      } => {
         let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = crate::Violations::default();
         rule.collect_violations_str(value, eff, &mut inner_violations);
@@ -653,7 +660,9 @@ impl Rule<String> {
 
         Rule::All(rules) => {
           for rule in rules {
-            rule.validate_str_async_inner(value, inherited_locale).await?;
+            rule
+              .validate_str_async_inner(value, inherited_locale)
+              .await?;
           }
           Ok(())
         }
@@ -671,7 +680,10 @@ impl Rule<String> {
           Err(last_err.unwrap())
         }
         Rule::Not(inner) => {
-          match inner.validate_str_async_inner(value, inherited_locale).await {
+          match inner
+            .validate_str_async_inner(value, inherited_locale)
+            .await
+          {
             Ok(()) => Err(Violation::negation_failed()),
             Err(_) => Ok(()),
           }
@@ -682,7 +694,9 @@ impl Rule<String> {
           else_rule,
         } => {
           if condition.evaluate_str(value) {
-            then_rule.validate_str_async_inner(value, inherited_locale).await
+            then_rule
+              .validate_str_async_inner(value, inherited_locale)
+              .await
           } else {
             match else_rule {
               Some(rule) => rule.validate_str_async_inner(value, inherited_locale).await,
@@ -690,9 +704,17 @@ impl Rule<String> {
             }
           }
         }
-        Rule::WithMessage { rule, message, locale } => {
+        Rule::WithMessage {
+          rule,
+          message,
+          locale,
+        } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(rule.validate_str_async_inner(value, eff).await, &value.to_string(), eff)
+          message.wrap_result(
+            rule.validate_str_async_inner(value, eff).await,
+            &value.to_string(),
+            eff,
+          )
         }
 
         // All sync rules — delegate to sync validation
@@ -763,7 +785,9 @@ mod tests {
   fn validate_option_string_some_delegates_to_string_validation() {
     let rule = Rule::<String>::Email(EmailOptions::default());
 
-    assert!(Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok());
+    assert!(
+      Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok()
+    );
     assert!(Validate::<Option<String>>::validate(&rule, Some("not-an-email".to_owned())).is_err());
   }
 
@@ -970,15 +994,19 @@ mod tests {
   fn test_validate_str_url_compiled() {
     let rule = Rule::<String>::Url(crate::UrlOptions::default());
     assert!(rule.validate_str("http://example.com").is_ok());
-    assert!(rule.validate_str("https://example.com/path?q=1#frag").is_ok());
+    assert!(
+      rule
+        .validate_str("https://example.com/path?q=1#frag")
+        .is_ok()
+    );
     assert!(rule.validate_str("not-a-url").is_err());
     assert!(rule.validate_str("ftp://example.com").is_err());
   }
 
   #[test]
   fn test_validate_str_url_with_message() {
-    let rule = Rule::<String>::Url(crate::UrlOptions::default())
-      .with_message("Please enter a valid URL");
+    let rule =
+      Rule::<String>::Url(crate::UrlOptions::default()).with_message("Please enter a valid URL");
     let err = rule.validate_str("bad").unwrap_err();
     assert_eq!(err.message(), "Please enter a valid URL");
   }
@@ -1359,8 +1387,11 @@ mod tests {
 
   #[test]
   fn test_validate_ip_all_violations() {
-    let rule = Rule::<String>::Required
-      .and(Rule::Ip(crate::IpOptions { allow_ipv4: true, allow_ipv6: false, ..Default::default() }));
+    let rule = Rule::<String>::Required.and(Rule::Ip(crate::IpOptions {
+      allow_ipv4: true,
+      allow_ipv6: false,
+      ..Default::default()
+    }));
 
     assert!(rule.validate_str_all("192.168.1.1").is_ok());
 
@@ -1536,15 +1567,24 @@ mod tests {
     assert!(rule.validate_str(&format!("{}.com", long_label)).is_ok());
     // Label with 64 chars - too long
     let too_long_label = "a".repeat(64);
-    assert!(rule.validate_str(&format!("{}.com", too_long_label)).is_err());
+    assert!(
+      rule
+        .validate_str(&format!("{}.com", too_long_label))
+        .is_err()
+    );
   }
 
   #[test]
   fn test_validate_hostname_total_length() {
     let rule = Rule::<String>::Hostname(crate::HostnameOptions::default());
     // Total length > 253 should fail
-    let long_hostname = format!("{}.{}.{}.{}.com",
-      "a".repeat(63), "b".repeat(63), "c".repeat(63), "d".repeat(63));
+    let long_hostname = format!(
+      "{}.{}.{}.{}.com",
+      "a".repeat(63),
+      "b".repeat(63),
+      "c".repeat(63),
+      "d".repeat(63)
+    );
     assert!(long_hostname.len() > 253);
     assert!(rule.validate_str(&long_hostname).is_err());
   }
@@ -1577,8 +1617,10 @@ mod tests {
 
   #[test]
   fn test_validate_hostname_all_violations() {
-    let rule = Rule::<String>::Required
-      .and(Rule::Hostname(crate::HostnameOptions { allow_ip: false, ..Default::default() }));
+    let rule = Rule::<String>::Required.and(Rule::Hostname(crate::HostnameOptions {
+      allow_ip: false,
+      ..Default::default()
+    }));
     assert!(rule.validate_str_all("example.com").is_ok());
     let result = rule.validate_str_all("192.168.1.1");
     assert!(result.is_err());
@@ -1604,4 +1646,3 @@ mod tests {
     assert_eq!(rule, Rule::Hostname(opts));
   }
 }
-

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -82,18 +82,16 @@ fn validate_ip(value: &str, opts: &IpOptions) -> RuleResult {
   }
 
   // Try IPv4
-  if opts.allow_ipv4 {
-    if inner.parse::<std::net::Ipv4Addr>().is_ok() {
+  if opts.allow_ipv4
+    && inner.parse::<std::net::Ipv4Addr>().is_ok() {
       return Ok(());
     }
-  }
 
   // Try IPv6
-  if opts.allow_ipv6 {
-    if inner.parse::<std::net::Ipv6Addr>().is_ok() {
+  if opts.allow_ipv6
+    && inner.parse::<std::net::Ipv6Addr>().is_ok() {
       return Ok(());
     }
-  }
 
   Err(Violation::invalid_ip())
 }

--- a/crates/validation/src/traits.rs
+++ b/crates/validation/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{Violation};
+use crate::Violation;
 use indexmap::{IndexMap, IndexSet};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 
@@ -113,19 +113,27 @@ pub trait IsEmpty {
 }
 
 impl IsEmpty for String {
-  fn is_empty(&self) -> bool { self.trim().is_empty() }
+  fn is_empty(&self) -> bool {
+    self.trim().is_empty()
+  }
 }
 
 impl IsEmpty for str {
-  fn is_empty(&self) -> bool { self.trim().is_empty() }
+  fn is_empty(&self) -> bool {
+    self.trim().is_empty()
+  }
 }
 
 impl IsEmpty for &str {
-  fn is_empty(&self) -> bool { self.trim().is_empty() }
+  fn is_empty(&self) -> bool {
+    self.trim().is_empty()
+  }
 }
 
 impl<T> IsEmpty for Vec<T> {
-  fn is_empty(&self) -> bool { self.is_empty() }
+  fn is_empty(&self) -> bool {
+    self.is_empty()
+  }
 }
 
 /// Implements [`IsEmpty`] for collection types that provide `.is_empty()`.
@@ -148,7 +156,9 @@ impl_is_empty_collection!(IndexMap<K, V, S>, K, V, S);
 impl_is_empty_collection!(IndexSet<T, S>, T, S);
 
 impl<T> IsEmpty for Option<T> {
-  fn is_empty(&self) -> bool { self.is_none() }
+  fn is_empty(&self) -> bool {
+    self.is_none()
+  }
 }
 
 impl IsEmpty for crate::Value {
@@ -166,9 +176,7 @@ macro_rules! impl_is_empty_never {
 }
 
 impl_is_empty_never!(
-  i8, i16, i32, i64, i128, isize,
-  u8, u16, u32, u64, u128, usize,
-  f32, f64, bool, char
+  i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64, bool, char
 );
 
 // ============================================================================
@@ -187,7 +195,9 @@ pub trait WithLength {
 macro_rules! impl_with_length_chars {
   ($type_:ty) => {
     impl WithLength for $type_ {
-      fn length(&self) -> usize { self.chars().count() }
+      fn length(&self) -> usize {
+        self.chars().count()
+      }
     }
   };
 }
@@ -237,7 +247,10 @@ pub trait ValidateAsync<T: Send> {
 /// rules (e.g., `Rule::CustomAsync`) are awaited.
 #[cfg(feature = "async")]
 pub trait ValidateRefAsync<T: ?Sized + Sync> {
-  fn validate_ref_async(&self, value: &T) -> impl std::future::Future<Output = ValidatorResult> + Send;
+  fn validate_ref_async(
+    &self,
+    value: &T,
+  ) -> impl std::future::Future<Output = ValidatorResult> + Send;
 }
 
 // ============================================================================
@@ -449,4 +462,3 @@ mod tests {
     assert!(!2.0_f32.rem_check(0.0));
   }
 }
-

--- a/crates/validation/src/value.rs
+++ b/crates/validation/src/value.rs
@@ -283,9 +283,7 @@ impl From<serde_json::Value> for Value {
         }
       }
       serde_json::Value::String(s) => Value::Str(s),
-      serde_json::Value::Array(arr) => {
-        Value::Array(arr.into_iter().map(Value::from).collect())
-      }
+      serde_json::Value::Array(arr) => Value::Array(arr.into_iter().map(Value::from).collect()),
       serde_json::Value::Object(map) => {
         Value::Object(map.into_iter().map(|(k, v)| (k, Value::from(v))).collect())
       }
@@ -558,10 +556,7 @@ mod tests {
       obj.as_object().unwrap().get("name"),
       Some(&Value::Str("test".to_string()))
     );
-    assert_eq!(
-      obj.as_object().unwrap().get("age"),
-      Some(&Value::I64(42))
-    );
+    assert_eq!(obj.as_object().unwrap().get("age"), Some(&Value::I64(42)));
   }
 
   #[cfg(feature = "serde_json_bridge")]

--- a/crates/validation/src/violation.rs
+++ b/crates/validation/src/violation.rs
@@ -58,7 +58,10 @@ impl Violation {
   pub fn too_short(min: usize, actual: usize) -> Self {
     Self::new(
       ViolationType::TooShort,
-      format!("Value length must be at least {};  Received {}.", min, actual),
+      format!(
+        "Value length must be at least {};  Received {}.",
+        min, actual
+      ),
     )
   }
 
@@ -74,7 +77,10 @@ impl Violation {
   pub fn exact_length(expected: usize, actual: usize) -> Self {
     Self::new(
       ViolationType::TooShort,
-      format!("Value length must be exactly {} (got {}).", expected, actual),
+      format!(
+        "Value length must be exactly {} (got {}).",
+        expected, actual
+      ),
     )
   }
 
@@ -166,7 +172,10 @@ impl Violation {
 
   /// Value is not one of the allowed values.
   pub fn not_one_of() -> Self {
-    Self::new(ViolationType::NotEqual, "Value must be one of the allowed values.")
+    Self::new(
+      ViolationType::NotEqual,
+      "Value must be one of the allowed values.",
+    )
   }
 
   /// A named rule reference could not be resolved.
@@ -179,7 +188,10 @@ impl Violation {
 
   /// The negated rule unexpectedly passed.
   pub fn negation_failed() -> Self {
-    Self::new(ViolationType::CustomError, "Value must not satisfy the negated rule.")
+    Self::new(
+      ViolationType::CustomError,
+      "Value must not satisfy the negated rule.",
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #144.

### NaN tests for missing rules
- `Step`, `Equals`, `OneOf` rules with `f32::NAN` / `f64::NAN` in both **steppable.rs** and **scalar.rs**
- Verifies all return `Err` (except scalar `Step` which is a pass-through → `Ok`)

### INFINITY / NEG_INFINITY tests
- All 6 rules (`Min`, `Max`, `Range`, `Step`, `Equals`, `OneOf`) tested with `f32`/`f64` infinity variants
- Verified actual behavior and locked down with assertions:
  - `Min(0.0)`: INFINITY passes, NEG_INFINITY fails
  - `Max(100.0)`: INFINITY fails, NEG_INFINITY passes
  - `Range`: INFINITY/NEG_INFINITY both fail
  - `Step`: steppable returns Err (NaN remainder), scalar passes through
  - `Equals`/`OneOf`: INFINITY/NEG_INFINITY both fail

**60 new assertion-based tests** added across steppable.rs and scalar.rs. All tests passing.