### PR TITLE
chore: #183 run cargo fmt across entire workspace

### DIFF
--- a/crates/acl/src/simple/acl.rs
+++ b/crates/acl/src/simple/acl.rs
@@ -388,10 +388,11 @@ impl Acl {
 
       let mut inherited = Vec::new();
       for i in 0..self._roles.vert_count() {
-        if i != role_idx && dfs.marked(i).unwrap_or(false) {
-          if let Some(name) = self._roles.name_as_ref(i) {
-            inherited.push(name);
-          }
+        if i != role_idx
+          && dfs.marked(i).unwrap_or(false)
+          && let Some(name) = self._roles.name_as_ref(i)
+        {
+          inherited.push(name);
         }
       }
 
@@ -409,10 +410,11 @@ impl Acl {
 
       let mut inherited = Vec::new();
       for i in 0..self._resources.vert_count() {
-        if i != resource_idx && dfs.marked(i).unwrap_or(false) {
-          if let Some(name) = self._resources.name_as_ref(i) {
-            inherited.push(name);
-          }
+        if i != resource_idx
+          && dfs.marked(i).unwrap_or(false)
+          && let Some(name) = self._resources.name_as_ref(i)
+        {
+          inherited.push(name);
         }
       }
 

--- a/crates/acl/src/simple/acl_builder.rs
+++ b/crates/acl/src/simple/acl_builder.rs
@@ -9,7 +9,7 @@ use walrs_digraph::DisymGraph;
 
 // Convenience method.
 fn _is_empty(list: &Option<&[&str]>) -> bool {
-  list.map_or(true, |xs| xs.is_empty())
+  list.is_none_or(|xs| xs.is_empty())
 }
 
 /// Builder for constructing `Acl` instances with a fluent interface.
@@ -316,12 +316,11 @@ impl AclBuilder {
         }
         // If only `role` is None, consider it the "received roles are empty" signal and
         // clear the 'by_role_id' map for this visiting resource
-        else if role.is_none() {
-          if let Some(resource_id) = resource {
-            if let Some(res_rules) = self._rules.by_resource_id.get_mut(resource_id) {
-              res_rules.by_role_id = None;
-            }
-          }
+        else if role.is_none()
+          && let Some(resource_id) = resource
+          && let Some(res_rules) = self._rules.by_resource_id.get_mut(resource_id)
+        {
+          res_rules.by_role_id = None;
         }
 
         // Get role rules for resource (will either be "for all roles" or specific role based on Some/None args passed in)
@@ -340,10 +339,10 @@ impl AclBuilder {
           if let Some(p_map) = role_rules.by_privilege_id.as_mut() {
             for privilege in privilege_list {
               // Remove the privilege entry if it has the opposite rule
-              if let Some(existing_rule) = p_map.get(*privilege) {
-                if existing_rule == &opposite_rule {
-                  p_map.remove(*privilege);
-                }
+              if let Some(existing_rule) = p_map.get(*privilege)
+                && existing_rule == &opposite_rule
+              {
+                p_map.remove(*privilege);
               }
             }
           }
@@ -391,7 +390,7 @@ impl AclBuilder {
     keys_to_filter.map_or(vec![None], |keys| {
       keys
         .iter()
-        .filter(|key| graph.contains(*key))
+        .filter(|key| graph.contains(key))
         .map(|key| Some(key.to_string()))
         .collect()
     })
@@ -704,7 +703,7 @@ impl TryFrom<&AclBuilder> for AclData {
         .for_all_roles
         .by_privilege_id
         .as_ref()
-        .map_or(true, |m| m.is_empty());
+        .is_none_or(|m| m.is_empty());
 
       if !by_priv_is_empty {
         if let Some(ref by_priv) = role_priv_rules.for_all_roles.by_privilege_id {
@@ -730,7 +729,7 @@ impl TryFrom<&AclBuilder> for AclData {
           let role_by_priv_is_empty = priv_rules
             .by_privilege_id
             .as_ref()
-            .map_or(true, |m| m.is_empty());
+            .is_none_or(|m| m.is_empty());
 
           if !role_by_priv_is_empty {
             if let Some(ref by_priv) = priv_rules.by_privilege_id {

--- a/crates/acl/src/simple/acl_data.rs
+++ b/crates/acl/src/simple/acl_data.rs
@@ -18,7 +18,7 @@ pub struct AclData {
 }
 
 #[cfg(feature = "std")]
-impl<'a> TryFrom<&'a mut File> for AclData {
+impl TryFrom<&mut File> for AclData {
   type Error = serde_json::Error;
 
   fn try_from(file: &mut File) -> Result<Self, Self::Error> {

--- a/crates/acl/src/simple/resource_role_rules.rs
+++ b/crates/acl/src/simple/resource_role_rules.rs
@@ -14,6 +14,12 @@ pub struct ResourceRoleRules {
   pub by_resource_id: HashMap<Resource, RolePrivilegeRules>,
 }
 
+impl Default for ResourceRoleRules {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl ResourceRoleRules {
   pub fn new() -> Self {
     ResourceRoleRules {

--- a/crates/form/examples/localized_form.rs
+++ b/crates/form/examples/localized_form.rs
@@ -26,33 +26,39 @@ impl LocalizedFormValidator {
   /// Validate username with localized error messages
   fn validate_username(&self, value: &str) -> Result<(), String> {
     let rule = Rule::<String>::Required
-      .with_message_provider(|ctx| match ctx.locale {
-        Some("es") => "El nombre de usuario es obligatorio".to_string(),
-        Some("fr") => "Le nom d'utilisateur est requis".to_string(),
-        Some("de") => "Benutzername ist erforderlich".to_string(),
-        _ => "Username is required".to_string(),
-      }, None)
+      .with_message_provider(
+        |ctx| match ctx.locale {
+          Some("es") => "El nombre de usuario es obligatorio".to_string(),
+          Some("fr") => "Le nom d'utilisateur est requis".to_string(),
+          Some("de") => "Benutzername ist erforderlich".to_string(),
+          _ => "Username is required".to_string(),
+        },
+        None,
+      )
       .and(
         Rule::<String>::MinLength(3)
           .and(Rule::MaxLength(20))
-          .with_message_provider(|ctx| {
-            let (min, max) = (3, 20);
-            match ctx.locale {
-              Some("es") => format!(
-                "El nombre de usuario debe tener entre {} y {} caracteres",
-                min, max
-              ),
-              Some("fr") => format!(
-                "Le nom d'utilisateur doit contenir entre {} et {} caractères",
-                min, max
-              ),
-              Some("de") => format!(
-                "Benutzername muss zwischen {} und {} Zeichen haben",
-                min, max
-              ),
-              _ => format!("Username must be between {} and {} characters", min, max),
-            }
-          }, None),
+          .with_message_provider(
+            |ctx| {
+              let (min, max) = (3, 20);
+              match ctx.locale {
+                Some("es") => format!(
+                  "El nombre de usuario debe tener entre {} y {} caracteres",
+                  min, max
+                ),
+                Some("fr") => format!(
+                  "Le nom d'utilisateur doit contenir entre {} et {} caractères",
+                  min, max
+                ),
+                Some("de") => format!(
+                  "Benutzername muss zwischen {} und {} Zeichen haben",
+                  min, max
+                ),
+                _ => format!("Username must be between {} and {} characters", min, max),
+              }
+            },
+            None,
+          ),
       );
 
     let rule = match &self.locale {
@@ -68,19 +74,25 @@ impl LocalizedFormValidator {
   /// Validate email with localized error messages
   fn validate_email(&self, value: &str) -> Result<(), String> {
     let rule = Rule::<String>::Required
-      .with_message_provider(|ctx| match ctx.locale {
-        Some("es") => "El correo electrónico es obligatorio".to_string(),
-        Some("fr") => "L'adresse e-mail est requise".to_string(),
-        Some("de") => "E-Mail ist erforderlich".to_string(),
-        _ => "Email is required".to_string(),
-      }, None)
+      .with_message_provider(
+        |ctx| match ctx.locale {
+          Some("es") => "El correo electrónico es obligatorio".to_string(),
+          Some("fr") => "L'adresse e-mail est requise".to_string(),
+          Some("de") => "E-Mail ist erforderlich".to_string(),
+          _ => "Email is required".to_string(),
+        },
+        None,
+      )
       .and(
-        Rule::<String>::Email(Default::default()).with_message_provider(|ctx| match ctx.locale {
-          Some("es") => "El formato del correo electrónico no es válido".to_string(),
-          Some("fr") => "Le format de l'adresse e-mail est invalide".to_string(),
-          Some("de") => "Ungültiges E-Mail-Format".to_string(),
-          _ => "Invalid email format".to_string(),
-        }, None),
+        Rule::<String>::Email(Default::default()).with_message_provider(
+          |ctx| match ctx.locale {
+            Some("es") => "El formato del correo electrónico no es válido".to_string(),
+            Some("fr") => "Le format de l'adresse e-mail est invalide".to_string(),
+            Some("de") => "Ungültiges E-Mail-Format".to_string(),
+            _ => "Invalid email format".to_string(),
+          },
+          None,
+        ),
       );
 
     let rule = match &self.locale {
@@ -96,44 +108,58 @@ impl LocalizedFormValidator {
   /// Validate password with localized error messages
   fn validate_password(&self, value: &str) -> Result<(), Vec<String>> {
     let rule = Rule::<String>::Required
-      .with_message_provider(|ctx| match ctx.locale {
-        Some("es") => "La contraseña es obligatoria".to_string(),
-        Some("fr") => "Le mot de passe est requis".to_string(),
-        Some("de") => "Passwort ist erforderlich".to_string(),
-        _ => "Password is required".to_string(),
-      }, None)
-      .and(Rule::<String>::MinLength(8).with_message_provider(|ctx| {
-        let min = 8;
-        match ctx.locale {
-          Some("es") => {
-            format!("La contraseña debe tener al menos {} caracteres", min)
-          }
-          Some("fr") => {
-            format!("Le mot de passe doit contenir au moins {} caractères", min)
-          }
-          Some("de") => format!("Passwort muss mindestens {} Zeichen haben", min),
-          _ => format!("Password must be at least {} characters", min),
-        }
-      }, None))
-      .and(
-        Rule::<String>::pattern(r"[A-Z]").unwrap().with_message_provider(|ctx| {
+      .with_message_provider(
+        |ctx| match ctx.locale {
+          Some("es") => "La contraseña es obligatoria".to_string(),
+          Some("fr") => "Le mot de passe est requis".to_string(),
+          Some("de") => "Passwort ist erforderlich".to_string(),
+          _ => "Password is required".to_string(),
+        },
+        None,
+      )
+      .and(Rule::<String>::MinLength(8).with_message_provider(
+        |ctx| {
+          let min = 8;
           match ctx.locale {
-            Some("es") => "La contraseña debe contener al menos una letra mayúscula".to_string(),
-            Some("fr") => "Le mot de passe doit contenir au moins une lettre majuscule".to_string(),
-            Some("de") => "Passwort muss mindestens einen Großbuchstaben enthalten".to_string(),
-            _ => "Password must contain at least one uppercase letter".to_string(),
+            Some("es") => {
+              format!("La contraseña debe tener al menos {} caracteres", min)
+            }
+            Some("fr") => {
+              format!("Le mot de passe doit contenir au moins {} caractères", min)
+            }
+            Some("de") => format!("Passwort muss mindestens {} Zeichen haben", min),
+            _ => format!("Password must be at least {} characters", min),
           }
-        }, None),
+        },
+        None,
+      ))
+      .and(
+        Rule::<String>::pattern(r"[A-Z]")
+          .unwrap()
+          .with_message_provider(
+            |ctx| match ctx.locale {
+              Some("es") => "La contraseña debe contener al menos una letra mayúscula".to_string(),
+              Some("fr") => {
+                "Le mot de passe doit contenir au moins une lettre majuscule".to_string()
+              }
+              Some("de") => "Passwort muss mindestens einen Großbuchstaben enthalten".to_string(),
+              _ => "Password must contain at least one uppercase letter".to_string(),
+            },
+            None,
+          ),
       )
       .and(
-        Rule::<String>::pattern(r"[0-9]").unwrap().with_message_provider(|ctx| {
-          match ctx.locale {
-            Some("es") => "La contraseña debe contener al menos un número".to_string(),
-            Some("fr") => "Le mot de passe doit contenir au moins un chiffre".to_string(),
-            Some("de") => "Passwort muss mindestens eine Zahl enthalten".to_string(),
-            _ => "Password must contain at least one number".to_string(),
-          }
-        }, None),
+        Rule::<String>::pattern(r"[0-9]")
+          .unwrap()
+          .with_message_provider(
+            |ctx| match ctx.locale {
+              Some("es") => "La contraseña debe contener al menos un número".to_string(),
+              Some("fr") => "Le mot de passe doit contenir au moins un chiffre".to_string(),
+              Some("de") => "Passwort muss mindestens eine Zahl enthalten".to_string(),
+              _ => "Password must contain at least one number".to_string(),
+            },
+            None,
+          ),
       );
 
     let rule = match &self.locale {

--- a/crates/form/src/form.rs
+++ b/crates/form/src/form.rs
@@ -4,8 +4,8 @@ use crate::form_data::FormData;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use walrs_validation::Attributes;
 use walrs_inputfilter::{FieldFilter, FormViolations};
+use walrs_validation::Attributes;
 /// HTTP form method.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FormMethod {
@@ -62,10 +62,10 @@ impl Form {
   pub fn bind_data(&mut self, data: FormData) -> &mut Self {
     if let Some(ref mut elements) = self.elements {
       for element in elements.iter_mut() {
-        if let Some(name) = element.name() {
-          if let Some(value) = data.get(name) {
-            Self::set_element_value(element, value.clone());
-          }
+        if let Some(name) = element.name()
+          && let Some(value) = data.get(name)
+        {
+          Self::set_element_value(element, value.clone());
         }
       }
     }

--- a/crates/form/src/form_data.rs
+++ b/crates/form/src/form_data.rs
@@ -167,7 +167,10 @@ mod tests {
   fn test_dot_notation_get() {
     let mut data = FormData::new();
     let mut user = HashMap::new();
-    user.insert("email".to_string(), Value::Str("test@example.com".to_string()));
+    user.insert(
+      "email".to_string(),
+      Value::Str("test@example.com".to_string()),
+    );
     data.insert("user", Value::Object(user));
     assert_eq!(
       data.get("user.email").unwrap().as_str(),

--- a/crates/form/src/input_element.rs
+++ b/crates/form/src/input_element.rs
@@ -16,9 +16,9 @@ use crate::input_type::InputType;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use walrs_validation::{Attributes, Value};
 use walrs_inputfilter::Field;
 use walrs_validation::Violations;
+use walrs_validation::{Attributes, Value};
 /// HTML input element.
 ///
 /// Represents the structure of an HTML `<input>` element with optional

--- a/crates/form/src/lib.rs
+++ b/crates/form/src/lib.rs
@@ -80,5 +80,5 @@ pub use select_option::{SelectOption, SelectOptionBuilder};
 pub use select_type::SelectType;
 pub use textarea_element::{TextareaElement, TextareaElementBuilder};
 // Re-export core types
-pub use walrs_validation::{Attributes, Value, ValueExt};
 pub use walrs_inputfilter::{Field, FieldBuilder, FieldFilter, FormViolations, IndexMap};
+pub use walrs_validation::{Attributes, Value, ValueExt};

--- a/crates/form/src/select_element.rs
+++ b/crates/form/src/select_element.rs
@@ -19,9 +19,9 @@ use crate::select_type::SelectType;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use walrs_validation::{Attributes, Value};
 use walrs_inputfilter::Field;
 use walrs_validation::Violations;
+use walrs_validation::{Attributes, Value};
 /// HTML select element.
 ///
 /// Represents a `<select>` element with options. Supports both single and

--- a/crates/form/src/textarea_element.rs
+++ b/crates/form/src/textarea_element.rs
@@ -14,9 +14,9 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use walrs_validation::{Attributes, Value};
 use walrs_inputfilter::Field;
 use walrs_validation::Violations;
+use walrs_validation::{Attributes, Value};
 /// HTML textarea element.
 ///
 /// Represents a `<textarea>` element for multi-line text input.

--- a/crates/graph/src/graph/graph.rs
+++ b/crates/graph/src/graph/graph.rs
@@ -138,9 +138,7 @@ impl Graph {
 
   /// Removes a vertex from the graph.
   pub fn remove_vertex(&mut self, v: usize) -> Result<&mut Self, String> {
-    if let Err(err) = self.validate_vertex(v) {
-      return Err(err);
-    }
+    self.validate_vertex(v)?;
 
     let target_v_adj = self.adj(v).unwrap();
 
@@ -227,17 +225,14 @@ impl Graph {
     if len == 0 || v >= len || w >= len {
       return false;
     }
-    self._adj_lists[v].binary_search(&w).map_or(false, |_| true)
+    self._adj_lists[v].binary_search(&w).is_ok_and(|_| true)
   }
 
   /// Removes edge `v` to `w` from graph.
   pub fn remove_edge(&mut self, v: usize, w: usize) -> Result<usize, String> {
-    if let Err(err) = self
+    self
       .validate_vertex(v)
-      .and_then(|_| self.validate_vertex(w))
-    {
-      return Err(err);
-    }
+      .and_then(|_| self.validate_vertex(w))?;
     let adj = &mut self._adj_lists;
 
     let adj_v = &mut adj[v];
@@ -268,10 +263,7 @@ impl Graph {
   pub fn validate_vertex(&self, v: usize) -> Result<usize, String> {
     let len = self._adj_lists.len();
     if v >= len {
-      return Err(format!(
-        "{}",
-        invalid_vertex_msg(v, if len > 0 { len - 1 } else { 0 })
-      ));
+      return Err(invalid_vertex_msg(v, if len > 0 { len - 1 } else { 0 }).to_string());
     }
     Ok(v)
   }

--- a/crates/graph/src/graph/symbol_graph.rs
+++ b/crates/graph/src/graph/symbol_graph.rs
@@ -93,7 +93,7 @@ where
   pub fn adj(&self, symbol_name: &str) -> Result<Vec<&T>, String> {
     if let Some(i) = self.index(symbol_name) {
       let indices = self._graph.adj(i)?;
-      Ok(self.vertices(&indices))
+      Ok(self.vertices(indices))
     } else {
       Err(format!(
         "Symbol \"{}\" doesn't exist in symbol graph",
@@ -180,9 +180,7 @@ where
         let v2 = self.add_vertex(w);
 
         // Add edges
-        if let Err(err) = self._graph.add_edge(v1, v2) {
-          return Err(err);
-        }
+        self._graph.add_edge(v1, v2)?;
       }
     }
 

--- a/crates/inputfilter/examples/field_basics.rs
+++ b/crates/inputfilter/examples/field_basics.rs
@@ -5,8 +5,8 @@
 //!
 //! Run with: `cargo run --example field_basics`
 
-use walrs_inputfilter::field::FieldBuilder;
 use walrs_filter::FilterOp;
+use walrs_inputfilter::field::FieldBuilder;
 use walrs_validation::Rule;
 
 fn main() {

--- a/crates/inputfilter/examples/field_filter.rs
+++ b/crates/inputfilter/examples/field_filter.rs
@@ -6,9 +6,9 @@
 //! Run with: `cargo run --example field_filter`
 
 use indexmap::IndexMap;
-use walrs_validation::Value;
 use walrs_inputfilter::field::FieldBuilder;
 use walrs_inputfilter::field_filter::{CrossFieldRule, CrossFieldRuleType, FieldFilter};
+use walrs_validation::Value;
 use walrs_validation::{Rule, Rule::*};
 
 fn main() {
@@ -23,12 +23,17 @@ fn main() {
       "email",
       FieldBuilder::<Value>::default()
         .name("email")
-          // Note: Rules that match html attributes will be exported when serializing to JSON;
-          // E.g., json output will resemble:
-          // { "type": "email", "name": "email", "required": true, "minlength": 5, "maxlength": 128 }
-          // Allows rules to be sent to front-end clients so that they're shared
-          // instead of isolated.
-        .rule(All(vec![Required, MinLength(5), MaxLength(128), Email(Default::default())]))
+        // Note: Rules that match html attributes will be exported when serializing to JSON;
+        // E.g., json output will resemble:
+        // { "type": "email", "name": "email", "required": true, "minlength": 5, "maxlength": 128 }
+        // Allows rules to be sent to front-end clients so that they're shared
+        // instead of isolated.
+        .rule(All(vec![
+          Required,
+          MinLength(5),
+          MaxLength(128),
+          Email(Default::default()),
+        ]))
         .build()
         .unwrap(),
     )

--- a/crates/inputfilter/examples/filters.rs
+++ b/crates/inputfilter/examples/filters.rs
@@ -52,8 +52,11 @@ fn main() {
 
   // Example 6: Chain filter (multiple filters in sequence)
   println!("\n6. Chain filter (Trim -> Lowercase -> StripTags):");
-  let chain_filter =
-    FilterOp::<String>::Chain(vec![FilterOp::Trim, FilterOp::Lowercase, FilterOp::StripTags]);
+  let chain_filter = FilterOp::<String>::Chain(vec![
+    FilterOp::Trim,
+    FilterOp::Lowercase,
+    FilterOp::StripTags,
+  ]);
   let input = "  <B>HELLO</B> World  ";
   let result = chain_filter.apply_ref(input);
   println!("   Input:  '{}'", input);

--- a/crates/inputfilter/examples/json_serialization.rs
+++ b/crates/inputfilter/examples/json_serialization.rs
@@ -5,10 +5,10 @@
 //!
 //! Run with: `cargo run --example json_serialization`
 
-use walrs_validation::Value;
-use walrs_inputfilter::field::{Field, FieldBuilder};
 use walrs_filter::FilterOp;
+use walrs_inputfilter::field::{Field, FieldBuilder};
 use walrs_validation::Rule;
+use walrs_validation::Value;
 
 fn main() {
   println!("=== JSON Serialization Examples ===\n");
@@ -69,7 +69,10 @@ fn main() {
 
   // Example 5: Serialize Rule::Any
   println!("\n5. Serialize Rule::Any:");
-  let any_rule = Rule::<String>::Any(vec![Rule::Email(Default::default()), Rule::pattern(r"^\d{10}$").unwrap()]);
+  let any_rule = Rule::<String>::Any(vec![
+    Rule::Email(Default::default()),
+    Rule::pattern(r"^\d{10}$").unwrap(),
+  ]);
 
   let json = serde_json::to_string_pretty(&any_rule).unwrap();
   println!("{}", json);

--- a/crates/inputfilter/examples/localized_messages.rs
+++ b/crates/inputfilter/examples/localized_messages.rs
@@ -21,24 +21,27 @@ fn main() {
   // may not contain them depending on how the rule is composed.
   let username_rule = Rule::<String>::MinLength(3)
     .and(Rule::MaxLength(20))
-    .with_message_provider(|ctx| {
-      let (min, max) = (3, 20); // Hardcode the constraint values
-      match ctx.locale {
-        Some("es") => format!(
-          "El nombre de usuario debe tener entre {} y {} caracteres",
-          min, max
-        ),
-        Some("fr") => format!(
-          "Le nom d'utilisateur doit contenir entre {} et {} caractères",
-          min, max
-        ),
-        Some("de") => format!(
-          "Der Benutzername muss zwischen {} und {} Zeichen lang sein",
-          min, max
-        ),
-        _ => format!("Username must be between {} and {} characters", min, max),
-      }
-    }, None);
+    .with_message_provider(
+      |ctx| {
+        let (min, max) = (3, 20); // Hardcode the constraint values
+        match ctx.locale {
+          Some("es") => format!(
+            "El nombre de usuario debe tener entre {} y {} caracteres",
+            min, max
+          ),
+          Some("fr") => format!(
+            "Le nom d'utilisateur doit contenir entre {} et {} caractères",
+            min, max
+          ),
+          Some("de") => format!(
+            "Der Benutzername muss zwischen {} und {} Zeichen lang sein",
+            min, max
+          ),
+          _ => format!("Username must be between {} and {} characters", min, max),
+        }
+      },
+      None,
+    );
 
   // Test with different locales
   let test_value = "ab".to_string(); // Too short
@@ -109,33 +112,49 @@ fn main() {
   println!("\n--- Example 2: Password Field with Multiple Rules ---\n");
 
   let password_rule = Rule::<String>::Required
-    .with_message_provider(|ctx| match ctx.locale {
-      Some("es") => "La contraseña es obligatoria".to_string(),
-      Some("fr") => "Le mot de passe est requis".to_string(),
-      _ => "Password is required".to_string(),
-    }, None)
-    .and(Rule::<String>::MinLength(8).with_message_provider(|ctx| {
-      // Hardcode constraint value for the message
-      let min = 8;
-      match ctx.locale {
-        Some("es") => format!("La contraseña debe tener al menos {} caracteres", min),
-        Some("fr") => format!("Le mot de passe doit contenir au moins {} caractères", min),
-        _ => format!("Password must be at least {} characters", min),
-      }
-    }, None))
+    .with_message_provider(
+      |ctx| match ctx.locale {
+        Some("es") => "La contraseña es obligatoria".to_string(),
+        Some("fr") => "Le mot de passe est requis".to_string(),
+        _ => "Password is required".to_string(),
+      },
+      None,
+    )
+    .and(Rule::<String>::MinLength(8).with_message_provider(
+      |ctx| {
+        // Hardcode constraint value for the message
+        let min = 8;
+        match ctx.locale {
+          Some("es") => format!("La contraseña debe tener al menos {} caracteres", min),
+          Some("fr") => format!("Le mot de passe doit contenir au moins {} caractères", min),
+          _ => format!("Password must be at least {} characters", min),
+        }
+      },
+      None,
+    ))
     .and(
-      Rule::<String>::pattern(r"[A-Z]").unwrap().with_message_provider(|ctx| match ctx.locale {
-        Some("es") => "La contraseña debe contener al menos una letra mayúscula".to_string(),
-        Some("fr") => "Le mot de passe doit contenir au moins une lettre majuscule".to_string(),
-        _ => "Password must contain at least one uppercase letter".to_string(),
-      }, None),
+      Rule::<String>::pattern(r"[A-Z]")
+        .unwrap()
+        .with_message_provider(
+          |ctx| match ctx.locale {
+            Some("es") => "La contraseña debe contener al menos una letra mayúscula".to_string(),
+            Some("fr") => "Le mot de passe doit contenir au moins une lettre majuscule".to_string(),
+            _ => "Password must contain at least one uppercase letter".to_string(),
+          },
+          None,
+        ),
     )
     .and(
-      Rule::<String>::pattern(r"[0-9]").unwrap().with_message_provider(|ctx| match ctx.locale {
-        Some("es") => "La contraseña debe contener al menos un número".to_string(),
-        Some("fr") => "Le mot de passe doit contenir au moins un chiffre".to_string(),
-        _ => "Password must contain at least one number".to_string(),
-      }, None),
+      Rule::<String>::pattern(r"[0-9]")
+        .unwrap()
+        .with_message_provider(
+          |ctx| match ctx.locale {
+            Some("es") => "La contraseña debe contener al menos un número".to_string(),
+            Some("fr") => "Le mot de passe doit contenir au moins un chiffre".to_string(),
+            _ => "Password must contain at least one number".to_string(),
+          },
+          None,
+        ),
     );
 
   // Test with a weak password
@@ -194,7 +213,10 @@ fn main() {
 
   let email_rule = Rule::<String>::Required
     .with_message_provider(|ctx| translate("email.required", ctx.locale), None)
-    .and(Rule::<String>::Email(Default::default()).with_message_provider(|ctx| translate("email.invalid", ctx.locale), None));
+    .and(
+      Rule::<String>::Email(Default::default())
+        .with_message_provider(|ctx| translate("email.invalid", ctx.locale), None),
+    );
 
   let invalid_email = "not-an-email".to_string();
 
@@ -226,12 +248,16 @@ fn main() {
   // without creating new fields. You can use Rule::with_locale to set the
   // locale on the rule, then validate via the ValidateRef trait.
 
-  let age_rule =
-    Rule::<String>::pattern(r"^\d+$").unwrap().with_message_provider(|ctx| match ctx.locale {
-      Some("es") => format!("'{}' no es un número válido", ctx.value),
-      Some("fr") => format!("'{}' n'est pas un nombre valide", ctx.value),
-      _ => format!("'{}' is not a valid number", ctx.value),
-    }, None);
+  let age_rule = Rule::<String>::pattern(r"^\d+$")
+    .unwrap()
+    .with_message_provider(
+      |ctx| match ctx.locale {
+        Some("es") => format!("'{}' no es un número válido", ctx.value),
+        Some("fr") => format!("'{}' n'est pas un nombre valide", ctx.value),
+        _ => format!("'{}' is not a valid number", ctx.value),
+      },
+      None,
+    );
 
   let invalid_age = "twenty";
 

--- a/crates/inputfilter/examples/rule_composition.rs
+++ b/crates/inputfilter/examples/rule_composition.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example rule_composition`
 
-use walrs_validation::{Condition, Rule, Validate, ValidateRef, UriOptions, IpOptions};
+use walrs_validation::{Condition, IpOptions, Rule, UriOptions, Validate, ValidateRef};
 
 fn main() {
   println!("=== Rule<T> Composition Examples ===\n");
@@ -20,10 +20,7 @@ fn main() {
     "   Required rule on 'hello': {:?}",
     required.validate_ref("hello")
   );
-  println!(
-    "   Required rule on '': {:?}",
-    required.validate_ref("")
-  );
+  println!("   Required rule on '': {:?}", required.validate_ref(""));
   println!(
     "   MinLength(3) on 'hi': {:?}",
     min_length.validate_ref("hi")
@@ -72,26 +69,21 @@ fn main() {
 
   // Example 4: Using .or() combinator (Any must pass)
   println!("\n4. Using .or() combinator (Any must pass):");
-  let contact_rule = Rule::<String>::Email(Default::default()).or(Rule::pattern(r"^\d{3}-\d{4}$").unwrap());
+  let contact_rule =
+    Rule::<String>::Email(Default::default()).or(Rule::pattern(r"^\d{3}-\d{4}$").unwrap());
 
   println!(
     "   'user@example.com': {:?}",
     contact_rule.validate_ref("user@example.com")
   );
-  println!(
-    "   '555-1234': {:?}",
-    contact_rule.validate_ref("555-1234")
-  );
-  println!(
-    "   'invalid': {:?}",
-    contact_rule.validate_ref("invalid")
-  );
+  println!("   '555-1234': {:?}", contact_rule.validate_ref("555-1234"));
+  println!("   'invalid': {:?}", contact_rule.validate_ref("invalid"));
 
   // Example 5: Using Rule::Any directly
   println!("\n5. Using Rule::Any directly:");
   let flexible_id = Rule::<String>::Any(vec![
     Rule::Email(Default::default()),
-    Rule::pattern(r"^\d{5,10}$").unwrap(), // Numeric ID
+    Rule::pattern(r"^\d{5,10}$").unwrap(),      // Numeric ID
     Rule::pattern(r"^[A-Z]{2}\d{6}$").unwrap(), // Code format
   ]);
 
@@ -99,18 +91,9 @@ fn main() {
     "   'user@example.com': {:?}",
     flexible_id.validate_ref("user@example.com")
   );
-  println!(
-    "   '123456': {:?}",
-    flexible_id.validate_ref("123456")
-  );
-  println!(
-    "   'AB123456': {:?}",
-    flexible_id.validate_ref("AB123456")
-  );
-  println!(
-    "   'invalid': {:?}",
-    flexible_id.validate_ref("invalid")
-  );
+  println!("   '123456': {:?}", flexible_id.validate_ref("123456"));
+  println!("   'AB123456': {:?}", flexible_id.validate_ref("AB123456"));
+  println!("   'invalid': {:?}", flexible_id.validate_ref("invalid"));
 
   // Example 6: Negation with .not()
   println!("\n6. Negation with .not():");
@@ -205,18 +188,9 @@ fn main() {
   let pin_code = Rule::<String>::ExactLength(4);
   let zip_code = Rule::<String>::ExactLength(5);
 
-  println!(
-    "   PIN(4) on '123': {:?}",
-    pin_code.validate_ref("123")
-  );
-  println!(
-    "   PIN(4) on '1234': {:?}",
-    pin_code.validate_ref("1234")
-  );
-  println!(
-    "   ZIP(5) on '12345': {:?}",
-    zip_code.validate_ref("12345")
-  );
+  println!("   PIN(4) on '123': {:?}", pin_code.validate_ref("123"));
+  println!("   PIN(4) on '1234': {:?}", pin_code.validate_ref("1234"));
+  println!("   ZIP(5) on '12345': {:?}", zip_code.validate_ref("12345"));
 
   // Example 12: OneOf for enum-like values
   println!("\n12. OneOf for enum-like values:");
@@ -250,8 +224,16 @@ fn main() {
   println!("\n14. Validating with combined rules:");
   let strict_rule = Rule::<String>::Required
     .and(Rule::MinLength(8))
-    .and(Rule::pattern(r"[0-9]").unwrap().with_message("Must contain a number"))
-    .and(Rule::pattern(r"[A-Z]").unwrap().with_message("Must contain uppercase"));
+    .and(
+      Rule::pattern(r"[0-9]")
+        .unwrap()
+        .with_message("Must contain a number"),
+    )
+    .and(
+      Rule::pattern(r"[A-Z]")
+        .unwrap()
+        .with_message("Must contain uppercase"),
+    );
 
   match strict_rule.validate_ref("abc") {
     Ok(()) => println!("   All rules passed!"),
@@ -298,10 +280,7 @@ fn main() {
   );
 
   let all_ip = Rule::<String>::Ip(IpOptions::default());
-  println!(
-    "   Ip(default) on '::1': {:?}",
-    all_ip.validate_ref("::1")
-  );
+  println!("   Ip(default) on '::1': {:?}", all_ip.validate_ref("::1"));
   println!(
     "   Ip(default) on '[::1]': {:?}",
     all_ip.validate_ref("[::1]")

--- a/crates/inputfilter/src/field.rs
+++ b/crates/inputfilter/src/field.rs
@@ -4,9 +4,9 @@
 //! rules for a single form field. It replaces the old `Input`/`RefInput` API with
 //! a unified, serializable design.
 
-use walrs_filter::{FilterOp, TryFilterOp};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use walrs_filter::{FilterOp, TryFilterOp};
 use walrs_validation::Value;
 use walrs_validation::{Rule, ValidateRef, Violation, Violations};
 
@@ -209,7 +209,10 @@ impl Field<String> {
         // Apply locale to rule if set, then validate via trait method
         // @todo `locale` should be set directly on `rule`.
         let result = if let Some(locale) = &self.locale {
-          rule.clone().with_locale(locale.as_ref()).validate_ref(value)
+          rule
+            .clone()
+            .with_locale(locale.as_ref())
+            .validate_ref(value)
         } else {
           rule.validate_ref(value)
         };
@@ -310,7 +313,10 @@ impl Field<Value> {
     match &self.rule {
       Some(rule) => {
         let result = if let Some(locale) = &self.locale {
-          rule.clone().with_locale(locale.as_ref()).validate_ref(value)
+          rule
+            .clone()
+            .with_locale(locale.as_ref())
+            .validate_ref(value)
         } else {
           rule.validate_ref(value)
         };
@@ -333,7 +339,10 @@ impl Field<Value> {
     match &self.rule {
       Some(rule) => {
         let result = if let Some(locale) = &self.locale {
-          rule.clone().with_locale(locale.as_ref()).validate_value(value)
+          rule
+            .clone()
+            .with_locale(locale.as_ref())
+            .validate_value(value)
         } else {
           rule.validate_value(value)
         };
@@ -374,7 +383,11 @@ impl Field<String> {
       Some(rule) => {
         use walrs_validation::ValidateRefAsync;
         let result = if let Some(locale) = &self.locale {
-          rule.clone().with_locale(locale.as_ref()).validate_ref_async(value).await
+          rule
+            .clone()
+            .with_locale(locale.as_ref())
+            .validate_ref_async(value)
+            .await
         } else {
           rule.validate_ref_async(value).await
         };
@@ -412,7 +425,11 @@ impl Field<Value> {
       Some(rule) => {
         use walrs_validation::ValidateRefAsync;
         let result = if let Some(locale) = &self.locale {
-          rule.clone().with_locale(locale.as_ref()).validate_ref_async(value).await
+          rule
+            .clone()
+            .with_locale(locale.as_ref())
+            .validate_ref_async(value)
+            .await
         } else {
           rule.validate_ref_async(value).await
         };
@@ -705,10 +722,7 @@ mod tests {
       .unwrap();
 
     // Happy path: trim -> try_filter passes -> validation passes
-    assert_eq!(
-      field.process("  hello  ".to_string()).unwrap(),
-      "hello"
-    );
+    assert_eq!(field.process("  hello  ".to_string()).unwrap(), "hello");
 
     // Try filter fails (empty after trim)
     let err = field.process("     ".to_string()).unwrap_err();
@@ -724,9 +738,7 @@ mod tests {
   fn test_string_field_process_try_filter_short_circuits() {
     let field = FieldBuilder::<String>::default()
       .try_filters(vec![
-        TryFilterOp::TryCustom(Arc::new(|_| {
-          Err(FilterError::new("first fails"))
-        })),
+        TryFilterOp::TryCustom(Arc::new(|_| Err(FilterError::new("first fails")))),
         TryFilterOp::TryCustom(Arc::new(|_| {
           panic!("should not reach second filter");
         })),
@@ -767,12 +779,8 @@ mod tests {
       .build()
       .unwrap();
 
-    assert!(field
-      .try_filter(Value::Str("hello".to_string()))
-      .is_ok());
-    assert!(field
-      .try_filter(Value::Str("".to_string()))
-      .is_err());
+    assert!(field.try_filter(Value::Str("hello".to_string())).is_ok());
+    assert!(field.try_filter(Value::Str("".to_string())).is_err());
   }
 
   #[test]

--- a/crates/inputfilter/src/field_filter.rs
+++ b/crates/inputfilter/src/field_filter.rs
@@ -6,13 +6,13 @@
 
 use crate::field::Field;
 use crate::form_violations::FormViolations;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use indexmap::IndexMap;
 use std::fmt::{self, Debug};
 use std::sync::Arc;
-use walrs_validation::{Value, ValueExt};
 use walrs_validation::{Condition, RuleResult, Violation, ViolationType};
+use walrs_validation::{Value, ValueExt};
 
 /// Multi-field validation configuration.
 ///
@@ -513,10 +513,7 @@ impl FieldFilter {
   ///
   /// Works like [`validate`](Self::validate) but supports `Rule::CustomAsync`
   /// in field rules and `CrossFieldRuleType::CustomAsync` in cross-field rules.
-  pub async fn validate_async(
-    &self,
-    data: &IndexMap<String, Value>,
-  ) -> Result<(), FormViolations> {
+  pub async fn validate_async(&self, data: &IndexMap<String, Value>) -> Result<(), FormViolations> {
     let mut violations = FormViolations::new();
 
     // Validate individual fields (async)
@@ -712,7 +709,10 @@ mod tests {
     let data = make_data(&[("email", Value::Str("  TEST@EXAMPLE.COM  ".to_string()))]);
     let filtered = field_filter.filter(data);
 
-    assert_eq!(filtered.get("email").unwrap(), &Value::Str("test@example.com".to_string()));
+    assert_eq!(
+      filtered.get("email").unwrap(),
+      &Value::Str("test@example.com".to_string())
+    );
   }
 
   #[test]

--- a/crates/inputfilter/src/lib.rs
+++ b/crates/inputfilter/src/lib.rs
@@ -68,8 +68,8 @@ pub use indexmap::IndexMap;
 
 // Re-export types from walrs_validation
 pub use walrs_validation::{
-  Attributes, IsEmpty, Message, MessageContext, MessageParams, Value, ValueExt,
-  Violation, ViolationMessage, ViolationType, Violations,
+  Attributes, IsEmpty, Message, MessageContext, MessageParams, Value, ValueExt, Violation,
+  ViolationMessage, ViolationType, Violations,
 };
 
 #[cfg(feature = "async")]

--- a/crates/inputfilter/tests/async_inputfilter.rs
+++ b/crates/inputfilter/tests/async_inputfilter.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "async")]
 
-use std::sync::Arc;
 use indexmap::IndexMap;
+use std::sync::Arc;
 use walrs_inputfilter::{
-  CrossFieldRule, CrossFieldRuleType, Field, FieldBuilder, FieldFilter,
-  Value, Violation, ViolationType,
+  CrossFieldRule, CrossFieldRuleType, Field, FieldBuilder, FieldFilter, Value, Violation,
+  ViolationType,
 };
 use walrs_validation::Rule;
 
@@ -59,13 +59,19 @@ async fn string_field_with_custom_async_rule() {
   let rule = Rule::<String>::custom_async(Arc::new(|value: &String| {
     Box::pin(async move {
       if value == "forbidden" {
-        Err(Violation::new(ViolationType::CustomError, "forbidden value"))
+        Err(Violation::new(
+          ViolationType::CustomError,
+          "forbidden value",
+        ))
       } else {
         Ok(())
       }
     })
   }));
-  let field = FieldBuilder::<String>::default().rule(rule).build().unwrap();
+  let field = FieldBuilder::<String>::default()
+    .rule(rule)
+    .build()
+    .unwrap();
 
   assert!(field.validate_ref_async("ok").await.is_ok());
   assert!(field.validate_ref_async("forbidden").await.is_err());
@@ -208,15 +214,9 @@ async fn field_filter_with_async_cross_field_rule() {
     fields: vec!["email".to_string()],
     rule: CrossFieldRuleType::CustomAsync(Arc::new(|data| {
       Box::pin(async move {
-        let email = data
-          .get("email")
-          .and_then(|v| v.as_str())
-          .unwrap_or("");
+        let email = data.get("email").and_then(|v| v.as_str()).unwrap_or("");
         if email.contains("@blocked.com") {
-          Err(Violation::new(
-            ViolationType::CustomError,
-            "blocked domain",
-          ))
+          Err(Violation::new(ViolationType::CustomError, "blocked domain"))
         } else {
           Ok(())
         }
@@ -284,10 +284,7 @@ async fn field_filter_mixed_sync_and_async_rules() {
   ff.add_cross_field_rule(CrossFieldRule {
     name: Some("one_required".into()),
     fields: vec!["age".to_string(), "username".to_string()],
-    rule: CrossFieldRuleType::OneOfRequired(vec![
-      "age".to_string(),
-      "username".to_string(),
-    ]),
+    rule: CrossFieldRuleType::OneOfRequired(vec!["age".to_string(), "username".to_string()]),
   });
 
   let data = make_data(&[

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -82,16 +82,14 @@ fn validate_ip(value: &str, opts: &IpOptions) -> RuleResult {
   }
 
   // Try IPv4
-  if opts.allow_ipv4
-    && inner.parse::<std::net::Ipv4Addr>().is_ok() {
-      return Ok(());
-    }
+  if opts.allow_ipv4 && inner.parse::<std::net::Ipv4Addr>().is_ok() {
+    return Ok(());
+  }
 
   // Try IPv6
-  if opts.allow_ipv6
-    && inner.parse::<std::net::Ipv6Addr>().is_ok() {
-      return Ok(());
-    }
+  if opts.allow_ipv6 && inner.parse::<std::net::Ipv6Addr>().is_ok() {
+    return Ok(());
+  }
 
   Err(Violation::invalid_ip())
 }


### PR DESCRIPTION
Closes #183

Ran `cargo fmt --all` across the entire workspace for consistent formatting. Also includes minor clippy auto-fixes.

**Changes:** 24 files across `acl`, `form`, `graph`, `inputfilter`, and `validation` crates.

**Verification:**
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `cargo clippy --workspace` ✅
- `cargo build --examples` ✅