### PR TITLE
feat(walrs_fieldset_derive): #201 Add derive(Fieldset) proc-macro crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,8 +2114,18 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "walrs_fieldset_derive",
  "walrs_filter",
  "walrs_validation",
+]
+
+[[package]]
+name = "walrs_fieldset_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,6 @@ members = [
     "crates/fieldfilter",
     "crates/navigation",
     "crates/validation",
-    "crates/rbac"
+    "crates/rbac",
+    "crates/fieldset_derive"
 ]

--- a/crates/fieldfilter/Cargo.toml
+++ b/crates/fieldfilter/Cargo.toml
@@ -9,6 +9,7 @@ include = ["src/**/*", "Cargo.toml"]
 [features]
 default = []
 async = ["walrs_validation/async"]
+derive = ["walrs_fieldset_derive"]
 
 [dependencies]
 derive_builder = "0.13.0"
@@ -17,6 +18,7 @@ serde_json = "1.0.82"
 indexmap = { version = "2", features = ["serde"] }
 walrs_filter = { path = "../filter", features = ["validation"] }
 walrs_validation = { path = "../validation" }
+walrs_fieldset_derive = { path = "../fieldset_derive", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/fieldfilter/examples/field_filter.rs
+++ b/crates/fieldfilter/examples/field_filter.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! FieldFilter example for multi-field validation.
 //!
 //! This example demonstrates how to use `FieldFilter` for validating

--- a/crates/fieldfilter/examples/form_violations.rs
+++ b/crates/fieldfilter/examples/form_violations.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! FormViolations example.
 //!
 //! This example demonstrates how to work with `FormViolations` for

--- a/crates/fieldfilter/src/fieldset.rs
+++ b/crates/fieldfilter/src/fieldset.rs
@@ -1,0 +1,412 @@
+//! Typed struct validation and filtering.
+//!
+//! This module provides the [`Fieldset`] trait for compile-time-checked
+//! validation and filtering of typed structs — the recommended replacement
+//! for the dynamic `FieldFilter` path when your fields are known at
+//! compile time.
+
+use walrs_validation::FieldsetViolations;
+
+#[cfg(feature = "async")]
+use std::future::Future;
+
+/// Trait for typed struct validation and filtering.
+///
+/// Implement this trait (or derive it with `#[derive(Fieldset)]`) on a struct
+/// to get compile-time-checked validation and filtering.
+///
+/// # Example
+///
+/// ```rust
+/// use walrs_fieldfilter::Fieldset;
+/// use walrs_validation::FieldsetViolations;
+///
+/// struct LoginForm {
+///     email: String,
+///     password: String,
+/// }
+///
+/// impl Fieldset for LoginForm {
+///     fn validate(&self) -> Result<(), FieldsetViolations> {
+///         let mut violations = FieldsetViolations::new();
+///         if self.email.is_empty() {
+///             violations.add("email", walrs_validation::Violation::value_missing());
+///         }
+///         if self.password.len() < 8 {
+///             violations.add("password", walrs_validation::Violation::new(
+///                 walrs_validation::ViolationType::TooShort, "Password must be at least 8 characters"
+///             ));
+///         }
+///         violations.into()
+///     }
+///
+///     fn filter(self) -> Result<Self, FieldsetViolations> {
+///         Ok(Self {
+///             email: self.email.trim().to_lowercase(),
+///             password: self.password,
+///         })
+///     }
+/// }
+///
+/// let form = LoginForm { email: " Test@Example.com ".to_string(), password: "secret123".to_string() };
+/// let cleaned = form.clean().unwrap();
+/// assert_eq!(cleaned.email, "test@example.com");
+/// ```
+pub trait Fieldset: Sized {
+  /// If `true`, validation stops after the first field with violations.
+  const BREAK_ON_FAILURE: bool = false;
+
+  /// Validate all fields, returning any violations.
+  fn validate(&self) -> Result<(), FieldsetViolations>;
+
+  /// Apply filters to all fields, returning the filtered struct.
+  fn filter(self) -> Result<Self, FieldsetViolations>;
+
+  /// Filter and then validate (convenience method).
+  fn clean(self) -> Result<Self, FieldsetViolations> {
+    let filtered = self.filter()?;
+    filtered.validate()?;
+    Ok(filtered)
+  }
+}
+
+/// Async version of [`Fieldset`].
+///
+/// Provides async validation and filtering for structs that need
+/// async validators (e.g., database uniqueness checks).
+#[cfg(feature = "async")]
+pub trait FieldsetAsync: Fieldset + Send {
+  /// Validate all fields asynchronously.
+  fn validate_async(&self) -> impl Future<Output = Result<(), FieldsetViolations>> + Send;
+
+  /// Apply filters to all fields asynchronously.
+  fn filter_async(self) -> impl Future<Output = Result<Self, FieldsetViolations>> + Send;
+
+  /// Filter and then validate asynchronously (convenience method).
+  fn clean_async(self) -> impl Future<Output = Result<Self, FieldsetViolations>> + Send {
+    async {
+      let filtered = self.filter_async().await?;
+      filtered.validate_async().await?;
+      Ok(filtered)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use walrs_validation::{Violation, ViolationType, Violations};
+
+  // --- Test struct ---
+
+  #[derive(Debug, Clone, PartialEq)]
+  struct ContactForm {
+    name: String,
+    email: String,
+  }
+
+  impl Fieldset for ContactForm {
+    fn validate(&self) -> Result<(), FieldsetViolations> {
+      let mut fv = FieldsetViolations::new();
+      if self.name.is_empty() {
+        fv.add("name", Violation::value_missing());
+      }
+      if self.email.is_empty() {
+        fv.add("email", Violation::value_missing());
+      } else if !self.email.contains('@') {
+        fv.add("email", Violation::invalid_email());
+      }
+      fv.into()
+    }
+
+    fn filter(self) -> Result<Self, FieldsetViolations> {
+      Ok(Self {
+        name: self.name.trim().to_string(),
+        email: self.email.trim().to_lowercase(),
+      })
+    }
+  }
+
+  // --- Struct with BREAK_ON_FAILURE ---
+
+  #[derive(Debug, Clone, PartialEq)]
+  struct StrictForm {
+    a: String,
+    b: String,
+  }
+
+  impl Fieldset for StrictForm {
+    const BREAK_ON_FAILURE: bool = true;
+
+    fn validate(&self) -> Result<(), FieldsetViolations> {
+      let mut fv = FieldsetViolations::new();
+      if self.a.is_empty() {
+        fv.add("a", Violation::value_missing());
+        if Self::BREAK_ON_FAILURE {
+          return fv.into();
+        }
+      }
+      if self.b.is_empty() {
+        fv.add("b", Violation::value_missing());
+      }
+      fv.into()
+    }
+
+    fn filter(self) -> Result<Self, FieldsetViolations> {
+      Ok(self)
+    }
+  }
+
+  // --- Struct whose filter can fail ---
+
+  #[derive(Debug, Clone, PartialEq)]
+  struct ParsedForm {
+    age: String,
+  }
+
+  impl Fieldset for ParsedForm {
+    fn validate(&self) -> Result<(), FieldsetViolations> {
+      FieldsetViolations::new().into()
+    }
+
+    fn filter(self) -> Result<Self, FieldsetViolations> {
+      // Simulate a filter that rejects invalid data
+      if self.age.parse::<u32>().is_err() {
+        let mut fv = FieldsetViolations::new();
+        fv.add(
+          "age",
+          Violation::new(ViolationType::TypeMismatch, "Must be a number"),
+        );
+        Err(fv)
+      } else {
+        Ok(self)
+      }
+    }
+  }
+
+  // 1. Test manual Fieldset impl — validate, filter, clean
+  #[test]
+  fn test_validate_pass() {
+    let form = ContactForm {
+      name: "Alice".into(),
+      email: "alice@example.com".into(),
+    };
+    assert!(form.validate().is_ok());
+  }
+
+  #[test]
+  fn test_validate_fail() {
+    let form = ContactForm {
+      name: "".into(),
+      email: "bad".into(),
+    };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("name").is_some());
+    assert!(err.get("email").is_some());
+  }
+
+  #[test]
+  fn test_filter() {
+    let form = ContactForm {
+      name: "  Bob  ".into(),
+      email: "  BOB@EXAMPLE.COM  ".into(),
+    };
+    let filtered = form.filter().unwrap();
+    assert_eq!(filtered.name, "Bob");
+    assert_eq!(filtered.email, "bob@example.com");
+  }
+
+  #[test]
+  fn test_clean_success() {
+    let form = ContactForm {
+      name: "  Alice  ".into(),
+      email: "  ALICE@EXAMPLE.COM  ".into(),
+    };
+    let cleaned = form.clean().unwrap();
+    assert_eq!(cleaned.name, "Alice");
+    assert_eq!(cleaned.email, "alice@example.com");
+  }
+
+  // 2. Test BREAK_ON_FAILURE const override
+  #[test]
+  fn test_break_on_failure_const() {
+    assert!(StrictForm::BREAK_ON_FAILURE);
+    assert!(!ContactForm::BREAK_ON_FAILURE);
+  }
+
+  #[test]
+  fn test_break_on_failure_stops_early() {
+    let form = StrictForm {
+      a: "".into(),
+      b: "".into(),
+    };
+    let err = form.validate().unwrap_err();
+    // Only "a" should be present because BREAK_ON_FAILURE is true
+    assert!(err.get("a").is_some());
+    assert!(err.get("b").is_none());
+    assert_eq!(err.len(), 1);
+  }
+
+  // 3. Test that clean = filter + validate
+  #[test]
+  fn test_clean_equals_filter_then_validate() {
+    let form1 = ContactForm {
+      name: "  Alice  ".into(),
+      email: "  ALICE@EXAMPLE.COM  ".into(),
+    };
+    let form2 = form1.clone();
+
+    let via_clean = form1.clean().unwrap();
+
+    let filtered = form2.filter().unwrap();
+    filtered.validate().unwrap();
+    let via_manual = filtered;
+
+    assert_eq!(via_clean, via_manual);
+  }
+
+  // 4. Test clean with filter error
+  #[test]
+  fn test_clean_filter_error() {
+    let form = ParsedForm {
+      age: "not-a-number".into(),
+    };
+    let err = form.clean().unwrap_err();
+    assert!(err.get("age").is_some());
+    assert_eq!(err.len(), 1);
+  }
+
+  // 5. Test clean with validation error
+  #[test]
+  fn test_clean_validation_error() {
+    let form = ContactForm {
+      name: "  ".into(),
+      email: "  bad  ".into(),
+    };
+    // Filter trims, then validate sees empty name and bad email
+    let err = form.clean().unwrap_err();
+    assert!(err.get("name").is_some() || err.get("email").is_some());
+  }
+
+  // 6. Test From<FormViolations> for FieldsetViolations
+  #[test]
+  fn test_from_form_violations_to_fieldset_violations() {
+    #[allow(deprecated)]
+    let mut fv = crate::FormViolations::new();
+    #[allow(deprecated)]
+    {
+      fv.add_field_violation(
+        "email",
+        Violation::new(ViolationType::TypeMismatch, "Invalid"),
+      );
+      fv.add_form_violation(Violation::new(ViolationType::CustomError, "Form error"));
+    }
+
+    let fsv: FieldsetViolations = fv.into();
+    assert_eq!(fsv.len(), 2);
+    assert!(fsv.get("email").is_some());
+    assert!(fsv.form_violations().is_some());
+  }
+
+  // 7. Test From<FieldsetViolations> for FormViolations
+  #[test]
+  fn test_from_fieldset_violations_to_form_violations() {
+    let mut fsv = FieldsetViolations::new();
+    fsv.add(
+      "username",
+      Violation::new(ViolationType::TooShort, "Too short"),
+    );
+    fsv.add(
+      "",
+      Violation::new(ViolationType::CustomError, "Form-level error"),
+    );
+
+    #[allow(deprecated)]
+    let fv: crate::FormViolations = fsv.into();
+    #[allow(deprecated)]
+    {
+      assert_eq!(fv.len(), 2);
+      assert!(fv.for_field("username").is_some());
+      assert_eq!(fv.form.len(), 1);
+    }
+  }
+
+  // 8. Test async trait
+  #[cfg(feature = "async")]
+  mod async_tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct AsyncForm {
+      email: String,
+    }
+
+    impl Fieldset for AsyncForm {
+      fn validate(&self) -> Result<(), FieldsetViolations> {
+        let mut fv = FieldsetViolations::new();
+        if self.email.is_empty() {
+          fv.add("email", Violation::value_missing());
+        }
+        fv.into()
+      }
+
+      fn filter(self) -> Result<Self, FieldsetViolations> {
+        Ok(Self {
+          email: self.email.trim().to_lowercase(),
+        })
+      }
+    }
+
+    impl FieldsetAsync for AsyncForm {
+      fn validate_async(&self) -> impl Future<Output = Result<(), FieldsetViolations>> + Send {
+        async { self.validate() }
+      }
+
+      fn filter_async(self) -> impl Future<Output = Result<Self, FieldsetViolations>> + Send {
+        async { self.filter() }
+      }
+    }
+
+    #[tokio::test]
+    async fn test_validate_async() {
+      let form = AsyncForm {
+        email: "test@example.com".into(),
+      };
+      assert!(form.validate_async().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_async_fail() {
+      let form = AsyncForm { email: "".into() };
+      let err = form.validate_async().await.unwrap_err();
+      assert!(err.get("email").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_filter_async() {
+      let form = AsyncForm {
+        email: "  TEST@EXAMPLE.COM  ".into(),
+      };
+      let filtered = form.filter_async().await.unwrap();
+      assert_eq!(filtered.email, "test@example.com");
+    }
+
+    #[tokio::test]
+    async fn test_clean_async() {
+      let form = AsyncForm {
+        email: "  VALID@EXAMPLE.COM  ".into(),
+      };
+      let cleaned = form.clean_async().await.unwrap();
+      assert_eq!(cleaned.email, "valid@example.com");
+    }
+
+    #[tokio::test]
+    async fn test_clean_async_validation_error() {
+      let form = AsyncForm {
+        email: "   ".into(),
+      };
+      let err = form.clean_async().await.unwrap_err();
+      assert!(err.get("email").is_some());
+    }
+  }
+}

--- a/crates/fieldfilter/src/form_violations.rs
+++ b/crates/fieldfilter/src/form_violations.rs
@@ -2,9 +2,13 @@
 //!
 //! This module provides the `FormViolations` struct for collecting validation
 //! errors from multiple fields and cross-field validation rules.
+//!
+//! **Deprecated:** Prefer [`FieldsetViolations`](walrs_validation::FieldsetViolations)
+//! for new code. `From` conversions are provided for migration.
 
+#[allow(deprecated)]
 use indexmap::IndexMap;
-use walrs_validation::Violations;
+use walrs_validation::{FieldsetViolations, Violations};
 
 /// Collection of validation violations for a form.
 ///
@@ -34,6 +38,11 @@ use walrs_validation::Violations;
 /// assert!(!form_violations.is_empty());
 /// assert!(form_violations.for_field("email").is_some());
 /// ```
+#[deprecated(
+  since = "0.2.0",
+  note = "Use `FieldsetViolations` from `walrs_validation` instead. \
+          `From<FormViolations>` and `From<FieldsetViolations>` conversions are provided."
+)]
 #[derive(Clone, Debug, Default)]
 pub struct FormViolations {
   /// Per-field violations, keyed by field name.
@@ -43,6 +52,7 @@ pub struct FormViolations {
   pub form: Violations,
 }
 
+#[allow(deprecated)]
 impl FormViolations {
   /// Creates a new empty `FormViolations`.
   pub fn new() -> Self {
@@ -133,6 +143,7 @@ impl FormViolations {
   }
 }
 
+#[allow(deprecated)]
 impl From<FormViolations> for Result<(), FormViolations> {
   fn from(violations: FormViolations) -> Self {
     if violations.is_empty() {
@@ -143,7 +154,37 @@ impl From<FormViolations> for Result<(), FormViolations> {
   }
 }
 
+#[allow(deprecated)]
+impl From<FormViolations> for FieldsetViolations {
+  fn from(fv: FormViolations) -> Self {
+    let mut result = FieldsetViolations::new();
+    for (field, violations) in fv.fields {
+      result.add_many(field, violations);
+    }
+    if !fv.form.is_empty() {
+      result.add_many("", fv.form);
+    }
+    result
+  }
+}
+
+#[allow(deprecated)]
+impl From<FieldsetViolations> for FormViolations {
+  fn from(fv: FieldsetViolations) -> Self {
+    let mut result = FormViolations::new();
+    for (field, violations) in fv.0 {
+      if field.is_empty() {
+        result.add_form_violations(violations);
+      } else {
+        result.add_field_violations(field, violations);
+      }
+    }
+    result
+  }
+}
+
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
   use super::*;
   use walrs_validation::{Violation, ViolationType};

--- a/crates/fieldfilter/src/lib.rs
+++ b/crates/fieldfilter/src/lib.rs
@@ -85,8 +85,11 @@ pub use walrs_filter::{FilterError, FilterOp, TryFilterOp};
 pub use field::{Field, FieldBuilder};
 pub use field_filter::{CrossFieldRule, CrossFieldRuleType, FieldFilter};
 pub use fieldset::Fieldset;
+
 #[allow(deprecated)]
 pub use form_violations::FormViolations;
+#[cfg(feature = "derive")]
+pub use walrs_fieldset_derive::Fieldset as DeriveFieldset;
 
 #[cfg(feature = "async")]
 pub use fieldset::FieldsetAsync;

--- a/crates/fieldfilter/src/lib.rs
+++ b/crates/fieldfilter/src/lib.rs
@@ -4,12 +4,14 @@
 //!
 //! This crate provides:
 //!
+//! - [`Fieldset`] - Typed struct validation and filtering (recommended for new code)
+//! - [`FieldsetAsync`] - Async version of `Fieldset` (behind `async` feature)
 //! - [`Field`] - Unified validation configuration
 //! - [`FieldFilter`] - Multi-field validation with cross-field rules
 //! - [`FilterOp`] - Serializable filter enum for value transformation (re-exported from `walrs_filter`)
 //! - [`TryFilterOp`] - Fallible filter enum for transformations that can fail (re-exported from `walrs_filter`)
 //! - [`FilterError`] - Error type for fallible filters (re-exported from `walrs_filter`)
-//! - [`FormViolations`] - Collection of form-level validation errors
+//! - [`FormViolations`] - (**Deprecated**: use [`FieldsetViolations`] instead)
 //!
 //! ## Example
 //!
@@ -57,7 +59,10 @@
 extern crate derive_builder;
 
 pub mod field;
+#[allow(deprecated)]
 pub mod field_filter;
+pub mod fieldset;
+#[allow(deprecated)]
 pub mod form_violations;
 
 pub mod rule;
@@ -67,8 +72,8 @@ pub use indexmap::IndexMap;
 
 // Re-export types from walrs_validation
 pub use walrs_validation::{
-  Attributes, IsEmpty, Message, MessageContext, MessageParams, Value, ValueExt, Violation,
-  ViolationMessage, ViolationType, Violations,
+  Attributes, FieldsetViolations, IsEmpty, Message, MessageContext, MessageParams, Value, ValueExt,
+  Violation, ViolationMessage, ViolationType, Violations,
 };
 
 #[cfg(feature = "async")]
@@ -79,6 +84,11 @@ pub use walrs_filter::{FilterError, FilterOp, TryFilterOp};
 
 pub use field::{Field, FieldBuilder};
 pub use field_filter::{CrossFieldRule, CrossFieldRuleType, FieldFilter};
+pub use fieldset::Fieldset;
+#[allow(deprecated)]
 pub use form_violations::FormViolations;
+
+#[cfg(feature = "async")]
+pub use fieldset::FieldsetAsync;
 
 pub use rule::{Condition, Rule, RuleResult};

--- a/crates/fieldfilter/tests/derive_fieldset.rs
+++ b/crates/fieldfilter/tests/derive_fieldset.rs
@@ -1,0 +1,499 @@
+//! Integration tests for `#[derive(Fieldset)]`.
+
+#[cfg(feature = "derive")]
+mod derive_tests {
+  use walrs_fieldfilter::{DeriveFieldset, Fieldset};
+  use walrs_validation::{Violation, ViolationType};
+
+  // =========================================================================
+  // Test 1: Simple struct with string validation + filters
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct UserAddress {
+    #[validate(required, min_length = 3)]
+    #[filter(trim)]
+    street: String,
+
+    #[validate(required, pattern = r"^\d{5}$")]
+    #[filter(trim)]
+    zip: String,
+  }
+
+  #[test]
+  fn test_simple_validate_pass() {
+    let addr = UserAddress {
+      street: "123 Main St".into(),
+      zip: "90210".into(),
+    };
+    assert!(addr.validate().is_ok());
+  }
+
+  #[test]
+  fn test_simple_validate_fail() {
+    let addr = UserAddress {
+      street: "ab".into(), // too short
+      zip: "bad".into(),   // doesn't match pattern
+    };
+    let err = addr.validate().unwrap_err();
+    assert!(err.get("street").is_some());
+    assert!(err.get("zip").is_some());
+  }
+
+  #[test]
+  fn test_simple_filter() {
+    let addr = UserAddress {
+      street: "  123 Main St  ".into(),
+      zip: "  90210  ".into(),
+    };
+    let filtered = addr.filter().unwrap();
+    assert_eq!(filtered.street, "123 Main St");
+    assert_eq!(filtered.zip, "90210");
+  }
+
+  #[test]
+  fn test_simple_clean() {
+    let addr = UserAddress {
+      street: "  123 Main St  ".into(),
+      zip: "  90210  ".into(),
+    };
+    let cleaned = addr.clean().unwrap();
+    assert_eq!(cleaned.street, "123 Main St");
+    assert_eq!(cleaned.zip, "90210");
+  }
+
+  #[test]
+  fn test_clean_fails_validation_after_filter() {
+    let addr = UserAddress {
+      street: "  ab  ".into(), // trims to "ab", too short
+      zip: "  bad  ".into(),   // trims to "bad", no match
+    };
+    let err = addr.clean().unwrap_err();
+    assert!(err.get("street").is_some());
+    assert!(err.get("zip").is_some());
+  }
+
+  // =========================================================================
+  // Test 2: Nested struct
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct Registration {
+    #[validate(required)]
+    #[filter(trim)]
+    name: String,
+
+    #[validate(nested)]
+    #[filter(nested)]
+    address: UserAddress,
+  }
+
+  #[test]
+  fn test_nested_validate_pass() {
+    let reg = Registration {
+      name: "Alice".into(),
+      address: UserAddress {
+        street: "123 Main St".into(),
+        zip: "90210".into(),
+      },
+    };
+    assert!(reg.validate().is_ok());
+  }
+
+  #[test]
+  fn test_nested_validate_fail() {
+    let reg = Registration {
+      name: "".into(),
+      address: UserAddress {
+        street: "ab".into(),
+        zip: "bad".into(),
+      },
+    };
+    let err = reg.validate().unwrap_err();
+    assert!(err.get("name").is_some());
+    assert!(err.get("address.street").is_some());
+    assert!(err.get("address.zip").is_some());
+  }
+
+  #[test]
+  fn test_nested_filter() {
+    let reg = Registration {
+      name: "  Alice  ".into(),
+      address: UserAddress {
+        street: "  123 Main  ".into(),
+        zip: "  90210  ".into(),
+      },
+    };
+    let filtered = reg.filter().unwrap();
+    assert_eq!(filtered.name, "Alice");
+    assert_eq!(filtered.address.street, "123 Main");
+    assert_eq!(filtered.address.zip, "90210");
+  }
+
+  // =========================================================================
+  // Test 3: Cross-field validation
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  #[cross_validate(passwords_match)]
+  struct PasswordForm {
+    #[validate(required, min_length = 8)]
+    password: String,
+
+    #[validate(required)]
+    confirm: String,
+  }
+
+  fn passwords_match(form: &PasswordForm) -> walrs_validation::RuleResult {
+    if form.password == form.confirm {
+      Ok(())
+    } else {
+      Err(Violation::new(
+        ViolationType::NotEqual,
+        "Passwords must match",
+      ))
+    }
+  }
+
+  #[test]
+  fn test_cross_validate_pass() {
+    let form = PasswordForm {
+      password: "secretpass".into(),
+      confirm: "secretpass".into(),
+    };
+    assert!(form.validate().is_ok());
+  }
+
+  #[test]
+  fn test_cross_validate_fail() {
+    let form = PasswordForm {
+      password: "secretpass".into(),
+      confirm: "different".into(),
+    };
+    let err = form.validate().unwrap_err();
+    // Cross-field violations are under "" key (form-level)
+    assert!(err.form_violations().is_some());
+  }
+
+  #[test]
+  fn test_cross_validate_with_field_errors() {
+    let form = PasswordForm {
+      password: "short".into(), // min_length = 8 fails
+      confirm: "different".into(),
+    };
+    let err = form.validate().unwrap_err();
+    // Both field and form-level errors
+    assert!(err.get("password").is_some());
+    assert!(err.form_violations().is_some());
+  }
+
+  // =========================================================================
+  // Test 4: Option<T> fields
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct OptionalForm {
+    #[validate(required)]
+    name: String,
+
+    #[validate(email)]
+    #[filter(trim, lowercase)]
+    email: Option<String>,
+  }
+
+  #[test]
+  fn test_option_none_skips() {
+    let form = OptionalForm {
+      name: "Alice".into(),
+      email: None,
+    };
+    // email is None and not required — should pass
+    assert!(form.validate().is_ok());
+  }
+
+  #[test]
+  fn test_option_some_validates() {
+    let form = OptionalForm {
+      name: "Alice".into(),
+      email: Some("not-an-email".into()),
+    };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("email").is_some());
+  }
+
+  #[test]
+  fn test_option_some_passes() {
+    let form = OptionalForm {
+      name: "Alice".into(),
+      email: Some("alice@example.com".into()),
+    };
+    assert!(form.validate().is_ok());
+  }
+
+  #[test]
+  fn test_option_filter() {
+    let form = OptionalForm {
+      name: "Alice".into(),
+      email: Some("  ALICE@EXAMPLE.COM  ".into()),
+    };
+    let filtered = form.filter().unwrap();
+    assert_eq!(filtered.email, Some("alice@example.com".into()));
+  }
+
+  #[test]
+  fn test_option_filter_none() {
+    let form = OptionalForm {
+      name: "Alice".into(),
+      email: None,
+    };
+    let filtered = form.filter().unwrap();
+    assert_eq!(filtered.email, None);
+  }
+
+  // =========================================================================
+  // Test 5: break_on_failure
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  #[fieldset(break_on_failure)]
+  struct StrictForm {
+    #[validate(required)]
+    first: String,
+
+    #[validate(required)]
+    second: String,
+  }
+
+  #[test]
+  fn test_break_on_failure_const() {
+    assert!(StrictForm::BREAK_ON_FAILURE);
+  }
+
+  #[test]
+  fn test_break_on_failure_stops_early() {
+    let form = StrictForm {
+      first: "".into(),
+      second: "".into(),
+    };
+    let err = form.validate().unwrap_err();
+    // Only first field should be reported because break_on_failure stops early
+    assert!(err.get("first").is_some());
+    assert!(err.get("second").is_none());
+    assert_eq!(err.len(), 1);
+  }
+
+  #[test]
+  fn test_break_on_failure_passes() {
+    let form = StrictForm {
+      first: "hello".into(),
+      second: "world".into(),
+    };
+    assert!(form.validate().is_ok());
+  }
+
+  // =========================================================================
+  // Test 6: Numeric validation
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct NumericForm {
+    #[validate(min = 0, max = 150)]
+    age: i64,
+
+    #[validate(range(min = 0.0, max = 100.0))]
+    score: f64,
+  }
+
+  #[test]
+  fn test_numeric_validate_pass() {
+    let form = NumericForm {
+      age: 25,
+      score: 85.5,
+    };
+    assert!(form.validate().is_ok());
+  }
+
+  #[test]
+  fn test_numeric_validate_fail_min() {
+    let form = NumericForm {
+      age: -1,
+      score: 50.0,
+    };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("age").is_some());
+  }
+
+  #[test]
+  fn test_numeric_validate_fail_max() {
+    let form = NumericForm {
+      age: 200,
+      score: 50.0,
+    };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("age").is_some());
+  }
+
+  #[test]
+  fn test_numeric_validate_fail_range() {
+    let form = NumericForm {
+      age: 25,
+      score: 150.0,
+    };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("score").is_some());
+  }
+
+  // =========================================================================
+  // Test 7: Message customization
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct CustomMessageForm {
+    #[validate(required, message = "Name is required!")]
+    name: String,
+  }
+
+  #[test]
+  fn test_custom_message() {
+    let form = CustomMessageForm { name: "".into() };
+    let err = form.validate().unwrap_err();
+    let violations = err.get("name").unwrap();
+    assert_eq!(violations.0.len(), 1);
+    assert_eq!(violations.0[0].message(), "Name is required!");
+  }
+
+  // =========================================================================
+  // Test 8: Multiple filters
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct MultiFilterForm {
+    #[filter(trim, lowercase)]
+    email: String,
+
+    #[filter(trim, uppercase)]
+    code: String,
+  }
+
+  #[test]
+  fn test_multiple_filters() {
+    let form = MultiFilterForm {
+      email: "  HELLO@WORLD.COM  ".into(),
+      code: "  abc123  ".into(),
+    };
+    let filtered = form.filter().unwrap();
+    assert_eq!(filtered.email, "hello@world.com");
+    assert_eq!(filtered.code, "ABC123");
+  }
+
+  // =========================================================================
+  // Test 9: Field with no attributes (passthrough)
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct MixedForm {
+    #[validate(required)]
+    name: String,
+
+    // No annotations — just passes through
+    extra: String,
+  }
+
+  #[test]
+  fn test_passthrough_field() {
+    let form = MixedForm {
+      name: "Alice".into(),
+      extra: "  some data  ".into(),
+    };
+    let filtered = form.filter().unwrap();
+    assert_eq!(filtered.extra, "  some data  "); // not modified
+  }
+
+  // =========================================================================
+  // Test 10: Numeric filter (clamp)
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct ClampForm {
+    #[validate(min = 0, max = 100)]
+    #[filter(clamp(min = 0, max = 100))]
+    percentage: i32,
+  }
+
+  #[test]
+  fn test_numeric_clamp_filter() {
+    let form = ClampForm { percentage: 150 };
+    let filtered = form.filter().unwrap();
+    assert_eq!(filtered.percentage, 100);
+  }
+
+  #[test]
+  fn test_numeric_clamp_clean() {
+    let form = ClampForm { percentage: 150 };
+    // After filter (clamp to 100), validation passes
+    let cleaned = form.clean().unwrap();
+    assert_eq!(cleaned.percentage, 100);
+  }
+
+  // =========================================================================
+  // Test 11: Per-field break_on_failure override
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  #[fieldset(break_on_failure)]
+  struct OverrideForm {
+    #[validate(required)]
+    #[fieldset(break_on_failure = false)]
+    first: String,
+
+    #[validate(required)]
+    second: String,
+  }
+
+  #[test]
+  fn test_per_field_break_override() {
+    let form = OverrideForm {
+      first: "".into(),
+      second: "".into(),
+    };
+    let err = form.validate().unwrap_err();
+    // first has break_on_failure=false override, so validation continues to second
+    // but second has struct-level break_on_failure=true
+    assert!(err.get("first").is_some());
+    assert!(err.get("second").is_some());
+  }
+
+  // =========================================================================
+  // Test 12: Option<T> with required
+  // =========================================================================
+
+  #[derive(Debug, DeriveFieldset)]
+  struct RequiredOptionForm {
+    #[validate(required, min_length = 3)]
+    nickname: Option<String>,
+  }
+
+  #[test]
+  fn test_required_option_none_fails() {
+    let form = RequiredOptionForm { nickname: None };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("nickname").is_some());
+  }
+
+  #[test]
+  fn test_required_option_some_validates() {
+    let form = RequiredOptionForm {
+      nickname: Some("ab".into()), // too short
+    };
+    let err = form.validate().unwrap_err();
+    assert!(err.get("nickname").is_some());
+  }
+
+  #[test]
+  fn test_required_option_some_passes() {
+    let form = RequiredOptionForm {
+      nickname: Some("alice".into()),
+    };
+    assert!(form.validate().is_ok());
+  }
+}

--- a/crates/fieldset_derive/Cargo.toml
+++ b/crates/fieldset_derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "walrs_fieldset_derive"
+version = "0.1.0"
+edition = "2024"
+authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
+description = "Derive macro for walrs_fieldfilter Fieldset trait"
+license = "Elastic-2.0"
+include = ["src/**/*", "Cargo.toml"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crates/fieldset_derive/src/gen_filter.rs
+++ b/crates/fieldset_derive/src/gen_filter.rs
@@ -1,0 +1,313 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::parse::{FieldInfo, FieldType, FilterAttr, NumericLit};
+
+/// Generate the body of `fn filter(self) -> Result<Self, FieldsetViolations>`.
+pub fn gen_filter(fields: &[FieldInfo]) -> TokenStream {
+  let field_filters: Vec<TokenStream> = fields.iter().map(gen_field_filter).collect();
+
+  let field_names: Vec<&syn::Ident> = fields.iter().map(|f| &f.ident).collect();
+
+  quote! {
+    fn filter(self) -> ::core::result::Result<Self, walrs_validation::FieldsetViolations> {
+      #(#field_filters)*
+      ::core::result::Result::Ok(Self {
+        #(#field_names),*
+      })
+    }
+  }
+}
+
+fn gen_field_filter(field: &FieldInfo) -> TokenStream {
+  let field_name = &field.ident;
+  let _field_name_str = field_name.to_string();
+
+  // No filters and not nested → passthrough
+  if field.filters.is_empty() && !field.is_nested_filter {
+    return quote! { let #field_name = self.#field_name; };
+  }
+
+  // Nested filter
+  if field.is_nested_filter {
+    return gen_nested_filter(field);
+  }
+
+  // Has filters
+  let has_try_filters = field
+    .filters
+    .iter()
+    .any(|f| matches!(f, FilterAttr::TryCustom(_)));
+
+  match &field.ty {
+    FieldType::String => gen_string_filter(field, has_try_filters),
+    FieldType::Numeric(ty_ident) => gen_numeric_filter(field, ty_ident),
+    FieldType::OptionString => gen_option_string_filter(field, has_try_filters),
+    FieldType::OptionNumeric(ty_ident) => gen_option_numeric_filter(field, ty_ident),
+    _ => {
+      // For other types just passthrough
+      quote! { let #field_name = self.#field_name; }
+    }
+  }
+}
+
+fn gen_string_filter(field: &FieldInfo, has_try: bool) -> TokenStream {
+  let field_name = &field.ident;
+  let field_name_str = field_name.to_string();
+  let steps = gen_filter_steps(field, quote! { self.#field_name }, has_try, &field_name_str);
+
+  quote! {
+    let #field_name = {
+      #steps
+    };
+  }
+}
+
+fn gen_numeric_filter(field: &FieldInfo, ty_ident: &syn::Ident) -> TokenStream {
+  let field_name = &field.ident;
+  let mut steps = Vec::new();
+  let mut current = quote! { self.#field_name };
+
+  for filter in &field.filters {
+    let apply = numeric_filter_token(filter, &current, ty_ident);
+    current = quote! { filtered };
+    steps.push(quote! { let filtered = #apply; });
+  }
+
+  if steps.is_empty() {
+    quote! { let #field_name = self.#field_name; }
+  } else {
+    quote! {
+      let #field_name = {
+        #(#steps)*
+        filtered
+      };
+    }
+  }
+}
+
+fn gen_option_string_filter(field: &FieldInfo, has_try: bool) -> TokenStream {
+  let field_name = &field.ident;
+  let field_name_str = field_name.to_string();
+  let inner_steps = gen_filter_steps(field, quote! { v }, has_try, &field_name_str);
+
+  if has_try {
+    quote! {
+      let #field_name = match self.#field_name {
+        ::core::option::Option::Some(v) => {
+          let result = (|| -> ::core::result::Result<String, walrs_validation::FieldsetViolations> {
+            ::core::result::Result::Ok({ #inner_steps })
+          })();
+          match result {
+            ::core::result::Result::Ok(filtered) => ::core::option::Option::Some(filtered),
+            ::core::result::Result::Err(e) => return ::core::result::Result::Err(e),
+          }
+        }
+        ::core::option::Option::None => ::core::option::Option::None,
+      };
+    }
+  } else {
+    quote! {
+      let #field_name = match self.#field_name {
+        ::core::option::Option::Some(v) => {
+          ::core::option::Option::Some({ #inner_steps })
+        }
+        ::core::option::Option::None => ::core::option::Option::None,
+      };
+    }
+  }
+}
+
+fn gen_option_numeric_filter(field: &FieldInfo, ty_ident: &syn::Ident) -> TokenStream {
+  let field_name = &field.ident;
+  let mut steps = Vec::new();
+  let mut current = quote! { v };
+
+  for filter in &field.filters {
+    let apply = numeric_filter_token(filter, &current, ty_ident);
+    current = quote! { filtered };
+    steps.push(quote! { let filtered = #apply; });
+  }
+
+  if steps.is_empty() {
+    quote! { let #field_name = self.#field_name; }
+  } else {
+    quote! {
+      let #field_name = match self.#field_name {
+        ::core::option::Option::Some(v) => {
+          #(#steps)*
+          ::core::option::Option::Some(filtered)
+        }
+        ::core::option::Option::None => ::core::option::Option::None,
+      };
+    }
+  }
+}
+
+fn gen_nested_filter(field: &FieldInfo) -> TokenStream {
+  let field_name = &field.ident;
+  let field_name_str = field_name.to_string();
+
+  match &field.ty {
+    FieldType::OptionOther(_) | FieldType::OptionString => {
+      quote! {
+        let #field_name = match self.#field_name {
+          ::core::option::Option::Some(v) => {
+            match walrs_fieldfilter::Fieldset::filter(v) {
+              ::core::result::Result::Ok(filtered) => ::core::option::Option::Some(filtered),
+              ::core::result::Result::Err(e) => {
+                let mut fv = walrs_validation::FieldsetViolations::new();
+                fv.merge_prefixed(#field_name_str, e);
+                return ::core::result::Result::Err(fv);
+              }
+            }
+          }
+          ::core::option::Option::None => ::core::option::Option::None,
+        };
+      }
+    }
+    _ => {
+      quote! {
+        let #field_name = walrs_fieldfilter::Fieldset::filter(self.#field_name)
+          .map_err(|e| {
+            let mut fv = walrs_validation::FieldsetViolations::new();
+            fv.merge_prefixed(#field_name_str, e);
+            fv
+          })?;
+      }
+    }
+  }
+}
+
+/// Generate sequential filter application steps for String fields.
+fn gen_filter_steps(
+  field: &FieldInfo,
+  initial: TokenStream,
+  _has_try: bool,
+  field_name_str: &str,
+) -> TokenStream {
+  let mut steps = Vec::new();
+  let mut first = true;
+
+  for filter in &field.filters {
+    let src = if first {
+      first = false;
+      initial.clone()
+    } else {
+      quote! { filtered }
+    };
+
+    match filter {
+      FilterAttr::Trim => {
+        steps.push(quote! { let filtered = walrs_filter::FilterOp::<String>::Trim.apply(#src); });
+      }
+      FilterAttr::Lowercase => {
+        steps
+          .push(quote! { let filtered = walrs_filter::FilterOp::<String>::Lowercase.apply(#src); });
+      }
+      FilterAttr::Uppercase => {
+        steps
+          .push(quote! { let filtered = walrs_filter::FilterOp::<String>::Uppercase.apply(#src); });
+      }
+      FilterAttr::StripTags => {
+        steps
+          .push(quote! { let filtered = walrs_filter::FilterOp::<String>::StripTags.apply(#src); });
+      }
+      FilterAttr::HtmlEntities => {
+        steps.push(
+          quote! { let filtered = walrs_filter::FilterOp::<String>::HtmlEntities.apply(#src); },
+        );
+      }
+      FilterAttr::Slug { max_length } => {
+        let ml = match max_length {
+          Some(n) => quote! { ::core::option::Option::Some(#n) },
+          None => quote! { ::core::option::Option::None },
+        };
+        steps.push(
+          quote! { let filtered = walrs_filter::FilterOp::<String>::Slug { max_length: #ml }.apply(#src); },
+        );
+      }
+      FilterAttr::Truncate { max_length } => {
+        let n = *max_length;
+        steps.push(
+          quote! { let filtered = walrs_filter::FilterOp::<String>::Truncate { max_length: #n }.apply(#src); },
+        );
+      }
+      FilterAttr::Replace { from, to } => {
+        steps.push(
+          quote! { let filtered = walrs_filter::FilterOp::<String>::Replace { from: #from.to_string(), to: #to.to_string() }.apply(#src); },
+        );
+      }
+      FilterAttr::Custom(path) => {
+        steps.push(
+          quote! { let filtered = walrs_filter::FilterOp::<String>::Custom(::std::sync::Arc::new(#path)).apply(#src); },
+        );
+      }
+      FilterAttr::TryCustom(path) => {
+        let fname = field_name_str;
+        steps.push(quote! {
+          let filtered = walrs_filter::TryFilterOp::<String>::TryCustom(::std::sync::Arc::new(#path))
+            .try_apply(#src)
+            .map_err(|e| {
+              let mut fv = walrs_validation::FieldsetViolations::new();
+              let violation: walrs_validation::Violation = e.into();
+              fv.add(#fname, violation);
+              fv
+            })?;
+        });
+      }
+      FilterAttr::Clamp { .. } => {
+        // Clamp doesn't apply to strings; ignore
+        if first {
+          first = false;
+        }
+        steps.push(quote! { let filtered = #src; });
+      }
+    }
+  }
+
+  if steps.is_empty() {
+    initial
+  } else {
+    quote! {
+      #(#steps)*
+      filtered
+    }
+  }
+}
+
+fn numeric_filter_token(
+  filter: &FilterAttr,
+  src: &TokenStream,
+  ty_ident: &syn::Ident,
+) -> TokenStream {
+  match filter {
+    FilterAttr::Clamp { min, max } => {
+      let min_lit = numeric_lit_token(min);
+      let max_lit = numeric_lit_token(max);
+      quote! {
+        walrs_filter::FilterOp::<#ty_ident>::Clamp { min: #min_lit, max: #max_lit }.apply(#src)
+      }
+    }
+    FilterAttr::Custom(path) => {
+      quote! {
+        walrs_filter::FilterOp::<#ty_ident>::Custom(::std::sync::Arc::new(#path)).apply(#src)
+      }
+    }
+    // Other string filters don't apply to numeric types
+    _ => quote! { #src },
+  }
+}
+
+fn numeric_lit_token(n: &NumericLit) -> TokenStream {
+  match n {
+    NumericLit::Int(v) => {
+      let lit = proc_macro2::Literal::i128_unsuffixed(*v);
+      quote! { #lit }
+    }
+    NumericLit::Float(v) => {
+      let lit = proc_macro2::Literal::f64_unsuffixed(*v);
+      quote! { #lit }
+    }
+  }
+}

--- a/crates/fieldset_derive/src/gen_validate.rs
+++ b/crates/fieldset_derive/src/gen_validate.rs
@@ -1,0 +1,410 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::parse::{FieldInfo, FieldType, NumericLit, OneOfItem, ValidateAttr};
+
+/// Generate the body of `fn validate(&self) -> Result<(), FieldsetViolations>`.
+pub fn gen_validate(
+  fields: &[FieldInfo],
+  cross_fns: &[syn::Path],
+  struct_break_on_failure: bool,
+) -> TokenStream {
+  let field_checks: Vec<TokenStream> = fields
+    .iter()
+    .filter(|f| !f.validations.is_empty() || f.is_nested_validate)
+    .map(|f| gen_field_validate(f, struct_break_on_failure))
+    .collect();
+
+  let cross_checks: Vec<TokenStream> = cross_fns
+    .iter()
+    .map(|path| {
+      quote! {
+        if let Err(violation) = #path(&self) {
+          violations.add_form_violation(violation);
+        }
+      }
+    })
+    .collect();
+
+  quote! {
+    fn validate(&self) -> ::core::result::Result<(), walrs_validation::FieldsetViolations> {
+      let mut violations = walrs_validation::FieldsetViolations::new();
+      #(#field_checks)*
+      #(#cross_checks)*
+      violations.into()
+    }
+  }
+}
+
+fn gen_field_validate(field: &FieldInfo, struct_break: bool) -> TokenStream {
+  let field_name = &field.ident;
+  let field_name_str = field_name.to_string();
+
+  let break_on_failure = field.break_on_failure_override.unwrap_or(struct_break);
+
+  let break_check = if break_on_failure {
+    quote! {
+      if !violations.is_empty() {
+        return ::core::result::Result::Err(violations);
+      }
+    }
+  } else {
+    quote! {}
+  };
+
+  // Handle nested validation
+  if field.is_nested_validate {
+    return gen_nested_validate(field, &break_check);
+  }
+
+  // Build rule expression
+  let rules = build_rules(field);
+  if rules.is_none() {
+    return quote! {};
+  }
+  let rule_expr = rules.unwrap();
+
+  match &field.ty {
+    FieldType::String => {
+      quote! {
+        {
+          let rule = #rule_expr;
+          if let ::core::result::Result::Err(violation) =
+            walrs_validation::ValidateRef::validate_ref(&rule, self.#field_name.as_str())
+          {
+            violations.add(#field_name_str, violation);
+            #break_check
+          }
+        }
+      }
+    }
+    FieldType::Numeric(_) | FieldType::Bool | FieldType::Char => {
+      quote! {
+        {
+          let rule = #rule_expr;
+          if let ::core::result::Result::Err(violation) =
+            walrs_validation::ValidateRef::validate_ref(&rule, &self.#field_name)
+          {
+            violations.add(#field_name_str, violation);
+            #break_check
+          }
+        }
+      }
+    }
+    FieldType::OptionString => {
+      let has_required = field
+        .validations
+        .iter()
+        .any(|v| matches!(v, ValidateAttr::Required));
+      if has_required {
+        quote! {
+          {
+            let rule = #rule_expr;
+            match self.#field_name.as_ref() {
+              ::core::option::Option::Some(inner) => {
+                if let ::core::result::Result::Err(violation) =
+                  walrs_validation::ValidateRef::validate_ref(&rule, inner.as_str())
+                {
+                  violations.add(#field_name_str, violation);
+                  #break_check
+                }
+              }
+              ::core::option::Option::None => {
+                violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+                #break_check
+              }
+            }
+          }
+        }
+      } else {
+        quote! {
+          {
+            let rule = #rule_expr;
+            if let ::core::option::Option::Some(inner) = self.#field_name.as_ref() {
+              if let ::core::result::Result::Err(violation) =
+                walrs_validation::ValidateRef::validate_ref(&rule, inner.as_str())
+              {
+                violations.add(#field_name_str, violation);
+                #break_check
+              }
+            }
+          }
+        }
+      }
+    }
+    FieldType::OptionNumeric(_) | FieldType::OptionBool | FieldType::OptionChar => {
+      let has_required = field
+        .validations
+        .iter()
+        .any(|v| matches!(v, ValidateAttr::Required));
+      if has_required {
+        quote! {
+          {
+            let rule = #rule_expr;
+            match self.#field_name.as_ref() {
+              ::core::option::Option::Some(inner) => {
+                if let ::core::result::Result::Err(violation) =
+                  walrs_validation::ValidateRef::validate_ref(&rule, inner)
+                {
+                  violations.add(#field_name_str, violation);
+                  #break_check
+                }
+              }
+              ::core::option::Option::None => {
+                violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+                #break_check
+              }
+            }
+          }
+        }
+      } else {
+        quote! {
+          {
+            let rule = #rule_expr;
+            if let ::core::option::Option::Some(inner) = self.#field_name.as_ref() {
+              if let ::core::result::Result::Err(violation) =
+                walrs_validation::ValidateRef::validate_ref(&rule, inner)
+              {
+                violations.add(#field_name_str, violation);
+                #break_check
+              }
+            }
+          }
+        }
+      }
+    }
+    FieldType::Other(_) | FieldType::OptionOther(_) => {
+      // For unknown types, attempt ValidateRef
+      quote! {
+        {
+          let rule = #rule_expr;
+          if let ::core::result::Result::Err(violation) =
+            walrs_validation::ValidateRef::validate_ref(&rule, &self.#field_name)
+          {
+            violations.add(#field_name_str, violation);
+            #break_check
+          }
+        }
+      }
+    }
+  }
+}
+
+fn gen_nested_validate(field: &FieldInfo, break_check: &TokenStream) -> TokenStream {
+  let field_name = &field.ident;
+  let field_name_str = field_name.to_string();
+
+  match &field.ty {
+    FieldType::OptionOther(_) | FieldType::OptionString => {
+      let has_required = field
+        .validations
+        .iter()
+        .any(|v| matches!(v, ValidateAttr::Required));
+      if has_required {
+        quote! {
+          match self.#field_name.as_ref() {
+            ::core::option::Option::Some(inner) => {
+              if let ::core::result::Result::Err(nested_violations) =
+                walrs_fieldfilter::Fieldset::validate(inner)
+              {
+                violations.merge_prefixed(#field_name_str, nested_violations);
+                #break_check
+              }
+            }
+            ::core::option::Option::None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              #break_check
+            }
+          }
+        }
+      } else {
+        quote! {
+          if let ::core::option::Option::Some(inner) = self.#field_name.as_ref() {
+            if let ::core::result::Result::Err(nested_violations) =
+              walrs_fieldfilter::Fieldset::validate(inner)
+            {
+              violations.merge_prefixed(#field_name_str, nested_violations);
+              #break_check
+            }
+          }
+        }
+      }
+    }
+    _ => {
+      quote! {
+        if let ::core::result::Result::Err(nested_violations) =
+          walrs_fieldfilter::Fieldset::validate(&self.#field_name)
+        {
+          violations.merge_prefixed(#field_name_str, nested_violations);
+          #break_check
+        }
+      }
+    }
+  }
+}
+
+/// Build the rule expression tokens for a field.
+fn build_rules(field: &FieldInfo) -> Option<TokenStream> {
+  let rule_type = match &field.ty {
+    FieldType::String | FieldType::OptionString => quote! { String },
+    FieldType::Numeric(id) | FieldType::OptionNumeric(id) => quote! { #id },
+    FieldType::Bool | FieldType::OptionBool => quote! { bool },
+    FieldType::Char | FieldType::OptionChar => quote! { char },
+    FieldType::Other(_) | FieldType::OptionOther(_) => return None,
+  };
+
+  // Separate message/locale modifiers from actual rules
+  let mut message: Option<String> = None;
+  let mut message_fn: Option<&syn::Path> = None;
+  let mut locale: Option<String> = None;
+  let mut rule_attrs: Vec<&ValidateAttr> = Vec::new();
+
+  for attr in &field.validations {
+    match attr {
+      ValidateAttr::Message(m) => message = Some(m.clone()),
+      ValidateAttr::MessageFn(p) => message_fn = Some(p),
+      ValidateAttr::Locale(l) => locale = Some(l.clone()),
+      _ => rule_attrs.push(attr),
+    }
+  }
+
+  if rule_attrs.is_empty() {
+    return None;
+  }
+
+  let individual_rules: Vec<TokenStream> = rule_attrs
+    .iter()
+    .map(|attr| attr_to_rule_token(attr, &rule_type))
+    .collect();
+
+  let base_rule = if individual_rules.len() == 1 {
+    individual_rules.into_iter().next().unwrap()
+  } else {
+    quote! {
+      walrs_validation::Rule::<#rule_type>::All(::std::vec![#(#individual_rules),*])
+    }
+  };
+
+  // Apply message/locale wrappers
+  let wrapped = apply_message_wrappers(base_rule, &message, &message_fn, &locale);
+
+  Some(wrapped)
+}
+
+fn attr_to_rule_token(attr: &ValidateAttr, rule_type: &TokenStream) -> TokenStream {
+  match attr {
+    ValidateAttr::Required => quote! { walrs_validation::Rule::<#rule_type>::Required },
+    ValidateAttr::MinLength(n) => {
+      quote! { walrs_validation::Rule::<#rule_type>::MinLength(#n) }
+    }
+    ValidateAttr::MaxLength(n) => {
+      quote! { walrs_validation::Rule::<#rule_type>::MaxLength(#n) }
+    }
+    ValidateAttr::ExactLength(n) => {
+      quote! { walrs_validation::Rule::<#rule_type>::ExactLength(#n) }
+    }
+    ValidateAttr::Email => {
+      quote! { walrs_validation::Rule::<#rule_type>::Email(::core::default::Default::default()) }
+    }
+    ValidateAttr::Url => {
+      quote! { walrs_validation::Rule::<#rule_type>::Url(::core::default::Default::default()) }
+    }
+    ValidateAttr::Uri => {
+      quote! { walrs_validation::Rule::<#rule_type>::Uri(::core::default::Default::default()) }
+    }
+    ValidateAttr::Ip => {
+      quote! { walrs_validation::Rule::<#rule_type>::Ip(::core::default::Default::default()) }
+    }
+    ValidateAttr::Hostname => {
+      quote! { walrs_validation::Rule::<#rule_type>::Hostname(::core::default::Default::default()) }
+    }
+    ValidateAttr::Pattern(pat) => {
+      quote! {
+        walrs_validation::Rule::<#rule_type>::Pattern(
+          walrs_validation::CompiledPattern::try_from(#pat).unwrap()
+        )
+      }
+    }
+    ValidateAttr::Min(n) => {
+      let lit = numeric_lit_token(n);
+      quote! { walrs_validation::Rule::<#rule_type>::Min(#lit) }
+    }
+    ValidateAttr::Max(n) => {
+      let lit = numeric_lit_token(n);
+      quote! { walrs_validation::Rule::<#rule_type>::Max(#lit) }
+    }
+    ValidateAttr::Range { min, max } => {
+      let min_lit = numeric_lit_token(min);
+      let max_lit = numeric_lit_token(max);
+      quote! { walrs_validation::Rule::<#rule_type>::Range { min: #min_lit, max: #max_lit } }
+    }
+    ValidateAttr::Step(n) => {
+      let lit = numeric_lit_token(n);
+      quote! { walrs_validation::Rule::<#rule_type>::Step(#lit) }
+    }
+    ValidateAttr::OneOf(items) => {
+      let item_tokens: Vec<TokenStream> = items.iter().map(one_of_item_token).collect();
+      quote! { walrs_validation::Rule::<#rule_type>::OneOf(::std::vec![#(#item_tokens),*]) }
+    }
+    ValidateAttr::Custom(path) => {
+      quote! {
+        walrs_validation::Rule::<#rule_type>::Custom(::std::sync::Arc::new(#path))
+      }
+    }
+    // Message/MessageFn/Locale are handled separately
+    ValidateAttr::Message(_) | ValidateAttr::MessageFn(_) | ValidateAttr::Locale(_) => {
+      quote! {}
+    }
+  }
+}
+
+fn numeric_lit_token(n: &NumericLit) -> TokenStream {
+  match n {
+    NumericLit::Int(v) => {
+      // Use the raw integer value; Rust will infer the type
+      let lit = proc_macro2::Literal::i128_unsuffixed(*v);
+      quote! { #lit }
+    }
+    NumericLit::Float(v) => {
+      let lit = proc_macro2::Literal::f64_unsuffixed(*v);
+      quote! { #lit }
+    }
+  }
+}
+
+fn one_of_item_token(item: &OneOfItem) -> TokenStream {
+  match item {
+    OneOfItem::Str(s) => quote! { #s.to_string() },
+    OneOfItem::Int(v) => {
+      let lit = proc_macro2::Literal::i128_unsuffixed(*v);
+      quote! { #lit }
+    }
+    OneOfItem::Float(v) => {
+      let lit = proc_macro2::Literal::f64_unsuffixed(*v);
+      quote! { #lit }
+    }
+  }
+}
+
+fn apply_message_wrappers(
+  base: TokenStream,
+  message: &Option<String>,
+  message_fn: &Option<&syn::Path>,
+  locale: &Option<String>,
+) -> TokenStream {
+  let mut result = base;
+
+  if let Some(msg) = message {
+    result = quote! { (#result).with_message(#msg) };
+  }
+
+  if let Some(path) = message_fn {
+    result = quote! { (#result).with_message_provider(#path, ::core::option::Option::None) };
+  }
+
+  if let Some(loc) = locale {
+    result = quote! { (#result).with_locale(#loc) };
+  }
+
+  result
+}

--- a/crates/fieldset_derive/src/lib.rs
+++ b/crates/fieldset_derive/src/lib.rs
@@ -1,0 +1,117 @@
+mod gen_filter;
+mod gen_validate;
+mod parse;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
+
+use gen_filter::gen_filter;
+use gen_validate::gen_validate;
+use parse::{parse_cross_validate_attrs, parse_field_info, parse_fieldset_struct_attrs};
+
+/// Derive macro for the `Fieldset` trait.
+///
+/// # Attributes
+///
+/// ## Struct-level
+///
+/// - `#[fieldset(break_on_failure)]` — stop validation after the first field with violations
+/// - `#[cross_validate(fn_name)]` — call `fn_name(&self) -> RuleResult` after per-field validation
+///
+/// ## Field-level validation (`#[validate(...)]`)
+///
+/// - `required` — field must not be empty/missing
+/// - `min_length = N` — minimum string/collection length
+/// - `max_length = N` — maximum string/collection length
+/// - `exact_length = N` — exact length
+/// - `email` — valid email format
+/// - `url` — valid URL format
+/// - `uri` — valid URI format
+/// - `ip` — valid IP address
+/// - `hostname` — valid hostname
+/// - `pattern = "regex"` — matches regex pattern
+/// - `min = N` — minimum numeric value
+/// - `max = N` — maximum numeric value
+/// - `range(min = A, max = B)` — numeric range
+/// - `step = N` — numeric step/divisibility
+/// - `one_of = [a, b, c]` — value must be one of the listed values
+/// - `custom = "path::to::fn"` — custom validation function
+/// - `nested` — field implements Fieldset; delegate validation
+/// - `message = "..."` — custom error message
+/// - `message_fn = "path"` — dynamic message provider
+/// - `locale = "en"` — locale for messages
+///
+/// ## Field-level filtering (`#[filter(...)]`)
+///
+/// - `trim` — trim whitespace
+/// - `lowercase` — convert to lowercase
+/// - `uppercase` — convert to uppercase
+/// - `strip_tags` — remove HTML tags
+/// - `html_entities` — encode HTML entities
+/// - `slug` / `slug(max_length = N)` — slugify
+/// - `truncate(max_length = N)` — truncate to length
+/// - `replace(from = "x", to = "y")` — string replacement
+/// - `clamp(min = A, max = B)` — clamp numeric value
+/// - `custom = "path::to::fn"` — custom filter function
+/// - `try_custom = "path::to::fn"` — fallible custom filter
+/// - `nested` — field implements Fieldset; delegate filtering
+#[proc_macro_derive(Fieldset, attributes(validate, filter, cross_validate, fieldset))]
+pub fn derive_fieldset(input: TokenStream) -> TokenStream {
+  let input = parse_macro_input!(input as DeriveInput);
+  match derive_fieldset_impl(input) {
+    Ok(tokens) => tokens.into(),
+    Err(e) => e.to_compile_error().into(),
+  }
+}
+
+fn derive_fieldset_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+  let struct_name = &input.ident;
+  let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+  // Only support named structs
+  let fields = match &input.data {
+    Data::Struct(ds) => match &ds.fields {
+      Fields::Named(named) => &named.named,
+      _ => {
+        return Err(syn::Error::new_spanned(
+          struct_name,
+          "Fieldset can only be derived for structs with named fields",
+        ));
+      }
+    },
+    _ => {
+      return Err(syn::Error::new_spanned(
+        struct_name,
+        "Fieldset can only be derived for structs",
+      ));
+    }
+  };
+
+  // Parse struct-level attributes
+  let struct_attrs = parse_fieldset_struct_attrs(&input.attrs);
+  let cross_validate = parse_cross_validate_attrs(&input.attrs);
+
+  // Parse all fields
+  let field_infos: Vec<_> = fields.iter().map(parse_field_info).collect();
+
+  // Generate the const
+  let break_on_failure = struct_attrs.break_on_failure;
+
+  // Generate validate and filter methods
+  let validate_fn = gen_validate(
+    &field_infos,
+    &cross_validate.fns,
+    struct_attrs.break_on_failure,
+  );
+  let filter_fn = gen_filter(&field_infos);
+
+  Ok(quote! {
+    impl #impl_generics walrs_fieldfilter::Fieldset for #struct_name #ty_generics #where_clause {
+      const BREAK_ON_FAILURE: bool = #break_on_failure;
+
+      #validate_fn
+      #filter_fn
+    }
+  })
+}

--- a/crates/fieldset_derive/src/parse.rs
+++ b/crates/fieldset_derive/src/parse.rs
@@ -1,0 +1,569 @@
+use syn::{
+  Attribute, Expr, ExprLit, Field, Ident, Lit, LitFloat, LitInt, LitStr, MetaNameValue, Path,
+  Token, Type, TypePath, parenthesized, parse::Parse, parse::ParseStream, punctuated::Punctuated,
+  token,
+};
+
+// ---------------------------------------------------------------------------
+// Struct-level attributes
+// ---------------------------------------------------------------------------
+
+/// Parsed `#[fieldset(...)]` on the struct.
+#[derive(Debug, Default)]
+pub struct FieldsetStructAttrs {
+  pub break_on_failure: bool,
+}
+
+/// Parsed `#[cross_validate(fn_name)]` on the struct.
+#[derive(Debug, Default)]
+pub struct CrossValidateAttrs {
+  pub fns: Vec<Path>,
+}
+
+// ---------------------------------------------------------------------------
+// Field-level parsed data
+// ---------------------------------------------------------------------------
+
+/// Everything we need to know about one field.
+#[derive(Debug)]
+pub struct FieldInfo {
+  pub ident: Ident,
+  pub ty: FieldType,
+  pub validations: Vec<ValidateAttr>,
+  pub filters: Vec<FilterAttr>,
+  pub is_nested_validate: bool,
+  pub is_nested_filter: bool,
+  pub break_on_failure_override: Option<bool>,
+}
+
+/// Simplified type classification.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum FieldType {
+  String,
+  Bool,
+  Char,
+  Numeric(Ident), // i32, u64, f64, etc.
+  OptionString,
+  OptionBool,
+  OptionChar,
+  OptionNumeric(Ident),
+  Other(Type), // for nested types
+  OptionOther(Type),
+}
+
+// ---------------------------------------------------------------------------
+// Validate attributes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum ValidateAttr {
+  Required,
+  MinLength(usize),
+  MaxLength(usize),
+  ExactLength(usize),
+  Email,
+  Url,
+  Uri,
+  Ip,
+  Hostname,
+  Pattern(String),
+  Min(NumericLit),
+  Max(NumericLit),
+  Range { min: NumericLit, max: NumericLit },
+  Step(NumericLit),
+  OneOf(Vec<OneOfItem>),
+  Custom(Path),
+  Message(String),
+  MessageFn(Path),
+  Locale(String),
+}
+
+/// A numeric literal that can be integer or float.
+#[derive(Debug, Clone)]
+pub enum NumericLit {
+  Int(i128),
+  Float(f64),
+}
+
+/// Items in a `one_of = [...]` list.
+#[derive(Debug, Clone)]
+pub enum OneOfItem {
+  Str(String),
+  Int(i128),
+  Float(f64),
+}
+
+// ---------------------------------------------------------------------------
+// Filter attributes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum FilterAttr {
+  Trim,
+  Lowercase,
+  Uppercase,
+  StripTags,
+  HtmlEntities,
+  Slug { max_length: Option<usize> },
+  Truncate { max_length: usize },
+  Replace { from: String, to: String },
+  Clamp { min: NumericLit, max: NumericLit },
+  Custom(Path),
+  TryCustom(Path),
+}
+
+// ---------------------------------------------------------------------------
+// Parsing implementations
+// ---------------------------------------------------------------------------
+
+const NUMERIC_TYPES: &[&str] = &[
+  "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64", "u128", "usize", "f32",
+  "f64",
+];
+
+/// Classify a syn::Type into our FieldType.
+pub fn classify_type(ty: &Type) -> FieldType {
+  if let Type::Path(TypePath { path, .. }) = ty
+    && let Some(seg) = path.segments.last()
+  {
+    let name = seg.ident.to_string();
+    // Check for Option<T>
+    if name == "Option" {
+      if let syn::PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+      {
+        return classify_option_inner(inner, ty);
+      }
+      return FieldType::OptionOther(ty.clone());
+    }
+    if name == "String" {
+      return FieldType::String;
+    }
+    if name == "bool" {
+      return FieldType::Bool;
+    }
+    if name == "char" {
+      return FieldType::Char;
+    }
+    if NUMERIC_TYPES.contains(&name.as_str()) {
+      return FieldType::Numeric(seg.ident.clone());
+    }
+  }
+  FieldType::Other(ty.clone())
+}
+
+fn classify_option_inner(inner: &Type, _outer: &Type) -> FieldType {
+  if let Type::Path(TypePath { path, .. }) = inner
+    && let Some(seg) = path.segments.last()
+  {
+    let name = seg.ident.to_string();
+    if name == "String" {
+      return FieldType::OptionString;
+    }
+    if name == "bool" {
+      return FieldType::OptionBool;
+    }
+    if name == "char" {
+      return FieldType::OptionChar;
+    }
+    if NUMERIC_TYPES.contains(&name.as_str()) {
+      return FieldType::OptionNumeric(seg.ident.clone());
+    }
+  }
+  FieldType::OptionOther(inner.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Parse struct-level `#[fieldset(...)]`
+// ---------------------------------------------------------------------------
+
+pub fn parse_fieldset_struct_attrs(attrs: &[Attribute]) -> FieldsetStructAttrs {
+  let mut result = FieldsetStructAttrs::default();
+  for attr in attrs {
+    if attr.path().is_ident("fieldset") {
+      let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("break_on_failure") {
+          result.break_on_failure = true;
+        }
+        Ok(())
+      });
+    }
+  }
+  result
+}
+
+// ---------------------------------------------------------------------------
+// Parse struct-level `#[cross_validate(fn_name)]`
+// ---------------------------------------------------------------------------
+
+pub fn parse_cross_validate_attrs(attrs: &[Attribute]) -> CrossValidateAttrs {
+  let mut result = CrossValidateAttrs::default();
+  for attr in attrs {
+    if attr.path().is_ident("cross_validate")
+      && let Ok(path) = attr.parse_args::<Path>()
+    {
+      result.fns.push(path);
+    }
+  }
+  result
+}
+
+// ---------------------------------------------------------------------------
+// Parse field-level attributes
+// ---------------------------------------------------------------------------
+
+pub fn parse_field_info(field: &Field) -> FieldInfo {
+  let ident = field
+    .ident
+    .clone()
+    .expect("Fieldset derive only supports named fields");
+  let ty = classify_type(&field.ty);
+  let mut validations = Vec::new();
+  let mut filters = Vec::new();
+  let mut is_nested_validate = false;
+  let mut is_nested_filter = false;
+  let mut break_on_failure_override = None;
+
+  for attr in &field.attrs {
+    if attr.path().is_ident("validate") {
+      parse_validate_attr(attr, &mut validations, &mut is_nested_validate);
+    } else if attr.path().is_ident("filter") {
+      parse_filter_attr(attr, &mut filters, &mut is_nested_filter);
+    } else if attr.path().is_ident("fieldset") {
+      let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("break_on_failure") {
+          if meta.input.peek(Token![=]) {
+            let _: Token![=] = meta.input.parse()?;
+            let lit: syn::LitBool = meta.input.parse()?;
+            break_on_failure_override = Some(lit.value());
+          } else {
+            break_on_failure_override = Some(true);
+          }
+        }
+        Ok(())
+      });
+    }
+  }
+
+  FieldInfo {
+    ident,
+    ty,
+    validations,
+    filters,
+    is_nested_validate,
+    is_nested_filter,
+    break_on_failure_override,
+  }
+}
+
+fn parse_validate_attr(
+  attr: &Attribute,
+  validations: &mut Vec<ValidateAttr>,
+  is_nested: &mut bool,
+) {
+  let _ = attr.parse_nested_meta(|meta| {
+    let path = &meta.path;
+
+    if path.is_ident("required") {
+      validations.push(ValidateAttr::Required);
+    } else if path.is_ident("min_length") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitInt = meta.input.parse()?;
+      validations.push(ValidateAttr::MinLength(lit.base10_parse()?));
+    } else if path.is_ident("max_length") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitInt = meta.input.parse()?;
+      validations.push(ValidateAttr::MaxLength(lit.base10_parse()?));
+    } else if path.is_ident("exact_length") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitInt = meta.input.parse()?;
+      validations.push(ValidateAttr::ExactLength(lit.base10_parse()?));
+    } else if path.is_ident("email") {
+      validations.push(ValidateAttr::Email);
+    } else if path.is_ident("url") {
+      validations.push(ValidateAttr::Url);
+    } else if path.is_ident("uri") {
+      validations.push(ValidateAttr::Uri);
+    } else if path.is_ident("ip") {
+      validations.push(ValidateAttr::Ip);
+    } else if path.is_ident("hostname") {
+      validations.push(ValidateAttr::Hostname);
+    } else if path.is_ident("pattern") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      validations.push(ValidateAttr::Pattern(lit.value()));
+    } else if path.is_ident("min") {
+      let _: Token![=] = meta.input.parse()?;
+      validations.push(ValidateAttr::Min(parse_numeric_lit(&meta.input)?));
+    } else if path.is_ident("max") {
+      let _: Token![=] = meta.input.parse()?;
+      validations.push(ValidateAttr::Max(parse_numeric_lit(&meta.input)?));
+    } else if path.is_ident("range") {
+      let content;
+      parenthesized!(content in meta.input);
+      let mut min = None;
+      let mut max = None;
+      let items: Punctuated<MetaNameValue, Token![,]> =
+        content.parse_terminated(MetaNameValue::parse, Token![,])?;
+      for item in items {
+        if item.path.is_ident("min") {
+          min = Some(expr_to_numeric_lit(&item.value)?);
+        } else if item.path.is_ident("max") {
+          max = Some(expr_to_numeric_lit(&item.value)?);
+        }
+      }
+      validations.push(ValidateAttr::Range {
+        min: min.expect("range requires min"),
+        max: max.expect("range requires max"),
+      });
+    } else if path.is_ident("step") {
+      let _: Token![=] = meta.input.parse()?;
+      validations.push(ValidateAttr::Step(parse_numeric_lit(&meta.input)?));
+    } else if path.is_ident("one_of") {
+      let _: Token![=] = meta.input.parse()?;
+      let content;
+      syn::bracketed!(content in meta.input);
+      let items: Punctuated<Expr, Token![,]> = content.parse_terminated(Expr::parse, Token![,])?;
+      let mut one_of_items = Vec::new();
+      for item in items {
+        match &item {
+          Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+          }) => one_of_items.push(OneOfItem::Str(s.value())),
+          Expr::Lit(ExprLit {
+            lit: Lit::Int(i), ..
+          }) => one_of_items.push(OneOfItem::Int(i.base10_parse()?)),
+          Expr::Lit(ExprLit {
+            lit: Lit::Float(f), ..
+          }) => one_of_items.push(OneOfItem::Float(f.base10_parse()?)),
+          // Handle negative numeric literals like -1
+          Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+            if let Expr::Lit(ExprLit { lit, .. }) = &*unary.expr {
+              match lit {
+                Lit::Int(i) => {
+                  let val: i128 = i.base10_parse()?;
+                  one_of_items.push(OneOfItem::Int(-val));
+                }
+                Lit::Float(f) => {
+                  let val: f64 = f.base10_parse()?;
+                  one_of_items.push(OneOfItem::Float(-val));
+                }
+                _ => {
+                  return Err(syn::Error::new_spanned(lit, "Expected numeric literal"));
+                }
+              }
+            }
+          }
+          _ => return Err(syn::Error::new_spanned(item, "Expected literal in one_of")),
+        }
+      }
+      validations.push(ValidateAttr::OneOf(one_of_items));
+    } else if path.is_ident("custom") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      let path: Path = lit.parse()?;
+      validations.push(ValidateAttr::Custom(path));
+    } else if path.is_ident("nested") {
+      *is_nested = true;
+    } else if path.is_ident("message") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      validations.push(ValidateAttr::Message(lit.value()));
+    } else if path.is_ident("message_fn") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      let path: Path = lit.parse()?;
+      validations.push(ValidateAttr::MessageFn(path));
+    } else if path.is_ident("locale") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      validations.push(ValidateAttr::Locale(lit.value()));
+    } else {
+      return Err(syn::Error::new_spanned(
+        path,
+        format!("Unknown validate attribute: {:?}", path.get_ident()),
+      ));
+    }
+    Ok(())
+  });
+}
+
+fn parse_filter_attr(attr: &Attribute, filters: &mut Vec<FilterAttr>, is_nested: &mut bool) {
+  let _ = attr.parse_nested_meta(|meta| {
+    let path = &meta.path;
+
+    if path.is_ident("trim") {
+      filters.push(FilterAttr::Trim);
+    } else if path.is_ident("lowercase") {
+      filters.push(FilterAttr::Lowercase);
+    } else if path.is_ident("uppercase") {
+      filters.push(FilterAttr::Uppercase);
+    } else if path.is_ident("strip_tags") {
+      filters.push(FilterAttr::StripTags);
+    } else if path.is_ident("html_entities") {
+      filters.push(FilterAttr::HtmlEntities);
+    } else if path.is_ident("slug") {
+      if meta.input.peek(token::Paren) {
+        let content;
+        parenthesized!(content in meta.input);
+        let items: Punctuated<MetaNameValue, Token![,]> =
+          content.parse_terminated(MetaNameValue::parse, Token![,])?;
+        let mut max_length = None;
+        for item in items {
+          if item.path.is_ident("max_length") {
+            max_length = Some(expr_to_usize(&item.value)?);
+          }
+        }
+        filters.push(FilterAttr::Slug { max_length });
+      } else {
+        filters.push(FilterAttr::Slug { max_length: None });
+      }
+    } else if path.is_ident("truncate") {
+      let content;
+      parenthesized!(content in meta.input);
+      let items: Punctuated<MetaNameValue, Token![,]> =
+        content.parse_terminated(MetaNameValue::parse, Token![,])?;
+      let mut max_length = None;
+      for item in items {
+        if item.path.is_ident("max_length") {
+          max_length = Some(expr_to_usize(&item.value)?);
+        }
+      }
+      filters.push(FilterAttr::Truncate {
+        max_length: max_length.expect("truncate requires max_length"),
+      });
+    } else if path.is_ident("replace") {
+      let content;
+      parenthesized!(content in meta.input);
+      let items: Punctuated<MetaNameValue, Token![,]> =
+        content.parse_terminated(MetaNameValue::parse, Token![,])?;
+      let mut from = None;
+      let mut to = None;
+      for item in items {
+        if item.path.is_ident("from") {
+          from = Some(expr_to_string(&item.value)?);
+        } else if item.path.is_ident("to") {
+          to = Some(expr_to_string(&item.value)?);
+        }
+      }
+      filters.push(FilterAttr::Replace {
+        from: from.expect("replace requires from"),
+        to: to.expect("replace requires to"),
+      });
+    } else if path.is_ident("clamp") {
+      let content;
+      parenthesized!(content in meta.input);
+      let items: Punctuated<MetaNameValue, Token![,]> =
+        content.parse_terminated(MetaNameValue::parse, Token![,])?;
+      let mut min = None;
+      let mut max = None;
+      for item in items {
+        if item.path.is_ident("min") {
+          min = Some(expr_to_numeric_lit(&item.value)?);
+        } else if item.path.is_ident("max") {
+          max = Some(expr_to_numeric_lit(&item.value)?);
+        }
+      }
+      filters.push(FilterAttr::Clamp {
+        min: min.expect("clamp requires min"),
+        max: max.expect("clamp requires max"),
+      });
+    } else if path.is_ident("custom") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      let path: Path = lit.parse()?;
+      filters.push(FilterAttr::Custom(path));
+    } else if path.is_ident("try_custom") {
+      let _: Token![=] = meta.input.parse()?;
+      let lit: LitStr = meta.input.parse()?;
+      let path: Path = lit.parse()?;
+      filters.push(FilterAttr::TryCustom(path));
+    } else if path.is_ident("nested") {
+      *is_nested = true;
+    } else {
+      return Err(syn::Error::new_spanned(
+        path,
+        format!("Unknown filter attribute: {:?}", path.get_ident()),
+      ));
+    }
+    Ok(())
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_numeric_lit(input: &ParseStream) -> syn::Result<NumericLit> {
+  // Check for negative sign
+  let negative = if input.peek(Token![-]) {
+    let _: Token![-] = input.parse()?;
+    true
+  } else {
+    false
+  };
+
+  if input.peek(LitFloat) {
+    let lit: LitFloat = input.parse()?;
+    let val: f64 = lit.base10_parse()?;
+    Ok(NumericLit::Float(if negative { -val } else { val }))
+  } else if input.peek(LitInt) {
+    let lit: LitInt = input.parse()?;
+    let val: i128 = lit.base10_parse()?;
+    Ok(NumericLit::Int(if negative { -val } else { val }))
+  } else {
+    Err(input.error("Expected numeric literal"))
+  }
+}
+
+fn expr_to_numeric_lit(expr: &Expr) -> syn::Result<NumericLit> {
+  match expr {
+    Expr::Lit(ExprLit {
+      lit: Lit::Int(i), ..
+    }) => Ok(NumericLit::Int(i.base10_parse()?)),
+    Expr::Lit(ExprLit {
+      lit: Lit::Float(f), ..
+    }) => Ok(NumericLit::Float(f.base10_parse()?)),
+    Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+      if let Expr::Lit(ExprLit { lit, .. }) = &*unary.expr {
+        match lit {
+          Lit::Int(i) => {
+            let val: i128 = i.base10_parse()?;
+            Ok(NumericLit::Int(-val))
+          }
+          Lit::Float(f) => {
+            let val: f64 = f.base10_parse()?;
+            Ok(NumericLit::Float(-val))
+          }
+          _ => Err(syn::Error::new_spanned(expr, "Expected numeric literal")),
+        }
+      } else {
+        Err(syn::Error::new_spanned(expr, "Expected numeric literal"))
+      }
+    }
+    _ => Err(syn::Error::new_spanned(expr, "Expected numeric literal")),
+  }
+}
+
+fn expr_to_usize(expr: &Expr) -> syn::Result<usize> {
+  if let Expr::Lit(ExprLit {
+    lit: Lit::Int(i), ..
+  }) = expr
+  {
+    i.base10_parse()
+  } else {
+    Err(syn::Error::new_spanned(expr, "Expected integer literal"))
+  }
+}
+
+fn expr_to_string(expr: &Expr) -> syn::Result<String> {
+  if let Expr::Lit(ExprLit {
+    lit: Lit::Str(s), ..
+  }) = expr
+  {
+    Ok(s.value())
+  } else {
+    Err(syn::Error::new_spanned(expr, "Expected string literal"))
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `walrs_fieldset_derive` proc-macro crate providing `#[derive(Fieldset)]` for compile-time type-checked validation and filtering.

## Related Issue

Closes #201
Part of #197

## Changes

- New `crates/fieldset_derive/` proc-macro crate
- Validation annotations: required, min_length, max_length, email, url, pattern, min, max, range, step, one_of, custom, nested
- Filter annotations: trim, lowercase, uppercase, strip_tags, html_entities, slug, truncate, replace, clamp, custom, try_custom, nested
- Cross-field validation via `#[cross_validate(fn_name)]`
- `break_on_failure` support (struct-level + per-field override)
- Message customization (`message`, `message_fn`, `locale`)
- `Option<T>` handling with automatic None-skipping
- Nested struct support with prefixed violations
- Feature-gated in `walrs_fieldfilter` via `derive` feature
- Integration tests

## Testing

- Integration tests covering: simple structs, nested structs, cross-field validation, Option fields, break_on_failure, numeric validation, message customization
- `cargo test --workspace` passes
- `cargo test -p walrs_fieldfilter --features derive` passes (32 tests)