### PR TITLE
refactor: #195 rename Filterable→Fieldset, FieldViolations→FieldsetViolations, process→clean

### DIFF
--- a/crates/fieldfilter/DESIGN.md
+++ b/crates/fieldfilter/DESIGN.md
@@ -34,7 +34,7 @@ walrs_validation → walrs_filter      → walrs_fieldfilter → walrs_form
 
 - **`FieldFilter`** — Multi-field form-level pipeline. Holds an
   `IndexMap<String, Field<Value>>` plus a list of `CrossFieldRule`s.
-  Provides `filter()`, `try_filter()`, `validate()`, and `process()`.
+  Provides `filter()`, `try_filter()`, `validate()`, and `clean()`.
 
 - **`CrossFieldRule` / `CrossFieldRuleType`** — Serializable cross-field
   validation (FieldsEqual, RequiredIf, RequiredUnless, OneOfRequired,
@@ -46,7 +46,7 @@ walrs_validation → walrs_filter      → walrs_fieldfilter → walrs_form
 
 ### Processing Pipeline
 
-`FieldFilter.process(data)` runs:
+`FieldFilter.clean(data)` runs:
 
 1. **`filter(data)`** — applies each field's `FilterOp` filters in order.
 2. **`try_filter(data)`** — applies each field's `TryFilterOp` filters;

--- a/crates/fieldfilter/examples/field_basics.rs
+++ b/crates/fieldfilter/examples/field_basics.rs
@@ -71,10 +71,10 @@ fn main() {
   println!("   Filtered: '{}'", filtered);
   println!("   Validation: {:?}", email_field.validate_ref(&filtered));
 
-  // Example 4: Process (filter + validate in one step)
-  println!("\n4. Using process() for filter + validate:");
+  // Example 4: Clean (filter + validate in one step)
+  println!("\n4. Using clean() for filter + validate:");
   let input = "  ADMIN@COMPANY.ORG  ".to_string();
-  match email_field.process(input.clone()) {
+  match email_field.clean(input.clone()) {
     Ok(result) => println!("   Input '{}' -> Result: '{}'", input, result),
     Err(violations) => println!("   Input '{}' -> Errors: {:?}", input, violations),
   }

--- a/crates/fieldfilter/src/field.rs
+++ b/crates/fieldfilter/src/field.rs
@@ -52,9 +52,9 @@ use walrs_validation::{Rule, ValidateRef, Violation, Violations};
 ///     .build()
 ///     .unwrap();
 ///
-/// // process() applies infallible filters, then fallible filters, then validates
-/// assert!(field.process("  hello  ".to_string()).is_ok());
-/// assert!(field.process("  \0bad  ".to_string()).is_err());
+/// // clean() applies infallible filters, then fallible filters, then validates
+/// assert!(field.clean("  hello  ".to_string()).is_ok());
+/// assert!(field.clean("  \0bad  ".to_string()).is_err());
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize, Builder)]
 #[builder(setter(into, strip_option), default)]
@@ -265,7 +265,7 @@ impl Field<String> {
   ///
   /// Applies infallible filters first, then fallible filters, then validates.
   /// Returns `Ok(filtered_value)` if all steps pass, or `Err(Violations)`.
-  pub fn process(&self, value: String) -> Result<String, Violations> {
+  pub fn clean(&self, value: String) -> Result<String, Violations> {
     let filtered = self.filter(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref(&filtered)?;
@@ -274,9 +274,9 @@ impl Field<String> {
 
   /// Filter a `&str` and then validate the result.
   ///
-  /// Like [`process`](Self::process) but starts from a `&str` reference,
+  /// Like [`clean`](Self::clean) but starts from a `&str` reference,
   /// avoiding the need for the caller to allocate a `String` up-front.
-  pub fn process_ref(&self, value: &str) -> Result<String, Violations> {
+  pub fn clean_ref(&self, value: &str) -> Result<String, Violations> {
     let filtered = self.filter_ref(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref(&filtered)?;
@@ -413,7 +413,7 @@ impl Field<Value> {
   ///
   /// Applies infallible filters first, then fallible filters, then validates.
   /// Returns `Ok(filtered_value)` if all steps pass, or `Err(Violations)`.
-  pub fn process(&self, value: Value) -> Result<Value, Violations> {
+  pub fn clean(&self, value: Value) -> Result<Value, Violations> {
     let filtered = self.filter(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref(&filtered)?;
@@ -462,15 +462,15 @@ impl Field<String> {
   /// Filter the value synchronously (infallible + fallible), then validate asynchronously.
   ///
   /// Returns `Ok(filtered_value)` if all steps pass, or `Err(Violations)`.
-  pub async fn process_async(&self, value: String) -> Result<String, Violations> {
+  pub async fn clean_async(&self, value: String) -> Result<String, Violations> {
     let filtered = self.filter(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref_async(&filtered).await?;
     Ok(filtered)
   }
 
-  /// Like [`process_async`](Self::process_async) but starts from a `&str` reference.
-  pub async fn process_ref_async(&self, value: &str) -> Result<String, Violations> {
+  /// Like [`clean_async`](Self::clean_async) but starts from a `&str` reference.
+  pub async fn clean_ref_async(&self, value: &str) -> Result<String, Violations> {
     let filtered = self.filter_ref(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref_async(&filtered).await?;
@@ -510,7 +510,7 @@ impl Field<Value> {
   }
 
   /// Filter the value synchronously (infallible + fallible), then validate asynchronously.
-  pub async fn process_async(&self, value: Value) -> Result<Value, Violations> {
+  pub async fn clean_async(&self, value: Value) -> Result<Value, Violations> {
     let filtered = self.filter(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref_async(&filtered).await?;
@@ -603,14 +603,14 @@ mod tests {
   }
 
   #[test]
-  fn test_string_field_process() {
+  fn test_string_field_clean() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .rule(Rule::MinLength(3))
       .build()
       .unwrap();
 
-    let result = field.process("  hello  ".to_string());
+    let result = field.clean("  hello  ".to_string());
     assert_eq!(result.unwrap(), "hello");
   }
 
@@ -768,7 +768,7 @@ mod tests {
   }
 
   #[test]
-  fn test_string_field_process_with_try_filters() {
+  fn test_string_field_clean_with_try_filters() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .try_filters(vec![TryFilterOp::TryCustom(Arc::new(|s: String| {
@@ -783,20 +783,20 @@ mod tests {
       .unwrap();
 
     // Happy path: trim -> try_filter passes -> validation passes
-    assert_eq!(field.process("  hello  ".to_string()).unwrap(), "hello");
+    assert_eq!(field.clean("  hello  ".to_string()).unwrap(), "hello");
 
     // Try filter fails (empty after trim)
-    let err = field.process("     ".to_string()).unwrap_err();
+    let err = field.clean("     ".to_string()).unwrap_err();
     assert_eq!(err.len(), 1);
     assert!(err[0].message().contains("empty after trimming"));
 
     // Try filter passes but validation fails (too short)
-    let err = field.process("  hi  ".to_string()).unwrap_err();
+    let err = field.clean("  hi  ".to_string()).unwrap_err();
     assert_eq!(err.len(), 1);
   }
 
   #[test]
-  fn test_string_field_process_try_filter_short_circuits() {
+  fn test_string_field_clean_try_filter_short_circuits() {
     let field = FieldBuilder::<String>::default()
       .try_filters(vec![
         TryFilterOp::TryCustom(Arc::new(|_| Err(FilterError::new("first fails")))),
@@ -807,7 +807,7 @@ mod tests {
       .build()
       .unwrap();
 
-    let err = field.process("hello".to_string()).unwrap_err();
+    let err = field.clean("hello".to_string()).unwrap_err();
     assert!(err[0].message().contains("first fails"));
   }
 
@@ -865,7 +865,7 @@ mod tests {
   }
 
   #[test]
-  fn test_value_field_process_with_try_filters() {
+  fn test_value_field_clean_with_try_filters() {
     let field = FieldBuilder::<Value>::default()
       .filters(vec![FilterOp::Trim])
       .try_filters(vec![TryFilterOp::TryCustom(Arc::new(|v: Value| {
@@ -882,12 +882,12 @@ mod tests {
 
     // Happy path
     assert_eq!(
-      field.process(Value::Str("  hello  ".to_string())).unwrap(),
+      field.clean(Value::Str("  hello  ".to_string())).unwrap(),
       Value::Str("hello".to_string())
     );
 
     // Try filter fails
-    assert!(field.process(Value::Str("     ".to_string())).is_err());
+    assert!(field.clean(Value::Str("     ".to_string())).is_err());
   }
 
   // ====================================================================
@@ -912,11 +912,11 @@ mod tests {
   }
 
   // ====================================================================
-  // process_ref tests — Field<String>
+  // clean_ref tests — Field<String>
   // ====================================================================
 
   #[test]
-  fn test_string_field_process_ref() {
+  fn test_string_field_clean_ref() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .rule(Rule::MinLength(3))
@@ -924,14 +924,14 @@ mod tests {
       .unwrap();
 
     // Happy path: starts from &str
-    assert_eq!(field.process_ref("  hello  ").unwrap(), "hello");
+    assert_eq!(field.clean_ref("  hello  ").unwrap(), "hello");
 
     // Validation fails
-    assert!(field.process_ref("  hi  ").is_err());
+    assert!(field.clean_ref("  hi  ").is_err());
   }
 
   #[test]
-  fn test_string_field_process_ref_with_try_filters() {
+  fn test_string_field_clean_ref_with_try_filters() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .try_filters(vec![TryFilterOp::TryCustom(Arc::new(|s: String| {
@@ -945,15 +945,15 @@ mod tests {
       .build()
       .unwrap();
 
-    assert_eq!(field.process_ref("  hello  ").unwrap(), "hello");
-    assert!(field.process_ref("     ").is_err()); // empty after trim
-    assert!(field.process_ref("  hi  ").is_err()); // too short
+    assert_eq!(field.clean_ref("  hello  ").unwrap(), "hello");
+    assert!(field.clean_ref("     ").is_err()); // empty after trim
+    assert!(field.clean_ref("  hi  ").is_err()); // too short
   }
 
   #[test]
-  fn test_string_field_process_ref_no_filters_no_rule() {
+  fn test_string_field_clean_ref_no_filters_no_rule() {
     let field = FieldBuilder::<String>::default().build().unwrap();
-    assert_eq!(field.process_ref("hello").unwrap(), "hello");
+    assert_eq!(field.clean_ref("hello").unwrap(), "hello");
   }
 
   // ====================================================================

--- a/crates/fieldfilter/src/field_filter.rs
+++ b/crates/fieldfilter/src/field_filter.rs
@@ -203,7 +203,7 @@ impl FieldFilter {
   }
 
   /// Filters (infallible + fallible) and then validates the data.
-  pub fn process(
+  pub fn clean(
     &self,
     data: IndexMap<String, Value>,
   ) -> Result<IndexMap<String, Value>, FormViolations> {
@@ -571,7 +571,7 @@ impl FieldFilter {
   /// Filters (infallible + fallible) and then validates the data asynchronously.
   ///
   /// Filtering is synchronous (CPU-bound); validation is async.
-  pub async fn process_async(
+  pub async fn clean_async(
     &self,
     data: IndexMap<String, Value>,
   ) -> Result<IndexMap<String, Value>, FormViolations> {
@@ -743,7 +743,7 @@ mod tests {
   }
 
   #[test]
-  fn test_process() {
+  fn test_clean() {
     let mut field_filter = FieldFilter::new();
     field_filter.add_field(
       "email",
@@ -755,7 +755,7 @@ mod tests {
     );
 
     let data = make_data(&[("email", Value::Str("  test@example.com  ".to_string()))]);
-    let result = field_filter.process(data);
+    let result = field_filter.clean(data);
     assert!(result.is_ok());
     assert_eq!(
       result.unwrap().get("email").unwrap(),
@@ -918,7 +918,7 @@ mod tests {
   }
 
   #[test]
-  fn test_field_filter_process_with_try_filters() {
+  fn test_field_filter_clean_with_try_filters() {
     use std::sync::Arc;
     use walrs_filter::{FilterError, TryFilterOp};
 
@@ -942,7 +942,7 @@ mod tests {
 
     // Happy path: trim -> try_filter passes -> validation passes
     let data = make_data(&[("name", Value::Str("  hello  ".to_string()))]);
-    let result = filter.process(data).unwrap();
+    let result = filter.clean(data).unwrap();
     assert_eq!(
       result.get("name").unwrap(),
       &Value::Str("hello".to_string())
@@ -950,7 +950,7 @@ mod tests {
 
     // Try filter fails
     let data = make_data(&[("name", Value::Str("     ".to_string()))]);
-    assert!(filter.process(data).is_err());
+    assert!(filter.clean(data).is_err());
   }
 
   #[test]

--- a/crates/fieldfilter/src/lib.rs
+++ b/crates/fieldfilter/src/lib.rs
@@ -29,8 +29,8 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! // Process (filter + validate) a value
-//! let result = email_field.process("  TEST@EXAMPLE.COM  ".to_string());
+//! // Clean (filter + validate) a value
+//! let result = email_field.clean("  TEST@EXAMPLE.COM  ".to_string());
 //! assert!(result.is_ok());
 //! assert_eq!(result.unwrap(), "test@example.com");
 //!
@@ -49,8 +49,8 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! assert!(encoded_field.process("hello".to_string()).is_ok());
-//! assert!(encoded_field.process("bad\0input".to_string()).is_err());
+//! assert!(encoded_field.clean("hello".to_string()).is_ok());
+//! assert!(encoded_field.clean("bad\0input".to_string()).is_err());
 //! ```
 
 #[macro_use]

--- a/crates/fieldfilter/tests/async_fieldfilter.rs
+++ b/crates/fieldfilter/tests/async_fieldfilter.rs
@@ -78,7 +78,7 @@ async fn string_field_with_custom_async_rule() {
 }
 
 #[tokio::test]
-async fn string_field_process_async() {
+async fn string_field_clean_async() {
   let rule = Rule::<String>::custom_async(Arc::new(|value: &String| {
     Box::pin(async move {
       if value.contains("bad") {
@@ -94,10 +94,10 @@ async fn string_field_process_async() {
     .build()
     .unwrap();
 
-  let result = field.process_async("  good  ".to_string()).await;
+  let result = field.clean_async("  good  ".to_string()).await;
   assert_eq!(result.unwrap(), "good");
 
-  let result = field.process_async("  bad  ".to_string()).await;
+  let result = field.clean_async("  bad  ".to_string()).await;
   assert!(result.is_err());
 }
 
@@ -134,16 +134,16 @@ async fn value_field_validate_ref_async_fails() {
 }
 
 #[tokio::test]
-async fn value_field_process_async() {
+async fn value_field_clean_async() {
   let field = FieldBuilder::<Value>::default()
     .rule(Rule::Required.and(async_not_banned_rule("bad")))
     .build()
     .unwrap();
 
-  let ok = field.process_async(Value::Str("good".into())).await;
+  let ok = field.clean_async(Value::Str("good".into())).await;
   assert!(ok.is_ok());
 
-  let err = field.process_async(Value::Str("bad".into())).await;
+  let err = field.clean_async(Value::Str("bad".into())).await;
   assert!(err.is_err());
 }
 
@@ -233,7 +233,7 @@ async fn field_filter_with_async_cross_field_rule() {
 }
 
 #[tokio::test]
-async fn field_filter_process_async() {
+async fn field_filter_clean_async() {
   let mut ff = FieldFilter::new();
   ff.add_field(
     "name",
@@ -245,13 +245,13 @@ async fn field_filter_process_async() {
   );
 
   let data = make_data(&[("name", Value::Str("  good  ".into()))]);
-  let result = ff.process_async(data).await;
+  let result = ff.clean_async(data).await;
   assert!(result.is_ok());
   let processed = result.unwrap();
   assert_eq!(processed["name"], Value::Str("good".into()));
 
   let data = make_data(&[("name", Value::Str("bad".into()))]);
-  assert!(ff.process_async(data).await.is_err());
+  assert!(ff.clean_async(data).await.is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/md/discussions/value_enum_impedance_mismatch.md
+++ b/md/discussions/value_enum_impedance_mismatch.md
@@ -2,7 +2,7 @@
 
 **Date:** April 8, 2026
 **Issue:** [#90](https://github.com/elycruz/walrs/issues/90) — Assess `Value` enum impedance mismatch with typed serde structs
-**Related:** [#88](https://github.com/elycruz/walrs/issues/88) (Filterable trait), [#87](https://github.com/elycruz/walrs/issues/87) (Filter apply_ref), [#85](https://github.com/elycruz/walrs/issues/85) (Filter enum move)
+**Related:** [#88](https://github.com/elycruz/walrs/issues/88) (Fieldset trait), [#87](https://github.com/elycruz/walrs/issues/87) (Filter apply_ref), [#85](https://github.com/elycruz/walrs/issues/85) (Filter enum move)
 
 ---
 
@@ -27,7 +27,7 @@ correctness risks when used to validate data that is **already statically typed*
 (e.g., `serde::Deserialize` structs in axum/actix handlers).
 
 **Recommendation: Keep dual paths** — retain `Value`-based validation for dynamic
-use cases and introduce the `Filterable` trait (as designed in
+use cases and introduce the `Fieldset` trait (as designed in
 [#88](https://github.com/elycruz/walrs/issues/88)) for compile-time-known structs.
 This is the lowest-risk, highest-value approach. See [§ Recommendation](#recommendation)
 for details.
@@ -164,7 +164,7 @@ data.insert("age".to_string(), Value::from(user.age as u64));
 let result = filter.validate(&data)?;
 
 // Step 5: Extract filtered values back (optional, 5 lines)
-let filtered = filter.process(data)?;
+let filtered = filter.clean(data)?;
 let username = filtered.get("username").unwrap().as_str().unwrap().to_string();
 let email = filtered.get("email").unwrap().as_str().unwrap().to_string();
 let age = filtered.get("age").unwrap().as_u64().unwrap() as u32;
@@ -172,10 +172,10 @@ let age = filtered.get("age").unwrap().as_u64().unwrap() as u32;
 
 **Total: ~25 lines** of boilerplate conversion code (Steps 2–5).
 
-**With proposed `Filterable` trait (from #88 design):**
+**With proposed `Fieldset` trait (from #88 design):**
 
 ```rust
-#[derive(Deserialize, Filterable)]
+#[derive(Deserialize, Fieldset)]
 struct CreateUser {
     #[validate(required, min_length = 3)]
     #[filter(trim, lowercase)]
@@ -190,7 +190,7 @@ struct CreateUser {
 }
 
 // Validate (1 line)
-let validated = user.process()?;
+let validated = user.clean()?;
 ```
 
 **Total: ~1 line** of validation code (annotations are co-located with the struct).
@@ -330,9 +330,9 @@ with `if let Value::Str(s) = value` guards.
 
 ## 4. Refactor Assessment
 
-### 4.1 Can the Filterable Trait Fully Replace Value-Based Validation for Typed Structs?
+### 4.1 Can the Fieldset Trait Fully Replace Value-Based Validation for Typed Structs?
 
-**Yes.** The `Filterable` trait design from [#88](https://github.com/elycruz/walrs/issues/88)
+**Yes.** The `Fieldset` trait design from [#88](https://github.com/elycruz/walrs/issues/88)
 can fully replace `Value`-based validation for compile-time-known structs:
 
 - **Per-field validation:** Each field gets a `Rule<T>` where `T` matches the field's
@@ -366,13 +366,13 @@ at compile time (§2). Removing it would break:
 | `FieldFilter` | None (kept) | Dynamic path preserved |
 | `Rule<Value>` impls | None (kept) | Dynamic path preserved |
 | `Form` + `FormData` | None (kept) | Dynamic path preserved |
-| New `Filterable` trait | New code | Additive — does not change existing APIs |
-| Derive macro crate | New code | `walrs_fieldfilter_derive` (new crate) |
-| User migration | Opt-in | Users can adopt `Filterable` incrementally |
+| New `Fieldset` trait | New code | Additive — does not change existing APIs |
+| Derive macro crate | New code | `walrs_fieldset_derive` (new crate) |
+| User migration | Opt-in | Users can adopt `Fieldset` incrementally |
 
-**Migration cost is zero for existing code** — the `Filterable` trait is purely
+**Migration cost is zero for existing code** — the `Fieldset` trait is purely
 additive. Users choose between the dynamic path (`FieldFilter` + `Value`) and the
-typed path (`Filterable`) based on their use case.
+typed path (`Fieldset`) based on their use case.
 
 ### 4.4 Does the Value Enum Add Maintenance Burden?
 
@@ -388,7 +388,7 @@ The `Rule<Value>` impl delegates to `Rule<String>` methods where possible (e.g.,
 `Value::Str`), which reduces some duplication. However, adding a new rule variant
 still requires updating the `Value` dispatch block.
 
-With the `Filterable` trait in place, the `Rule<Value>` path becomes a **stable
+With the `Fieldset` trait in place, the `Rule<Value>` path becomes a **stable
 maintenance surface** — it only needs updates when new `Rule` variants are added,
 and the typed path handles the common case.
 
@@ -396,7 +396,7 @@ and the typed path handles the common case.
 
 ## Recommendation
 
-### **Keep dual paths** — `Value`-based for dynamic, `Filterable` for typed
+### **Keep dual paths** — `Value`-based for dynamic, `Fieldset` for typed
 
 This is the recommended approach, aligned with the design in
 [#88](https://github.com/elycruz/walrs/issues/88).
@@ -407,13 +407,13 @@ This is the recommended approach, aligned with the design in
    `FormData` continues to work unchanged.
 
 2. **Compile-time safety for the common case:** The vast majority of Rust web
-   applications use typed structs. The `Filterable` trait eliminates all 18
+   applications use typed structs. The `Fieldset` trait eliminates all 18
    `TypeMismatch` runtime error paths for these users.
 
 3. **Dynamic use cases preserved:** Config-driven forms, WASM bridges, and
    serializable validation configs continue to use the `Value` path.
 
-4. **Incremental adoption:** Users can mix both paths — e.g., use `Filterable`
+4. **Incremental adoption:** Users can mix both paths — e.g., use `Fieldset`
    for API handlers and `FieldFilter` for admin panel forms loaded from config.
 
 5. **Reduced maintenance over time:** As the typed path becomes the primary
@@ -421,10 +421,10 @@ This is the recommended approach, aligned with the design in
 
 #### Implementation Priority
 
-1. **Implement `Filterable` trait** in `walrs_fieldfilter` (manual impl first).
-2. **Create `walrs_fieldfilter_derive`** proc-macro crate for `#[derive(Filterable)]`.
+1. **Implement `Fieldset` trait** in `walrs_fieldfilter` (manual impl first).
+2. **Create `walrs_fieldset_derive`** proc-macro crate for `#[derive(Fieldset)]`.
 3. **Resolve #87** (Filter `apply_ref` pattern) — enables efficient `&str`-based
-   filtering in the `Filterable` impl.
+   filtering in the `Fieldset` impl.
 4. **Resolve #85** (Filter enum move) — structural cleanup, not blocking.
 5. **Document migration guide** showing both paths side-by-side.
 
@@ -438,7 +438,7 @@ generation and WASM bridge use cases genuinely require runtime-typed values.
 
 Adding `TryFrom<T>` impls or making `Value` generic would add complexity without
 addressing the fundamental issue: `Value` erases type information that typed structs
-already have. The `Filterable` trait is a cleaner solution because it bypasses
+already have. The `Fieldset` trait is a cleaner solution because it bypasses
 `Value` entirely for typed use cases, rather than trying to make `Value` work better
 with types it shouldn't need to interact with.
 
@@ -446,7 +446,7 @@ with types it shouldn't need to interact with.
 
 ## Appendix: Quantitative Summary
 
-| Metric | `Value` Path | `Filterable` Path | Savings |
+| Metric | `Value` Path | `Fieldset` Path | Savings |
 |--------|-------------|-------------------|---------|
 | Allocations per 7-field form | ~13 | 0 | 13 allocations |
 | Boilerplate lines per form | ~25 | ~1 | 24 lines |

--- a/md/plans/filterable_derive_design.md
+++ b/md/plans/filterable_derive_design.md
@@ -1,9 +1,9 @@
-# Design: `Filterable` Trait & `walrs_fieldfilter_derive`
+# Design: `Fieldset` Trait & `walrs_fieldset_derive`
 
 **Date:** April 12, 2026
 **Updated:** April 12, 2026
 **Status:** Design
-**Crates affected:** `walrs_validation` (new `FieldViolations` type), `walrs_fieldfilter` (trait + migration), `walrs_fieldfilter_derive` (new proc-macro crate)
+**Crates affected:** `walrs_validation` (new `FieldsetViolations` type), `walrs_fieldfilter` (trait + migration), `walrs_fieldset_derive` (new proc-macro crate)
 
 ---
 
@@ -11,12 +11,12 @@
 
 1. [Goal](#goal)
 2. [Background](#background)
-3. [Unified Violations Type: `FieldViolations`](#unified-violations-type-fieldviolations)
+3. [Unified Violations Type: `FieldsetViolations`](#unified-violations-type-fieldviolations)
    - [3.1 Definition](#31-definition)
    - [3.2 Cross-Field / Form-Level Violations](#32-cross-field--form-level-violations)
    - [3.3 Migration from `FormViolations`](#33-migration-from-formviolations)
-4. [The `Filterable` Trait](#the-filterable-trait)
-5. [Derive Macro: `#[derive(Filterable)]`](#derive-macro-derivefilterable)
+4. [The `Fieldset` Trait](#the-fieldset-trait)
+5. [Derive Macro: `#[derive(Fieldset)]`](#derive-macro-derivefieldset)
    - [5.1 Validation Annotations](#51-validation-annotations)
    - [5.2 Filter Annotations (Infallible + Fallible)](#52-filter-annotations-infallible--fallible)
    - [5.3 Cross-Field Validation](#53-cross-field-validation)
@@ -37,12 +37,12 @@
 
 ## Goal
 
-Provide a `Filterable` trait and companion `#[derive(Filterable)]` proc-macro so
+Provide a `Fieldset` trait and companion `#[derive(Fieldset)]` proc-macro so
 that users can attach **compile-time type-checked** validation rules and filters
 directly to struct fields, replacing runtime string-keyed `FieldFilter` +
 `HashMap<String, Value>` for statically known structs.
 
-Additionally, introduce a **unified violations type** (`FieldViolations`) that
+Additionally, introduce a **unified violations type** (`FieldsetViolations`) that
 can be used consistently across the entire forms/validations/filters ecosystem.
 
 ---
@@ -61,13 +61,13 @@ validating a known Rust struct, field names are runtime strings and type
 mismatches (e.g., `Rule::<Value>::MinLength(3)` on a numeric Value) are only
 caught at runtime.
 
-The `Filterable` trait provides the **typed alternative**: field names are
+The `Fieldset` trait provides the **typed alternative**: field names are
 compile-time string literals, rules are constructed with the correct `Rule<T>`
 for each field's concrete type, and mismatches cause **compiler errors**.
 
 ---
 
-## Unified Violations Type: `FieldViolations`
+## Unified Violations Type: `FieldsetViolations`
 
 ### 3.1 Definition
 
@@ -90,9 +90,9 @@ use crate::Violations;
 /// # Example
 ///
 /// ```rust
-/// use walrs_validation::{FieldViolations, Violation, ViolationType};
+/// use walrs_validation::{FieldsetViolations, Violation, ViolationType};
 ///
-/// let mut fv = FieldViolations::new();
+/// let mut fv = FieldsetViolations::new();
 /// fv.add("email", Violation::invalid_email());
 /// fv.add("", Violation::new(ViolationType::NotEqual, "Passwords must match"));
 ///
@@ -101,10 +101,10 @@ use crate::Violations;
 /// assert!(fv.form_violations().is_some());
 /// ```
 #[derive(Clone, Debug, Default)]
-pub struct FieldViolations(pub IndexMap<String, Violations>);
+pub struct FieldsetViolations(pub IndexMap<String, Violations>);
 
-impl FieldViolations {
-    /// Creates a new empty `FieldViolations`.
+impl FieldsetViolations {
+    /// Creates a new empty `FieldsetViolations`.
     pub fn new() -> Self {
         Self::default()
     }
@@ -171,22 +171,22 @@ impl FieldViolations {
         self.0.iter()
     }
 
-    /// Merges another `FieldViolations` into this one.
-    pub fn merge(&mut self, other: FieldViolations) -> &mut Self {
+    /// Merges another `FieldsetViolations` into this one.
+    pub fn merge(&mut self, other: FieldsetViolations) -> &mut Self {
         for (field, violations) in other.0 {
             self.add_many(field, violations);
         }
         self
     }
 
-    /// Merges another `FieldViolations` with a key prefix.
+    /// Merges another `FieldsetViolations` with a key prefix.
     ///
     /// Useful for nested struct violations: `merge_prefixed("address", nested)`
     /// turns key `"street"` into `"address.street"`.
     pub fn merge_prefixed(
         &mut self,
         prefix: &str,
-        other: FieldViolations,
+        other: FieldsetViolations,
     ) -> &mut Self {
         for (field, violations) in other.0 {
             let prefixed = if field.is_empty() {
@@ -206,7 +206,7 @@ impl FieldViolations {
     }
 }
 
-impl std::fmt::Display for FieldViolations {
+impl std::fmt::Display for FieldsetViolations {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (field, violations) in &self.0 {
             if !violations.is_empty() {
@@ -218,10 +218,10 @@ impl std::fmt::Display for FieldViolations {
     }
 }
 
-impl std::error::Error for FieldViolations {}
+impl std::error::Error for FieldsetViolations {}
 
-impl From<FieldViolations> for Result<(), FieldViolations> {
-    fn from(fv: FieldViolations) -> Self {
+impl From<FieldsetViolations> for Result<(), FieldsetViolations> {
+    fn from(fv: FieldsetViolations) -> Self {
         if fv.is_empty() { Ok(()) } else { Err(fv) }
     }
 }
@@ -239,49 +239,49 @@ both per-field and form-level violations through a single structure.
 ### 3.3 Migration from `FormViolations`
 
 The existing `FormViolations` in `walrs_fieldfilter` will be deprecated in
-favor of `FieldViolations` from `walrs_validation`. Migration path:
+favor of `FieldsetViolations` from `walrs_validation`. Migration path:
 
-1. Add `FieldViolations` to `walrs_validation`.
-2. Add a `type FormViolations = FieldViolations;` alias in `walrs_fieldfilter`
+1. Add `FieldsetViolations` to `walrs_validation`.
+2. Add a `type FormViolations = FieldsetViolations;` alias in `walrs_fieldfilter`
    for backward compatibility (marked `#[deprecated]`).
-3. Update `FieldFilter` internals to use `FieldViolations`.
-4. New code (`Filterable`, derive macros) uses `FieldViolations` exclusively.
+3. Update `FieldFilter` internals to use `FieldsetViolations`.
+4. New code (`Fieldset`, derive macros) uses `FieldsetViolations` exclusively.
 
-The `FieldViolations::merge_prefixed()` method replaces the nested violation
+The `FieldsetViolations::merge_prefixed()` method replaces the nested violation
 key-prefixing that `FormViolations` relied on ad-hoc logic for.
 
 ---
 
-## The `Filterable` Trait
+## The `Fieldset` Trait
 
-Defined in `walrs_fieldfilter::filterable`:
+Defined in `walrs_fieldfilter::fieldset`:
 
 ```rust
-use walrs_validation::FieldViolations;
+use walrs_validation::FieldsetViolations;
 
 /// Trait for structs that support type-safe field validation and filtering.
 ///
-/// Implementors can either derive this trait via `#[derive(Filterable)]` or
+/// Implementors can either derive this trait via `#[derive(Fieldset)]` or
 /// implement it manually for full control over validation and filtering logic.
-pub trait Filterable: Sized {
+pub trait Fieldset: Sized {
     /// Validate all fields and cross-field rules.
     ///
     /// Returns `Ok(())` when all fields pass validation, or
-    /// `Err(FieldViolations)` with per-field and form-level violations.
-    fn validate(&self) -> Result<(), FieldViolations>;
+    /// `Err(FieldsetViolations)` with per-field and form-level violations.
+    fn validate(&self) -> Result<(), FieldsetViolations>;
 
     /// Apply all per-field filters (infallible and fallible).
     ///
-    /// Returns `Ok(filtered)` on success, or `Err(FieldViolations)` if any
+    /// Returns `Ok(filtered)` on success, or `Err(FieldsetViolations)` if any
     /// fallible filter fails. Takes ownership to avoid `mem::take` / `Default`
     /// requirements on non-`Default` fields.
-    fn filter(self) -> Result<Self, FieldViolations>;
+    fn filter(self) -> Result<Self, FieldsetViolations>;
 
     /// Filter then validate (provided default).
     ///
     /// Applies `filter()` first, then `validate()` on the result.
-    /// Returns `Ok(filtered)` if both succeed, or `Err(FieldViolations)`.
-    fn process(self) -> Result<Self, FieldViolations> {
+    /// Returns `Ok(filtered)` if both succeed, or `Err(FieldsetViolations)`.
+    fn clean(self) -> Result<Self, FieldsetViolations> {
         let filtered = self.filter()?;
         filtered.validate()?;
         Ok(filtered)
@@ -293,24 +293,24 @@ pub trait Filterable: Sized {
 
 - **`validate(&self)`** — borrows `self`, runs `Rule<T>::validate_ref()` for
   strings/refs, `Rule<T>::validate()` for `Copy` types. Collects errors into
-  `FieldViolations` keyed by field name string literals.
+  `FieldsetViolations` keyed by field name string literals.
 
-- **`filter(self) -> Result<Self, FieldViolations>`** — takes ownership. Runs
+- **`filter(self) -> Result<Self, FieldsetViolations>`** — takes ownership. Runs
   **all** filters (both infallible `FilterOp` and fallible `TryFilterOp`) in a
   single pass. Returns `Result` so that fallible filter failures propagate
   naturally without requiring a separate `try_filter()` method or special
-  handling in `process()`. Infallible filters (e.g., `Trim`) are simply wrapped
+  handling in `clean()`. Infallible filters (e.g., `Trim`) are simply wrapped
   in `Ok(...)` internally.
 
-- **`process(self)`** — provided default: `filter()? → validate()?`. Mirrors
-  the existing `Field<T>::process` semantics but simplified since `filter()`
+- **`clean(self)`** — provided default: `filter()? → validate()?`. Mirrors
+  the existing `Field<T>::clean` semantics but simplified since `filter()`
   already handles fallible operations.
 
 ---
 
-## Derive Macro: `#[derive(Filterable)]`
+## Derive Macro: `#[derive(Fieldset)]`
 
-A new proc-macro crate `walrs_fieldfilter_derive` provides `#[derive(Filterable)]`.
+A new proc-macro crate `walrs_fieldset_derive` provides `#[derive(Fieldset)]`.
 
 ### 5.1 Validation Annotations
 
@@ -335,7 +335,7 @@ Placed on struct fields via `#[validate(...)]`:
 | `step = N` | `Rule::Step(N)` | `SteppableValue` types |
 | `one_of = [a, b, c]` | `Rule::OneOf(vec![a, b, c])` | Types with `PartialEq` |
 | `custom = "path::to::fn"` | `Rule::Custom(Arc::new(path::to::fn))` | All |
-| `nested` | Calls `field.validate()` (requires `Filterable`) | Nested structs |
+| `nested` | Calls `field.validate()` (requires `Fieldset`) | Nested structs |
 
 Multiple `#[validate(...)]` attributes on the same field are combined via
 `Rule::All(vec![...])`.
@@ -360,7 +360,7 @@ All filters — infallible and fallible — are placed on struct fields via
 | `replace(from = "x", to = "y")` | `FilterOp::Replace { from, to }` | `String` |
 | `clamp(min = A, max = B)` | `FilterOp::Clamp { min: A, max: B }` | Numeric scalars |
 | `custom = "path::to::fn"` | `FilterOp::Custom(Arc::new(path::to::fn))` | All |
-| `nested` | Calls `field.filter()` (requires `Filterable`) | Nested structs |
+| `nested` | Calls `field.filter()` (requires `Fieldset`) | Nested structs |
 
 #### Fallible filters
 
@@ -368,10 +368,10 @@ All filters — infallible and fallible — are placed on struct fields via
 |---|---|---|
 | `try_custom = "path::to::fn"` | `TryFilterOp::TryCustom(Arc::new(path::to::fn))` | All |
 
-Since `filter()` returns `Result<Self, FieldViolations>`, both infallible and
+Since `filter()` returns `Result<Self, FieldsetViolations>`, both infallible and
 fallible filters run in sequence within the same method. Infallible filters
 always succeed; fallible filters may fail, in which case their error is
-converted to a `Violation` and added to `FieldViolations` under the field's
+converted to a `Violation` and added to `FieldsetViolations` under the field's
 name.
 
 Multiple `#[filter(...)]` annotations on the same field produce a chained
@@ -382,7 +382,7 @@ sequence: infallible filters run first, then fallible filters.
 #### MVP: `#[cross_validate(...)]` struct attribute
 
 ```rust
-#[derive(Filterable)]
+#[derive(Fieldset)]
 #[cross_validate(passwords_match)]
 struct Registration {
     #[validate(required, min_length = 8)]
@@ -403,18 +403,18 @@ fn passwords_match(r: &Registration) -> walrs_validation::ValidatorResult {
 
 Generated `validate()` calls each `#[cross_validate]` function **after**
 per-field checks, passing `&self` as the argument. Any returned `Violation` is
-added to `FieldViolations` under the `""` (empty string) key (form-level violations).
+added to `FieldsetViolations` under the `""` (empty string) key (form-level violations).
 
 Multiple `#[cross_validate(...)]` attributes are supported — each function is
 called in declaration order.
 
 ### 5.4 Nested Structs
 
-When a field's type also implements `Filterable`, use `#[validate(nested)]`
+When a field's type also implements `Fieldset`, use `#[validate(nested)]`
 and/or `#[filter(nested)]`:
 
 ```rust
-#[derive(Filterable)]
+#[derive(Fieldset)]
 struct UserRegistration {
     #[validate(required, min_length = 2)]
     #[filter(trim)]
@@ -429,7 +429,7 @@ struct UserRegistration {
 Generated code:
 
 - **`validate()`**: calls `self.address.validate()` and prefixes nested
-  violations with the field name via `FieldViolations::merge_prefixed("address", ...)`.
+  violations with the field name via `FieldsetViolations::merge_prefixed("address", ...)`.
 - **`filter()`**: calls `self.address.filter()?` and propagates errors with
   prefix.
 
@@ -463,8 +463,8 @@ let field = match self.field {
 Controlled via struct-level attributes:
 
 ```rust
-#[derive(Filterable)]
-#[filterable(into_form_data)]
+#[derive(Fieldset)]
+#[fieldset(into_form_data)]
 struct UserAddress {
     street: String,
     zip: String,
@@ -474,7 +474,7 @@ struct UserAddress {
 - `into_form_data` generates `impl From<&UserAddress> for FormData`
 - `try_from_form_data` generates `impl TryFrom<FormData> for UserAddress`
 
-This enables bridging between the typed `Filterable` path and the dynamic
+This enables bridging between the typed `Fieldset` path and the dynamic
 `FieldFilter` / `Form` path.
 
 ---
@@ -484,11 +484,11 @@ This enables bridging between the typed `Filterable` path and the dynamic
 ### 6.1 Simple Struct
 
 ```rust
-use walrs_fieldfilter::Filterable;
+use walrs_fieldfilter::Fieldset;
 use walrs_filter::FilterOp;
 use walrs_validation::{Rule, CompiledPattern};
 
-#[derive(Filterable)]
+#[derive(Fieldset)]
 struct UserAddress {
     #[validate(required, min_length = 3)]
     #[filter(trim)]
@@ -500,12 +500,12 @@ struct UserAddress {
 }
 ```
 
-**Generated `Filterable` impl:**
+**Generated `Fieldset` impl:**
 
 ```rust
-impl Filterable for UserAddress {
-    fn validate(&self) -> Result<(), walrs_validation::FieldViolations> {
-        let mut violations = walrs_validation::FieldViolations::new();
+impl Fieldset for UserAddress {
+    fn validate(&self) -> Result<(), walrs_validation::FieldsetViolations> {
+        let mut violations = walrs_validation::FieldsetViolations::new();
 
         // street: required + min_length(3)
         {
@@ -534,7 +534,7 @@ impl Filterable for UserAddress {
         if violations.is_empty() { Ok(()) } else { Err(violations) }
     }
 
-    fn filter(self) -> Result<Self, walrs_validation::FieldViolations> {
+    fn filter(self) -> Result<Self, walrs_validation::FieldsetViolations> {
         let street = FilterOp::<String>::Trim.apply(self.street);
         let zip = FilterOp::<String>::Trim.apply(self.zip);
         Ok(Self { street, zip })
@@ -545,10 +545,10 @@ impl Filterable for UserAddress {
 ### 6.2 Nested Struct with Cross-Field Validation
 
 ```rust
-use walrs_fieldfilter::Filterable;
+use walrs_fieldfilter::Fieldset;
 use walrs_validation::{Violation, ViolationType};
 
-#[derive(Filterable)]
+#[derive(Fieldset)]
 #[cross_validate(passwords_match)]
 struct UserRegistration {
     #[validate(required, min_length = 2, max_length = 50)]
@@ -598,21 +598,21 @@ fn passwords_match(r: &UserRegistration) -> walrs_validation::ValidatorResult {
 
 ### 6.3 Manual Implementation
 
-Users can implement `Filterable` without the derive macro:
+Users can implement `Fieldset` without the derive macro:
 
 ```rust
-use walrs_fieldfilter::Filterable;
+use walrs_fieldfilter::Fieldset;
 use walrs_filter::FilterOp;
-use walrs_validation::{FieldViolations, Rule, ValidateRef, Violation, ViolationType};
+use walrs_validation::{FieldsetViolations, Rule, ValidateRef, Violation, ViolationType};
 
 struct LoginForm {
     username: String,
     password: String,
 }
 
-impl Filterable for LoginForm {
-    fn validate(&self) -> Result<(), FieldViolations> {
-        let mut violations = FieldViolations::new();
+impl Fieldset for LoginForm {
+    fn validate(&self) -> Result<(), FieldsetViolations> {
+        let mut violations = FieldsetViolations::new();
 
         let username_rule = Rule::<String>::Required.and(Rule::MinLength(3));
         if let Err(v) = username_rule.validate_ref(self.username.as_str()) {
@@ -627,7 +627,7 @@ impl Filterable for LoginForm {
         if violations.is_empty() { Ok(()) } else { Err(violations) }
     }
 
-    fn filter(self) -> Result<Self, FieldViolations> {
+    fn filter(self) -> Result<Self, FieldsetViolations> {
         let username = FilterOp::<String>::Trim.apply(self.username);
         Ok(Self { username, password: self.password })
     }
@@ -647,7 +647,7 @@ method:
 | `i8`..`i128`, `isize` | `Rule<{int}>` | `rule.validate(self.field)` |
 | `u8`..`u128`, `usize` | `Rule<{uint}>` | `rule.validate(self.field)` |
 | `f32`, `f64` | `Rule<{float}>` | `rule.validate(self.field)` |
-| `T: Filterable` | N/A (nested) | `self.field.validate()` |
+| `T: Fieldset` | N/A (nested) | `self.field.validate()` |
 | `Option<T>` | Conditional | Skip if `None` unless `required` |
 | `Vec<T>` | `Rule<Vec<T>>` | `rule.validate_ref(&self.field)` |
 
@@ -657,7 +657,7 @@ For filtering (all return `Result`):
 |---|---|
 | `String` | `Ok(FilterOp::<String>::apply(self.field))` |
 | Numeric (`Copy`) | `Ok(FilterOp::<T>::apply(self.field))` |
-| `T: Filterable` (nested) | `self.field.filter()?` |
+| `T: Fieldset` (nested) | `self.field.filter()?` |
 | `Option<T>` | `self.field.map(\|v\| filter.apply(v))` wrapped in `Ok(...)` |
 | Fallible (`TryFilterOp`) | `try_filter.try_apply(self.field).map_err(\|e\| ...)` |
 
@@ -668,16 +668,16 @@ For filtering (all return `Result`):
 ```
 crates/
 ├── fieldfilter/
-│   ├── Cargo.toml           # adds `walrs_fieldfilter_derive` as optional dep
+│   ├── Cargo.toml           # adds `walrs_fieldset_derive` as optional dep
 │   └── src/
-│       ├── lib.rs            # re-exports `Filterable` trait; conditionally
+│       ├── lib.rs            # re-exports `Fieldset` trait; conditionally
 │       │                     #   re-exports derive macro
-│       ├── filterable.rs     # `Filterable` trait definition (NEW)
+│       ├── fieldset.rs     # `Fieldset` trait definition (NEW)
 │       └── ...               # existing modules unchanged
-├── fieldfilter_derive/       # (NEW)
+├── fieldset_derive/       # (NEW)
 │   ├── Cargo.toml            # proc-macro = true
 │   └── src/
-│       ├── lib.rs            # #[proc_macro_derive(Filterable, attributes(validate, filter, cross_validate, filterable))]
+│       ├── lib.rs            # #[proc_macro_derive(Fieldset, attributes(validate, filter, cross_validate, fieldset))]
 │       ├── parse.rs          # Attribute parsing (syn-based)
 │       ├── gen_validate.rs   # Code generation for validate()
 │       ├── gen_filter.rs     # Code generation for filter() (infallible + fallible)
@@ -690,10 +690,10 @@ crates/
 # crates/fieldfilter/Cargo.toml
 [features]
 default = []
-derive = ["walrs_fieldfilter_derive"]
+derive = ["walrs_fieldset_derive"]
 
 [dependencies]
-walrs_fieldfilter_derive = { path = "../fieldfilter_derive", optional = true }
+walrs_fieldset_derive = { path = "../fieldset_derive", optional = true }
 ```
 
 Users opt in with:
@@ -702,15 +702,15 @@ Users opt in with:
 walrs_fieldfilter = { version = "...", features = ["derive"] }
 ```
 
-### `walrs_fieldfilter_derive/Cargo.toml`
+### `walrs_fieldset_derive/Cargo.toml`
 
 ```toml
 [package]
-name = "walrs_fieldfilter_derive"
+name = "walrs_fieldset_derive"
 version = "0.1.0"
 edition = "2024"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
-description = "Derive macro for walrs_fieldfilter Filterable trait"
+description = "Derive macro for walrs_fieldfilter Fieldset trait"
 license = "Elastic-2.0"
 
 [lib]
@@ -732,11 +732,11 @@ The `HashMap<String, Value>` / `FieldFilter` path is **preserved unchanged**:
 - WASM boundaries (`web_sys::FormData`) → `FormData` + `FieldFilter`
 - Dynamic form generation → `FieldFilter`
 
-The struct-based `Filterable` path **supplements** the existing dynamic path.
+The struct-based `Fieldset` path **supplements** the existing dynamic path.
 No existing public APIs are changed or removed.
 
 The existing `FormViolations` type in `walrs_fieldfilter` is deprecated and
-replaced by a type alias to `FieldViolations` from `walrs_validation`. Existing
+replaced by a type alias to `FieldsetViolations` from `walrs_validation`. Existing
 code using `FormViolations` continues to compile with a deprecation warning.
 
 ---
@@ -745,11 +745,11 @@ code using `FormViolations` continues to compile with a deprecation warning.
 
 1. **`break_on_failure` semantics** — The typed path currently validates all
    fields and collects all violations. Should we add a
-   `#[filterable(break_on_failure)]` struct-level attribute for short-circuit
+   `#[fieldset(break_on_failure)]` struct-level attribute for short-circuit
    validation?
 
-2. **Async validation** — Should `Filterable` have an async counterpart
-   (`FilterableAsync`) mirroring the `ValidateAsync` / `ValidateRefAsync` traits?
+2. **Async validation** — Should `Fieldset` have an async counterpart
+   (`FieldsetAsync`) mirroring the `ValidateAsync` / `ValidateRefAsync` traits?
    This would enable `Rule::CustomAsync` in derive macros.
 
 3. **Error message customization** — Should `#[validate]` annotations support
@@ -760,7 +760,7 @@ code using `FormViolations` continues to compile with a deprecation warning.
 
 ## Out of Scope
 
-1. **`impl Filterable for FormData`** — Unifying the dynamic and typed paths
+1. **`impl Fieldset for FormData`** — Unifying the dynamic and typed paths
    under a single trait is a potential future improvement.
 2. **Runtime schema validation** — The derive macro generates static code;
    schema-driven validation at runtime continues to use `FieldFilter`.

--- a/md/plans/form_derive_design.md
+++ b/md/plans/form_derive_design.md
@@ -23,7 +23,7 @@
    - [5.1 Simple Form](#51-simple-form)
    - [5.2 Select Element with Options](#52-select-element-with-options)
    - [5.3 Nested Fieldset](#53-nested-fieldset)
-6. [Combining with `Filterable`](#combining-with-filterable)
+6. [Combining with `Fieldset`](#combining-with-fieldset)
    - [6.1 Both Derives Together](#61-both-derives-together)
    - [6.2 Full Integration Example](#62-full-integration-example)
 7. [Type Mapping: Rust Type → Element Type](#type-mapping-rust-type--element-type)
@@ -439,54 +439,54 @@ each containing `Address`'s elements with their respective legends.
 
 ---
 
-## Combining with `Filterable`
+## Combining with `Fieldset`
 
-The `Fieldset` derive and `Filterable` derive are **independent** but
+The `Fieldset` derive and `Fieldset` derive are **independent** but
 **complementary**. A struct can derive both:
 
 ### 6.1 Both Derives Together
 
 ```rust
-use walrs_fieldfilter_derive::Filterable;
+use walrs_fieldset_derive::Fieldset;
 use walrs_form_derive::Fieldset;
 
-#[derive(Filterable, Fieldset)]
+#[derive(Fieldset, Fieldset)]
 #[fieldset(legend = "User Registration")]
 #[cross_validate(passwords_match)]
 struct UserRegistration {
-    // Filterable: validate + filter
+    // Fieldset: validate + filter
     // Fieldset: generate InputElement(Text)
     #[validate(required, min_length = 2, max_length = 50)]
     #[filter(trim)]
     #[field(type = "text", label = "Full Name")]
     name: String,
 
-    // Filterable: validate + filter
+    // Fieldset: validate + filter
     // Fieldset: generate InputElement(Email)
     #[validate(required, email)]
     #[filter(trim, lowercase)]
     #[field(type = "email", label = "Email Address")]
     email: String,
 
-    // Filterable: validate
+    // Fieldset: validate
     // Fieldset: generate InputElement(Password)
     #[validate(required, min_length = 8)]
     #[field(type = "password", label = "Password")]
     password: String,
 
-    // Filterable: validate
+    // Fieldset: validate
     // Fieldset: generate InputElement(Password)
     #[validate(required)]
     #[field(type = "password", label = "Confirm Password")]
     confirm_password: String,
 
-    // Filterable: validate (numeric)
+    // Fieldset: validate (numeric)
     // Fieldset: generate InputElement(Number)
     #[validate(min = 0, max = 150)]
     #[field(type = "number", label = "Age")]
     age: i64,
 
-    // Filterable: validate (select value is one_of the options)
+    // Fieldset: validate (select value is one_of the options)
     // Fieldset: generate SelectElement with options
     #[validate(required, one_of = ["us", "ca", "uk"])]
     #[field(select, label = "Country", options(
@@ -519,7 +519,7 @@ fn passwords_match(r: &UserRegistration) -> walrs_validation::ValidatorResult {
 
 ```rust
 use walrs_form::Form;
-use walrs_fieldfilter::Filterable;
+use walrs_fieldfilter::Fieldset;
 use walrs_form::IntoFieldset;
 
 // Build the form structure from the struct definition
@@ -535,10 +535,10 @@ fn build_registration_form() -> Form {
     form
 }
 
-// Validate incoming data using Filterable
-fn handle_registration(input: UserRegistration) -> Result<UserRegistration, walrs_validation::FieldViolations> {
-    // process() = filter() + validate()
-    input.process()
+// Validate incoming data using Fieldset
+fn handle_registration(input: UserRegistration) -> Result<UserRegistration, walrs_validation::FieldsetViolations> {
+    // clean() = filter() + validate()
+    input.clean()
 }
 
 // Combined: build form for rendering, validate on submission
@@ -562,7 +562,7 @@ fn main() {
         },
     };
 
-    match registration.process() {
+    match registration.clean() {
         Ok(clean) => {
             // Filters applied: name trimmed, email trimmed+lowercased
             assert_eq!(clean.name, "Jane Doe");

--- a/md/plans/form_serde_design.md
+++ b/md/plans/form_serde_design.md
@@ -577,7 +577,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 3. **Validation metadata in schema** — Should the JSON Schema include
    `minLength`, `maxLength`, `pattern`, `minimum`, `maximum` etc. that come
-   from `Filterable` validation rules? If so, the form serde crate would need
+   from `Fieldset` validation rules? If so, the form serde crate would need
    to understand `walrs_fieldfilter` types, creating a dependency. Alternative:
    a separate `walrs_form_schema` integration crate.
 
@@ -593,7 +593,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 2. **Database storage** — Persisting forms to a database is outside this crate's
    scope.
 3. **Runtime validation** — Validation is handled by `walrs_fieldfilter` /
-   `Filterable`. This crate only generates _schemas_ that describe validation
+   `Fieldset`. This crate only generates _schemas_ that describe validation
    constraints.
 4. **Custom schema extensions** — OpenAPI / Swagger integration is a separate
    concern.

--- a/md/plans/validation_return_type_change.md
+++ b/md/plans/validation_return_type_change.md
@@ -70,13 +70,13 @@ Every sync validation function produces either "valid" or "violation" — none c
 
 5. **`#[must_use]` already enforced** — Both `Violation` and `Violations` are marked `#[must_use]`, and `Option` is also `#[must_use]` by default. No loss of compile-time safety.
 
-6. **`impl Error` becomes optional** — `Violation`/`Violations` implement `Error` today (violation.rs:219, 356). With `Option` returns, these impls are only needed for the `process()` path where violations end up inside `Result`. They can be kept but are no longer load-bearing for the primary API.
+6. **`impl Error` becomes optional** — `Violation`/`Violations` implement `Error` today (violation.rs:219, 356). With `Option` returns, these impls are only needed for the `clean()` path where violations end up inside `Result`. They can be kept but are no longer load-bearing for the primary API.
 
 ### Cons
 
 1. **Massive refactor scope** — This is a cross-cutting change touching 3 crates, ~90 type alias usages, ~344 `Ok`/`Err` patterns, and extensive test rewrites. High risk of regressions.
 
-2. **Loss of `?` operator for early return** — 14 production call-sites use `?` on validation results for short-circuit returns (in `Rule::All` chaining and `Field::process()`). These become:
+2. **Loss of `?` operator for early return** — 14 production call-sites use `?` on validation results for short-circuit returns (in `Rule::All` chaining and `Field::clean()`). These become:
    ```rust
    // Before:
    rule.validate_str_inner(value, locale)?;
@@ -88,9 +88,9 @@ Every sync validation function produces either "valid" or "violation" — none c
    ```
    This is slightly more verbose but equally clear. A helper macro could restore conciseness if desired.
 
-3. **`process()` methods require conversion** — `Field::process()` and `FieldFilter::process()` chain `try_filter()` (genuinely fallible, returns `Result`) with validation. The validation `Option` must be converted:
+3. **`clean()` methods require conversion** — `Field::clean()` and `FieldFilter::clean()` chain `try_filter()` (genuinely fallible, returns `Result`) with validation. The validation `Option` must be converted:
    ```rust
-   // Field::process()
+   // Field::clean()
    let filtered = self.try_filter(filtered)?;          // stays Result
    if let Some(v) = self.check_ref(&filtered) {       // Option → Result bridge
      return Err(v.into());
@@ -215,8 +215,8 @@ pub type AsyncCheckResult = Result<Option<Violation>, Box<dyn Error + Send + Syn
 
 ### Neutral / Design Decisions
 
-- **`process()` / `process_async()` return type stays `Result`** — Because `try_filter` is genuinely fallible, the `process()` pipeline must remain `Result`. For sync `process()`, the `Option` from validation is bridged with `if let Some(v)`. For `process_async()`, the nested `Result<Option<Violation>, E>` needs to be mapped into the pipeline's error type.
-- **`impl Error for Violation`/`Violations`** — Keep these impls. They're still useful when violations end up inside `Result` (via `process()`) and for `Box<dyn Error>` interop.
+- **`clean()` / `clean_async()` return type stays `Result`** — Because `try_filter` is genuinely fallible, the `clean()` pipeline must remain `Result`. For sync `clean()`, the `Option` from validation is bridged with `if let Some(v)`. For `clean_async()`, the nested `Result<Option<Violation>, E>` needs to be mapped into the pipeline's error type.
+- **`impl Error for Violation`/`Violations`** — Keep these impls. They're still useful when violations end up inside `Result` (via `clean()`) and for `Box<dyn Error>` interop.
 - **Trait renaming** — This change is tightly coupled with the item 5 rename (`validate*` → `check*`). Doing both together makes sense to avoid two breaking changes.
 - **`Violations` (plural) at field/form level** — `Field::check()` returns `Option<Violations>`, `FieldFilter::check()` returns `Option<FormViolations>`. The async versions wrap these in `Result<..., Box<dyn Error + Send + Sync>>`.
 
@@ -267,11 +267,11 @@ The main counter-argument is **cost vs. payoff**: ~344 `Ok`/`Err` flips and ~622
 - Update `Field<String>` sync validation methods: `Result<(), Violations>` → `Option<Violations>`
 - Update `Field<Value>` sync validation methods similarly
 - Update `Field` async validation methods: → `Result<Option<Violations>, Box<dyn Error + Send + Sync>>`
-- Update `Field::process()` to bridge sync `Option` → `Result`
-- Update `Field::process_async()` to handle async result + bridge
+- Update `Field::clean()` to bridge sync `Option` → `Result`
+- Update `Field::clean_async()` to handle async result + bridge
 - Update `FieldFilter::validate()`: `Result<(), FormViolations>` → `Option<FormViolations>`
 - Update `FieldFilter::validate_async()`: → `Result<Option<FormViolations>, Box<dyn Error + Send + Sync>>`
-- Update `FieldFilter::process()` / `process_async()` bridges
+- Update `FieldFilter::clean()` / `clean_async()` bridges
 - Update `CrossFieldRule::evaluate()`: `RuleResult` → `Option<Violation>`
 - Update `CrossFieldRuleType::CustomAsync` signature
 - Update fieldfilter crate tests and examples


### PR DESCRIPTION
Closes #195

## Summary

Renames across design docs and codebase:

### Code (breaking change)
- `Field<T>::process()` → `clean()`
- `Field<T>::process_ref()` → `clean_ref()`
- `Field<T>::process_async()` → `clean_async()`
- `Field<T>::process_ref_async()` → `clean_ref_async()`
- `FieldFilter::process()` → `clean()`
- `FieldFilter::process_async()` → `clean_async()`

All tests, doctests, examples, and `DESIGN.md` updated.

### Design Docs
- `Filterable` → `Fieldset`
- `FieldViolations` → `FieldsetViolations`
- `process()` → `clean()`
- `#[derive(Filterable)]` → `#[derive(Fieldset)]`
- `walrs_fieldfilter_derive` → `walrs_fieldset_derive`

Updated in:
- `md/plans/filterable_derive_design.md`
- `md/plans/form_derive_design.md`
- `md/plans/form_serde_design.md`
- `md/plans/validation_return_type_change.md`
- `md/discussions/value_enum_impedance_mismatch.md`

## Verification
- `cargo test -p walrs_fieldfilter` ✅
- `cargo build --examples -p walrs_fieldfilter` ✅
- `cargo clippy -p walrs_fieldfilter` ✅
- `cargo fmt -p walrs_fieldfilter` ✅
- Zero remaining stale names via grep ✅