### PR TITLE
test(walrs_validation): #143 #145 Add Rule::Ref and deeply nested combinator tests

### DIFF
--- a/crates/validation/src/rule_impls/length.rs
+++ b/crates/validation/src/rule_impls/length.rs
@@ -1,6 +1,6 @@
+use crate::Violation;
 use crate::rule::{Rule, RuleResult};
 use crate::traits::WithLength;
-use crate::Violation;
 
 impl<T: WithLength> Rule<T> {
   /// Validates a collection's length against this rule.
@@ -170,10 +170,10 @@ impl<T: WithLength> Rule<T> {
             any_passed = true;
             break;
           }
-          any_violations.extend(rule_violations.into_iter());
+          any_violations.extend(rule_violations);
         }
         if !any_passed && !rules.is_empty() {
-          violations.extend(any_violations.into_iter());
+          violations.extend(any_violations);
         }
       }
       Rule::When {
@@ -424,8 +424,7 @@ mod tests {
 
   #[test]
   fn test_validate_len_with_message_static() {
-    let rule = Rule::<Vec<i32>>::MinLength(3)
-      .with_message("Too few items");
+    let rule = Rule::<Vec<i32>>::MinLength(3).with_message("Too few items");
 
     let result = rule.validate_len(&vec![1]);
     assert!(result.is_err());
@@ -437,15 +436,17 @@ mod tests {
 
   #[test]
   fn test_validate_len_with_message_provider_and_locale() {
-    let rule = Rule::<Vec<i32>>::MinLength(2)
-      .with_message_provider(
-        |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
-          Some("es") => format!("Se requieren al menos 2 elementos, recibidos: {}", ctx.value.len()),
-          Some("fr") => format!("Au moins 2 éléments requis, reçu : {}", ctx.value.len()),
-          _ => format!("At least 2 items required, got: {}", ctx.value.len()),
-        },
-        Some("es"),
-      );
+    let rule = Rule::<Vec<i32>>::MinLength(2).with_message_provider(
+      |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
+        Some("es") => format!(
+          "Se requieren al menos 2 elementos, recibidos: {}",
+          ctx.value.len()
+        ),
+        Some("fr") => format!("Au moins 2 éléments requis, reçu : {}", ctx.value.len()),
+        _ => format!("At least 2 items required, got: {}", ctx.value.len()),
+      },
+      Some("es"),
+    );
 
     let result = rule.validate_len(&vec![1]);
     assert!(result.is_err());
@@ -457,14 +458,13 @@ mod tests {
 
   #[test]
   fn test_validate_len_with_message_provider_default_locale() {
-    let rule = Rule::<Vec<i32>>::MinLength(2)
-      .with_message_provider(
-        |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
-          Some("es") => "Muy pocos".to_string(),
-          _ => format!("Need at least 2, got {}", ctx.value.len()),
-        },
-        None,
-      );
+    let rule = Rule::<Vec<i32>>::MinLength(2).with_message_provider(
+      |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
+        Some("es") => "Muy pocos".to_string(),
+        _ => format!("Need at least 2, got {}", ctx.value.len()),
+      },
+      None,
+    );
 
     // No locale set → default arm
     let result = rule.validate_len(&vec![1]);
@@ -500,30 +500,25 @@ mod tests {
   #[test]
   fn test_validate_len_nested_with_message_locale_inheritance() {
     // Inner WithMessage has a locale-aware provider, outer sets the locale
-    let inner = Rule::<Vec<i32>>::MinLength(2)
-      .with_message_provider(
-        |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
-          Some("fr") => format!("Besoin d'au moins 2, reçu {}", ctx.value.len()),
-          _ => format!("Need at least 2, got {}", ctx.value.len()),
-        },
-        None,
-      );
+    let inner = Rule::<Vec<i32>>::MinLength(2).with_message_provider(
+      |ctx: &crate::MessageContext<Vec<i32>>| match ctx.locale {
+        Some("fr") => format!("Besoin d'au moins 2, reçu {}", ctx.value.len()),
+        _ => format!("Need at least 2, got {}", ctx.value.len()),
+      },
+      None,
+    );
 
     let outer = inner.with_locale("fr".to_string());
 
     let result = outer.validate_len(&vec![1]);
     assert!(result.is_err());
-    assert_eq!(
-      result.unwrap_err().message(),
-      "Besoin d'au moins 2, reçu 1"
-    );
+    assert_eq!(result.unwrap_err().message(), "Besoin d'au moins 2, reçu 1");
   }
 
   #[test]
   fn test_validate_len_with_message_empty_static_uses_default() {
     // Empty static message should fall back to the default violation message
-    let rule = Rule::<Vec<i32>>::MinLength(3)
-      .with_locale("en".to_string());
+    let rule = Rule::<Vec<i32>>::MinLength(3).with_locale("en".to_string());
 
     let result = rule.validate_len(&vec![1]);
     assert!(result.is_err());
@@ -553,5 +548,37 @@ mod tests {
     assert_eq!(violations.len(), 2);
     assert_eq!(violations[0].message(), "Error de longitud (3)");
     assert_eq!(violations[1].message(), "Error de longitud (3)");
+  }
+
+  // ========================================================================
+  // Rule::Ref tests (#143)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_len_ref_returns_err() {
+    let rule = Rule::<Vec<i32>>::Ref("len_ref".into());
+    let result = rule.validate_len(&vec![1, 2, 3]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), crate::ViolationType::CustomError);
+    assert!(err.message().contains("len_ref"));
+  }
+
+  #[test]
+  fn test_validate_len_ref_inside_all() {
+    let rule = Rule::<Vec<i32>>::All(vec![Rule::MinLength(1), Rule::Ref("len_ref".into())]);
+    assert!(rule.validate_len(&vec![1, 2]).is_err());
+  }
+
+  #[test]
+  fn test_validate_len_ref_inside_any() {
+    let rule = Rule::<Vec<i32>>::Any(vec![Rule::Ref("len_ref".into()), Rule::MinLength(1)]);
+    assert!(rule.validate_len(&vec![1, 2]).is_ok());
+  }
+
+  #[test]
+  fn test_validate_len_ref_inside_not() {
+    let rule = Rule::<Vec<i32>>::Not(Box::new(Rule::Ref("len_ref".into())));
+    assert!(rule.validate_len(&vec![1, 2]).is_ok());
   }
 }

--- a/crates/validation/src/rule_impls/scalar.rs
+++ b/crates/validation/src/rule_impls/scalar.rs
@@ -872,6 +872,130 @@ mod tests {
   }
 
   // ==========================================================================
+  // Rule::Ref tests (#143)
+  // ==========================================================================
+
+  #[test]
+  fn test_validate_scalar_ref_returns_err() {
+    let rule = Rule::<i32>::Ref("my_ref".into());
+    let result = rule.validate_scalar(42);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), crate::ViolationType::CustomError);
+    assert!(err.message().contains("my_ref"));
+  }
+
+  #[test]
+  fn test_validate_scalar_ref_inside_all() {
+    let rule = Rule::<i32>::All(vec![Rule::Min(0), Rule::Ref("my_ref".into())]);
+    assert!(rule.validate_scalar(42).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_ref_inside_any() {
+    // One branch passes → overall passes
+    let rule = Rule::<i32>::Any(vec![Rule::Ref("my_ref".into()), Rule::Min(0)]);
+    assert!(rule.validate_scalar(42).is_ok());
+
+    // All branches fail → overall fails
+    let rule_all_fail = Rule::<i32>::Any(vec![Rule::Ref("my_ref".into()), Rule::Min(100)]);
+    assert!(rule_all_fail.validate_scalar(42).is_err());
+  }
+
+  #[test]
+  fn test_validate_scalar_ref_inside_not() {
+    // Not(Ref) → Ref fails → Not succeeds
+    let rule = Rule::<i32>::Not(Box::new(Rule::Ref("my_ref".into())));
+    assert!(rule.validate_scalar(42).is_ok());
+  }
+
+  // ==========================================================================
+  // Deeply nested combinator tests (#145)
+  // ==========================================================================
+
+  #[test]
+  fn test_nested_depth2_all_containing_all_and_any() {
+    // All([All([Min(0), Max(100)]), Any([Equals(50), Equals(75)])])
+    let rule = Rule::<i32>::All(vec![
+      Rule::All(vec![Rule::Min(0), Rule::Max(100)]),
+      Rule::Any(vec![Rule::Equals(50), Rule::Equals(75)]),
+    ]);
+    assert!(rule.validate_scalar(50).is_ok());
+    assert!(rule.validate_scalar(75).is_ok());
+    assert!(rule.validate_scalar(25).is_err()); // Any fails
+    assert!(rule.validate_scalar(150).is_err()); // Max fails
+  }
+
+  #[test]
+  fn test_nested_depth2_when_with_nested_all_then() {
+    // When { condition: GreaterThan(0), then: All([Min(1), Max(10)]), else: None }
+    let rule = Rule::<i32>::When {
+      condition: Condition::GreaterThan(0),
+      then_rule: Box::new(Rule::All(vec![Rule::Min(1), Rule::Max(10)])),
+      else_rule: None,
+    };
+    assert!(rule.validate_scalar(5).is_ok());
+    assert!(rule.validate_scalar(11).is_err());
+    assert!(rule.validate_scalar(0).is_ok()); // condition false → pass
+  }
+
+  #[test]
+  fn test_nested_depth3_not_all_any() {
+    // Not(All([Any([Equals(1), Equals(2)]), Min(0)]))
+    // Value 1: Any passes, Min passes → All passes → Not fails
+    // Value 5: Any fails → All fails → Not passes
+    let rule = Rule::<i32>::Not(Box::new(Rule::All(vec![
+      Rule::Any(vec![Rule::Equals(1), Rule::Equals(2)]),
+      Rule::Min(0),
+    ])));
+    assert!(rule.validate_scalar(1).is_err());
+    assert!(rule.validate_scalar(2).is_err());
+    assert!(rule.validate_scalar(5).is_ok());
+  }
+
+  #[test]
+  fn test_nested_any_with_not_and_all() {
+    // Any([Not(Min(0)), All([Min(0), Max(10)])])
+    // -1: Not(Min(0)) → Min fails → Not passes → Any passes
+    // 5: Not fails, All passes → Any passes
+    // 15: Not fails, All fails → Any fails
+    let rule = Rule::<i32>::Any(vec![
+      Rule::Not(Box::new(Rule::Min(0))),
+      Rule::All(vec![Rule::Min(0), Rule::Max(10)]),
+    ]);
+    assert!(rule.validate_scalar(-1).is_ok());
+    assert!(rule.validate_scalar(5).is_ok());
+    assert!(rule.validate_scalar(15).is_err());
+  }
+
+  #[test]
+  fn test_nested_depth3_when_else_any_not() {
+    // When { condition: GreaterThan(50), then: Max(100),
+    //        else: Any([Not(Min(0)), Equals(25)]) }
+    let rule = Rule::<i32>::When {
+      condition: Condition::GreaterThan(50),
+      then_rule: Box::new(Rule::Max(100)),
+      else_rule: Some(Box::new(Rule::Any(vec![
+        Rule::Not(Box::new(Rule::Min(0))),
+        Rule::Equals(25),
+      ]))),
+    };
+    // > 50 → then: Max(100)
+    assert!(rule.validate_scalar(75).is_ok());
+    assert!(rule.validate_scalar(101).is_err());
+    // <= 50 → else: Any([Not(Min(0)), Equals(25)])
+    assert!(rule.validate_scalar(25).is_ok()); // Equals(25) passes
+    assert!(rule.validate_scalar(-1).is_ok()); // Not(Min(0)) passes
+    assert!(rule.validate_scalar(10).is_err()); // Neither passes
+  }
+
+  #[test]
+  fn test_empty_any_passes() {
+    let rule = Rule::<i32>::Any(vec![]);
+    assert!(rule.validate_scalar(42).is_ok());
+  }
+
+  // ==========================================================================
   // Async tests for bool / char
   // ==========================================================================
 

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -718,6 +718,135 @@ mod tests {
     assert!(rule.validate_ref(&Some(-0.1)).is_err());
   }
 
+  // ========================================================================
+  // Rule::Ref tests (#143)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_step_ref_returns_err() {
+    let rule = Rule::<i32>::Ref("step_ref".into());
+    let result = rule.validate_step(10);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), crate::ViolationType::CustomError);
+    assert!(err.message().contains("step_ref"));
+  }
+
+  #[test]
+  fn test_validate_ref_trait_ref_returns_err() {
+    let rule = Rule::<i32>::Ref("step_ref".into());
+    let result = rule.validate(10);
+    assert!(result.is_err());
+    let result_ref = rule.validate_ref(&10);
+    assert!(result_ref.is_err());
+    let err = result_ref.unwrap_err();
+    assert_eq!(err.violation_type(), crate::ViolationType::CustomError);
+    assert!(err.message().contains("step_ref"));
+  }
+
+  #[test]
+  fn test_validate_step_ref_inside_all() {
+    let rule = Rule::<i32>::All(vec![Rule::Min(0), Rule::Ref("step_ref".into())]);
+    assert!(rule.validate_step(10).is_err());
+  }
+
+  #[test]
+  fn test_validate_step_ref_inside_any() {
+    let rule = Rule::<i32>::Any(vec![Rule::Ref("step_ref".into()), Rule::Min(0)]);
+    assert!(rule.validate_step(10).is_ok());
+
+    let rule_all_fail = Rule::<i32>::Any(vec![Rule::Ref("step_ref".into()), Rule::Min(100)]);
+    assert!(rule_all_fail.validate_step(10).is_err());
+  }
+
+  #[test]
+  fn test_validate_step_ref_inside_not() {
+    let rule = Rule::<i32>::Not(Box::new(Rule::Ref("step_ref".into())));
+    assert!(rule.validate_step(10).is_ok());
+  }
+
+  // ========================================================================
+  // Deeply nested combinator tests (#145)
+  // ========================================================================
+
+  #[test]
+  fn test_nested_depth2_all_containing_all_and_any() {
+    // All([All([Min(0), Max(100)]), Any([Equals(50), Equals(75)])])
+    let rule = Rule::<i32>::All(vec![
+      Rule::All(vec![Rule::Min(0), Rule::Max(100)]),
+      Rule::Any(vec![Rule::Equals(50), Rule::Equals(75)]),
+    ]);
+    assert!(rule.validate_step(50).is_ok());
+    assert!(rule.validate_step(75).is_ok());
+    assert!(rule.validate_step(25).is_err());
+  }
+
+  #[test]
+  fn test_nested_depth2_when_with_nested_all_then() {
+    // When { condition: GreaterThan(0), then: All([Min(1), Max(10), Step(1)]), else: None }
+    let rule = Rule::<i32>::When {
+      condition: crate::rule::Condition::GreaterThan(0),
+      then_rule: Box::new(Rule::All(vec![Rule::Min(1), Rule::Max(10), Rule::Step(1)])),
+      else_rule: None,
+    };
+    assert!(rule.validate_step(5).is_ok());
+    assert!(rule.validate_step(11).is_err());
+    assert!(rule.validate_step(0).is_ok()); // condition false → pass
+  }
+
+  #[test]
+  fn test_nested_depth3_not_all_any() {
+    // Not(All([Any([Equals(1), Equals(2)]), Min(0)]))
+    // Value 1: Any passes, Min passes → All passes → Not fails
+    // Value 5: Any fails → All fails → Not passes
+    let rule = Rule::<i32>::Not(Box::new(Rule::All(vec![
+      Rule::Any(vec![Rule::Equals(1), Rule::Equals(2)]),
+      Rule::Min(0),
+    ])));
+    assert!(rule.validate_step(1).is_err());
+    assert!(rule.validate_step(5).is_ok());
+  }
+
+  #[test]
+  fn test_nested_any_with_not_and_all() {
+    // Any([Not(Min(0)), All([Min(0), Max(10)])])
+    // -1: Not(Min(0)) passes → Any passes
+    // 5: All passes → Any passes
+    // 15: Not fails, All fails → Any fails
+    let rule = Rule::<i32>::Any(vec![
+      Rule::Not(Box::new(Rule::Min(0))),
+      Rule::All(vec![Rule::Min(0), Rule::Max(10)]),
+    ]);
+    assert!(rule.validate_step(-1).is_ok());
+    assert!(rule.validate_step(5).is_ok());
+    assert!(rule.validate_step(15).is_err());
+  }
+
+  #[test]
+  fn test_nested_depth3_when_else_any_not() {
+    // When { condition: GreaterThan(50), then: Max(100),
+    //        else: Any([Not(Min(0)), Equals(25)]) }
+    let rule = Rule::<i32>::When {
+      condition: crate::rule::Condition::GreaterThan(50),
+      then_rule: Box::new(Rule::Max(100)),
+      else_rule: Some(Box::new(Rule::Any(vec![
+        Rule::Not(Box::new(Rule::Min(0))),
+        Rule::Equals(25),
+      ]))),
+    };
+    assert!(rule.validate_step(75).is_ok());
+    assert!(rule.validate_step(101).is_err());
+    assert!(rule.validate_step(25).is_ok());
+    assert!(rule.validate_step(-1).is_ok());
+    assert!(rule.validate_step(10).is_err());
+  }
+
+  #[test]
+  fn test_empty_any_passes() {
+    let rule = Rule::<i32>::Any(vec![]);
+    assert!(rule.validate_step(42).is_ok());
+  }
+
   #[cfg(feature = "async")]
   mod async_option_tests {
     use crate::rule::Rule;

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -1,7 +1,9 @@
-use crate::rule::{Rule, RuleResult};
 use crate::Violation;
+use crate::options::{
+  DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, IpOptions, UriOptions, UrlOptions,
+};
+use crate::rule::{Rule, RuleResult};
 use crate::traits::{Validate, ValidateRef};
-use crate::options::{DateOptions, DateRangeOptions, EmailOptions, HostnameOptions, UriOptions, UrlOptions, IpOptions};
 
 // ============================================================================
 // URI / IP Validation Helpers
@@ -33,7 +35,8 @@ fn validate_uri(value: &str, opts: &UriOptions) -> RuleResult {
       if opts.allow_relative && !value.is_empty() {
         // Validate as a relative reference using a fixed base URL.
         // This ensures syntactically invalid relative URIs are rejected.
-        let base = url::Url::parse("http://example.com/").expect("hard-coded base URL must be valid");
+        let base =
+          url::Url::parse("http://example.com/").expect("hard-coded base URL must be valid");
         match url::Url::options().base_url(Some(&base)).parse(value) {
           Ok(_) => Ok(()),
           Err(_) => Err(Violation::invalid_uri()),
@@ -80,14 +83,14 @@ fn validate_ip(value: &str, opts: &IpOptions) -> RuleResult {
 
   // Try IPv4
   if opts.allow_ipv4 {
-    if let Ok(_) = inner.parse::<std::net::Ipv4Addr>() {
+    if inner.parse::<std::net::Ipv4Addr>().is_ok() {
       return Ok(());
     }
   }
 
   // Try IPv6
   if opts.allow_ipv6 {
-    if let Ok(_) = inner.parse::<std::net::Ipv6Addr>() {
+    if inner.parse::<std::net::Ipv6Addr>().is_ok() {
       return Ok(());
     }
   }
@@ -121,10 +124,9 @@ fn is_ipvfuture(s: &str) -> bool {
   if dot_pos + 1 >= bytes.len() {
     return false;
   }
-  bytes[dot_pos + 1..].iter().all(|&b| {
-    b.is_ascii_alphanumeric()
-      || b"-._~!$&'()*+,;=:".contains(&b)
-  })
+  bytes[dot_pos + 1..]
+    .iter()
+    .all(|&b| b.is_ascii_alphanumeric() || b"-._~!$&'()*+,;=:".contains(&b))
 }
 
 // ============================================================================
@@ -178,7 +180,9 @@ fn is_valid_dns_label(label: &str) -> bool {
     return false;
   }
   // Interior characters: alphanumeric or hyphen
-  bytes.iter().all(|&b| b.is_ascii_alphanumeric() || b == b'-')
+  bytes
+    .iter()
+    .all(|&b| b.is_ascii_alphanumeric() || b == b'-')
 }
 
 /// Validates a hostname string according to the given options.
@@ -259,8 +263,7 @@ fn validate_hostname(value: &str, opts: &HostnameOptions) -> RuleResult {
 
 /// Characters allowed in the local part of an email address (RFC 5321/5322 simplified).
 fn is_valid_local_char(b: u8) -> bool {
-  b.is_ascii_alphanumeric()
-    || b"!#$%&'*+/=?^_`{|}~-.".contains(&b)
+  b.is_ascii_alphanumeric() || b"!#$%&'*+/=?^_`{|}~-.".contains(&b)
 }
 
 /// Validates an email address string according to the given options.
@@ -312,8 +315,7 @@ fn validate_email(value: &str, opts: &EmailOptions) -> RuleResult {
       allow_local: opts.allow_local,
       require_public_ipv4: false,
     };
-    validate_hostname(domain, &hostname_opts)
-      .map_err(|_| Violation::invalid_email())?;
+    validate_hostname(domain, &hostname_opts).map_err(|_| Violation::invalid_email())?;
   }
 
   Ok(())
@@ -427,12 +429,12 @@ impl Rule<String> {
         }
       }
       Rule::Pattern(cp) => {
-          if cp.0.is_match(value) {
-            Ok(())
-          } else {
-            Err(Violation::pattern_mismatch(cp.as_str()))
-          }
-      },
+        if cp.0.is_match(value) {
+          Ok(())
+        } else {
+          Err(Violation::pattern_mismatch(cp.as_str()))
+        }
+      }
       Rule::Email(opts) => validate_email(value, opts),
       Rule::Url(opts) => validate_url(value, opts),
       Rule::Uri(opts) => validate_uri(value, opts),
@@ -496,10 +498,14 @@ impl Rule<String> {
       #[cfg(feature = "async")]
       Rule::CustomAsync(_) => Ok(()),
       Rule::Ref(name) => Err(Violation::unresolved_ref(name)),
-      Rule::WithMessage { rule, message, locale } => {
+      Rule::WithMessage {
+        rule,
+        message,
+        locale,
+      } => {
         let eff = locale.as_deref().or(inherited_locale);
         message.wrap_result(rule.validate_str_inner(value, eff), &value.to_string(), eff)
-      },
+      }
       // Numeric rules don't apply to strings - pass through
       Rule::Min(_) | Rule::Max(_) | Rule::Range { .. } | Rule::Step(_) => Ok(()),
     }
@@ -508,10 +514,7 @@ impl Rule<String> {
   /// Validates a string value and collects all violations.
   ///
   /// Returns `Ok(())` if validation passes, or `Err(Violations)` with all failures.
-  pub(crate) fn validate_str_all(
-    &self,
-    value: &str,
-  ) -> Result<(), crate::Violations> {
+  pub(crate) fn validate_str_all(&self, value: &str) -> Result<(), crate::Violations> {
     let mut violations = crate::Violations::default();
     self.collect_violations_str(value, None, &mut violations);
     if violations.is_empty() {
@@ -568,10 +571,10 @@ impl Rule<String> {
             any_passed = true;
             break;
           }
-          any_violations.extend(rule_violations.into_iter());
+          any_violations.extend(rule_violations);
         }
         if !any_passed && !rules.is_empty() {
-          violations.extend(any_violations.into_iter());
+          violations.extend(any_violations);
         }
       }
       Rule::When {
@@ -586,7 +589,11 @@ impl Rule<String> {
           rule.collect_violations_str(value, inherited_locale, violations);
         }
       }
-      Rule::WithMessage { rule, message, locale } => {
+      Rule::WithMessage {
+        rule,
+        message,
+        locale,
+      } => {
         let eff = locale.as_deref().or(inherited_locale);
         let mut inner_violations = crate::Violations::default();
         rule.collect_violations_str(value, eff, &mut inner_violations);
@@ -653,7 +660,9 @@ impl Rule<String> {
 
         Rule::All(rules) => {
           for rule in rules {
-            rule.validate_str_async_inner(value, inherited_locale).await?;
+            rule
+              .validate_str_async_inner(value, inherited_locale)
+              .await?;
           }
           Ok(())
         }
@@ -671,7 +680,10 @@ impl Rule<String> {
           Err(last_err.unwrap())
         }
         Rule::Not(inner) => {
-          match inner.validate_str_async_inner(value, inherited_locale).await {
+          match inner
+            .validate_str_async_inner(value, inherited_locale)
+            .await
+          {
             Ok(()) => Err(Violation::negation_failed()),
             Err(_) => Ok(()),
           }
@@ -682,7 +694,9 @@ impl Rule<String> {
           else_rule,
         } => {
           if condition.evaluate_str(value) {
-            then_rule.validate_str_async_inner(value, inherited_locale).await
+            then_rule
+              .validate_str_async_inner(value, inherited_locale)
+              .await
           } else {
             match else_rule {
               Some(rule) => rule.validate_str_async_inner(value, inherited_locale).await,
@@ -690,9 +704,17 @@ impl Rule<String> {
             }
           }
         }
-        Rule::WithMessage { rule, message, locale } => {
+        Rule::WithMessage {
+          rule,
+          message,
+          locale,
+        } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(rule.validate_str_async_inner(value, eff).await, &value.to_string(), eff)
+          message.wrap_result(
+            rule.validate_str_async_inner(value, eff).await,
+            &value.to_string(),
+            eff,
+          )
         }
 
         // All sync rules — delegate to sync validation
@@ -763,7 +785,9 @@ mod tests {
   fn validate_option_string_some_delegates_to_string_validation() {
     let rule = Rule::<String>::Email(EmailOptions::default());
 
-    assert!(Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok());
+    assert!(
+      Validate::<Option<String>>::validate(&rule, Some("user@example.com".to_owned())).is_ok()
+    );
     assert!(Validate::<Option<String>>::validate(&rule, Some("not-an-email".to_owned())).is_err());
   }
 
@@ -970,15 +994,19 @@ mod tests {
   fn test_validate_str_url_compiled() {
     let rule = Rule::<String>::Url(crate::UrlOptions::default());
     assert!(rule.validate_str("http://example.com").is_ok());
-    assert!(rule.validate_str("https://example.com/path?q=1#frag").is_ok());
+    assert!(
+      rule
+        .validate_str("https://example.com/path?q=1#frag")
+        .is_ok()
+    );
     assert!(rule.validate_str("not-a-url").is_err());
     assert!(rule.validate_str("ftp://example.com").is_err());
   }
 
   #[test]
   fn test_validate_str_url_with_message() {
-    let rule = Rule::<String>::Url(crate::UrlOptions::default())
-      .with_message("Please enter a valid URL");
+    let rule =
+      Rule::<String>::Url(crate::UrlOptions::default()).with_message("Please enter a valid URL");
     let err = rule.validate_str("bad").unwrap_err();
     assert_eq!(err.message(), "Please enter a valid URL");
   }
@@ -1359,8 +1387,11 @@ mod tests {
 
   #[test]
   fn test_validate_ip_all_violations() {
-    let rule = Rule::<String>::Required
-      .and(Rule::Ip(crate::IpOptions { allow_ipv4: true, allow_ipv6: false, ..Default::default() }));
+    let rule = Rule::<String>::Required.and(Rule::Ip(crate::IpOptions {
+      allow_ipv4: true,
+      allow_ipv6: false,
+      ..Default::default()
+    }));
 
     assert!(rule.validate_str_all("192.168.1.1").is_ok());
 
@@ -1536,15 +1567,24 @@ mod tests {
     assert!(rule.validate_str(&format!("{}.com", long_label)).is_ok());
     // Label with 64 chars - too long
     let too_long_label = "a".repeat(64);
-    assert!(rule.validate_str(&format!("{}.com", too_long_label)).is_err());
+    assert!(
+      rule
+        .validate_str(&format!("{}.com", too_long_label))
+        .is_err()
+    );
   }
 
   #[test]
   fn test_validate_hostname_total_length() {
     let rule = Rule::<String>::Hostname(crate::HostnameOptions::default());
     // Total length > 253 should fail
-    let long_hostname = format!("{}.{}.{}.{}.com",
-      "a".repeat(63), "b".repeat(63), "c".repeat(63), "d".repeat(63));
+    let long_hostname = format!(
+      "{}.{}.{}.{}.com",
+      "a".repeat(63),
+      "b".repeat(63),
+      "c".repeat(63),
+      "d".repeat(63)
+    );
     assert!(long_hostname.len() > 253);
     assert!(rule.validate_str(&long_hostname).is_err());
   }
@@ -1577,8 +1617,10 @@ mod tests {
 
   #[test]
   fn test_validate_hostname_all_violations() {
-    let rule = Rule::<String>::Required
-      .and(Rule::Hostname(crate::HostnameOptions { allow_ip: false, ..Default::default() }));
+    let rule = Rule::<String>::Required.and(Rule::Hostname(crate::HostnameOptions {
+      allow_ip: false,
+      ..Default::default()
+    }));
     assert!(rule.validate_str_all("example.com").is_ok());
     let result = rule.validate_str_all("192.168.1.1");
     assert!(result.is_err());
@@ -1603,5 +1645,133 @@ mod tests {
     let rule = Rule::<String>::hostname(opts.clone());
     assert_eq!(rule, Rule::Hostname(opts));
   }
-}
 
+  // ========================================================================
+  // Rule::Ref tests (#143)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_str_ref_returns_err() {
+    let rule = Rule::<String>::Ref("some_ref".into());
+    let result = rule.validate_ref("test");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), crate::ViolationType::CustomError);
+    assert!(err.message().contains("some_ref"));
+  }
+
+  #[test]
+  fn test_validate_str_ref_via_validate_trait() {
+    let rule = Rule::<String>::Ref("some_ref".into());
+    let result: Result<(), Violation> = Validate::validate(&rule, Some("test".to_string()));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), crate::ViolationType::CustomError);
+    assert!(err.message().contains("some_ref"));
+  }
+
+  #[test]
+  fn test_validate_str_ref_inside_all() {
+    let rule = Rule::<String>::All(vec![Rule::MinLength(1), Rule::Ref("some_ref".into())]);
+    assert!(rule.validate_ref("test").is_err());
+  }
+
+  #[test]
+  fn test_validate_str_ref_inside_any() {
+    // Any: if one branch passes, the overall passes
+    let rule = Rule::<String>::Any(vec![Rule::Ref("some_ref".into()), Rule::MinLength(1)]);
+    assert!(rule.validate_ref("test").is_ok());
+
+    // Any: if all branches fail, the overall fails
+    let rule_all_fail =
+      Rule::<String>::Any(vec![Rule::Ref("some_ref".into()), Rule::MinLength(100)]);
+    assert!(rule_all_fail.validate_ref("test").is_err());
+  }
+
+  #[test]
+  fn test_validate_str_ref_inside_not() {
+    // Not(Ref) → Ref fails → Not succeeds
+    let rule = Rule::<String>::Not(Box::new(Rule::Ref("some_ref".into())));
+    assert!(rule.validate_ref("test").is_ok());
+  }
+
+  // ========================================================================
+  // Deeply nested combinator tests (#145)
+  // ========================================================================
+
+  #[test]
+  fn test_nested_depth2_all_containing_all_and_pattern() {
+    let rule = Rule::<String>::All(vec![
+      Rule::All(vec![Rule::MinLength(2), Rule::MaxLength(10)]),
+      Rule::pattern("^[a-z]+$").unwrap(),
+    ]);
+    assert!(rule.validate_ref("hello").is_ok());
+    assert!(rule.validate_ref("a").is_err()); // too short
+    assert!(rule.validate_ref("Hello").is_err()); // pattern mismatch
+    assert!(rule.validate_ref("abcdefghijk").is_err()); // too long
+  }
+
+  #[test]
+  fn test_nested_depth2_when_with_combinator_then() {
+    let rule = Rule::<String>::When {
+      condition: Condition::IsNotEmpty,
+      then_rule: Box::new(Rule::All(vec![Rule::MinLength(3), Rule::MaxLength(10)])),
+      else_rule: None,
+    };
+    assert!(rule.validate_ref("hello").is_ok());
+    assert!(rule.validate_ref("ab").is_err()); // too short
+    assert!(rule.validate_ref("").is_ok()); // empty → condition false → pass
+  }
+
+  #[test]
+  fn test_nested_depth2_when_with_combinator_else() {
+    let rule = Rule::<String>::When {
+      condition: Condition::Matches(crate::CompiledPattern::try_from("^[A-Z]").unwrap()),
+      then_rule: Box::new(Rule::MinLength(5)),
+      else_rule: Some(Box::new(Rule::All(vec![
+        Rule::MinLength(1),
+        Rule::MaxLength(3),
+      ]))),
+    };
+    // Starts with uppercase → then: MinLength(5)
+    assert!(rule.validate_ref("Hello").is_ok());
+    assert!(rule.validate_ref("Hi").is_err());
+    // Lowercase → else: length 1..3
+    assert!(rule.validate_ref("abc").is_ok());
+    assert!(rule.validate_ref("abcd").is_err());
+  }
+
+  #[test]
+  fn test_nested_depth3_not_all_any() {
+    // Not(All([Any([MinLength(3), MaxLength(1)]), Pattern(...)]))
+    // "ab" → Any fails (len 2: MinLength(3) fail, MaxLength(1) fail) → All fails → Not passes
+    // "abc" → Any passes (MinLength(3) ok) and Pattern passes → All passes → Not fails
+    let rule = Rule::<String>::Not(Box::new(Rule::All(vec![
+      Rule::Any(vec![Rule::MinLength(3), Rule::MaxLength(1)]),
+      Rule::pattern("^[a-z]+$").unwrap(),
+    ])));
+    assert!(rule.validate_ref("ab").is_ok()); // inner All fails → Not passes
+    assert!(rule.validate_ref("abc").is_err()); // inner All passes → Not fails
+  }
+
+  #[test]
+  fn test_nested_any_with_not_and_all() {
+    // Any([Not(MinLength(3)), All([MinLength(3), MaxLength(6)])])
+    let rule = Rule::<String>::Any(vec![
+      Rule::Not(Box::new(Rule::MinLength(3))),
+      Rule::All(vec![Rule::MinLength(3), Rule::MaxLength(6)]),
+    ]);
+    // "ab": Not(MinLength(3)) → MinLength(3) fails → Not passes → Any passes
+    assert!(rule.validate_ref("ab").is_ok());
+    // "hello": Not fails (MinLength passes), All passes → Any passes
+    assert!(rule.validate_ref("hello").is_ok());
+    // "abcdefghij": Not fails, All fails (MaxLength) → Any fails
+    assert!(rule.validate_ref("abcdefghij").is_err());
+  }
+
+  #[test]
+  fn test_empty_any_passes() {
+    let rule = Rule::<String>::Any(vec![]);
+    assert!(rule.validate_ref("anything").is_ok());
+  }
+}

--- a/crates/validation/src/rule_impls/value.rs
+++ b/crates/validation/src/rule_impls/value.rs
@@ -1077,6 +1077,108 @@ mod tests {
   }
 
   // ========================================================================
+  // Rule::Ref tests (#143)
+  // ========================================================================
+
+  #[test]
+  fn test_validate_value_ref_returns_err() {
+    let rule = Rule::<Value>::Ref("val_ref".into());
+    let result = rule.validate_value(&value!(42));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), ViolationType::CustomError);
+    assert!(err.message().contains("val_ref"));
+  }
+
+  #[test]
+  fn test_validate_value_ref_with_string() {
+    let rule = Rule::<Value>::Ref("val_ref".into());
+    let result = rule.validate_value(&value!("hello"));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.violation_type(), ViolationType::CustomError);
+    assert!(err.message().contains("val_ref"));
+  }
+
+  #[test]
+  fn test_validate_value_ref_inside_all() {
+    let rule = Rule::<Value>::All(vec![Rule::MinLength(1), Rule::Ref("val_ref".into())]);
+    assert!(rule.validate_value(&value!("test")).is_err());
+  }
+
+  #[test]
+  fn test_validate_value_ref_inside_any() {
+    let rule = Rule::<Value>::Any(vec![Rule::Ref("val_ref".into()), Rule::MinLength(1)]);
+    assert!(rule.validate_value(&value!("test")).is_ok());
+
+    let rule_all_fail = Rule::<Value>::Any(vec![Rule::Ref("val_ref".into()), Rule::MinLength(100)]);
+    assert!(rule_all_fail.validate_value(&value!("test")).is_err());
+  }
+
+  #[test]
+  fn test_validate_value_ref_inside_not() {
+    let rule = Rule::<Value>::Not(Box::new(Rule::Ref("val_ref".into())));
+    assert!(rule.validate_value(&value!("test")).is_ok());
+  }
+
+  // ========================================================================
+  // Deeply nested combinator tests (#145)
+  // ========================================================================
+
+  #[test]
+  fn test_nested_depth2_all_containing_all_and_any_value() {
+    // All([All([Min(0), Max(100)]), Any([Equals(50), Equals(75)])])
+    let rule = Rule::<Value>::All(vec![
+      Rule::All(vec![Rule::Min(value!(0)), Rule::Max(value!(100))]),
+      Rule::Any(vec![Rule::Equals(value!(50)), Rule::Equals(value!(75))]),
+    ]);
+    assert!(rule.validate_value(&value!(50)).is_ok());
+    assert!(rule.validate_value(&value!(75)).is_ok());
+    assert!(rule.validate_value(&value!(25)).is_err());
+  }
+
+  #[test]
+  fn test_nested_depth2_when_with_combinator_then_value() {
+    let rule = Rule::<Value>::When {
+      condition: Condition::IsNotEmpty,
+      then_rule: Box::new(Rule::All(vec![Rule::MinLength(3), Rule::MaxLength(10)])),
+      else_rule: None,
+    };
+    assert!(rule.validate_value(&value!("hello")).is_ok());
+    assert!(rule.validate_value(&value!("ab")).is_err());
+    assert!(rule.validate_value(&value!(null)).is_ok());
+  }
+
+  #[test]
+  fn test_nested_depth3_not_all_any_value() {
+    // Not(All([Any([Equals(1), Equals(2)]), Min(0)]))
+    let rule = Rule::<Value>::Not(Box::new(Rule::All(vec![
+      Rule::Any(vec![Rule::Equals(value!(1)), Rule::Equals(value!(2))]),
+      Rule::Min(value!(0)),
+    ])));
+    assert!(rule.validate_value(&value!(1)).is_err()); // inner passes → Not fails
+    assert!(rule.validate_value(&value!(5)).is_ok()); // Any fails → Not passes
+  }
+
+  #[test]
+  fn test_nested_any_with_not_and_all_value() {
+    // Any([Not(MinLength(3)), All([MinLength(3), MaxLength(6)])])
+    let rule = Rule::<Value>::Any(vec![
+      Rule::Not(Box::new(Rule::MinLength(3))),
+      Rule::All(vec![Rule::MinLength(3), Rule::MaxLength(6)]),
+    ]);
+    assert!(rule.validate_value(&value!("ab")).is_ok()); // Not passes
+    assert!(rule.validate_value(&value!("hello")).is_ok()); // All passes
+    assert!(rule.validate_value(&value!("abcdefghij")).is_err()); // Both fail
+  }
+
+  #[test]
+  fn test_empty_any_passes_value() {
+    let rule = Rule::<Value>::Any(vec![]);
+    assert!(rule.validate_value(&value!("anything")).is_ok());
+  }
+
+  // ========================================================================
   // #148 — Serde round-trip tests for Rule<Value>
   // ========================================================================
 


### PR DESCRIPTION
## Summary

Closes #143, closes #145.

### Rule::Ref tests (#143)
- Tests `Rule::Ref` returns `Err(Violation::unresolved_ref(name))` with `ViolationType::CustomError` across all validation impls:
  - **string.rs**: `validate`, `validate_ref`
  - **scalar.rs**: `validate_scalar`
  - **steppable.rs**: `validate_step`, `validate`, `validate_ref`
  - **value.rs**: `validate`, `validate_ref` with `Value` types
  - **length.rs**: `validate_len` for Vec
- Tests `Rule::Ref` inside `All`, `Any`, `Not` combinators

### Deeply nested combinator tests (#145)
- Depth-2 nesting: `All([All([...]), Any([...])])`, `When { then: All([...]) }`
- Depth-3 nesting: `Not(All([Any(...)]))`, `Any([Not(...), All([...])])`, `When` with nested else
- Applied across string, scalar, steppable, and value impls

All 465 tests passing.