### PR TITLE
feat(walrs_fieldset_derive): #197 Add Into<FormData>/TryFrom<FormData> bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "walrs_fieldfilter",
+ "walrs_fieldset_derive",
  "walrs_validation",
  "wasm-bindgen",
  "web-sys",

--- a/crates/fieldset_derive/src/gen_form_data.rs
+++ b/crates/fieldset_derive/src/gen_form_data.rs
@@ -40,7 +40,7 @@ pub fn gen_into_form_data(
               data.insert(#field_name_str, walrs_validation::Value::I64(value.#field_name as i64));
             },
             "i128" => quote! {
-              data.insert(#field_name_str, walrs_validation::Value::I64(value.#field_name as i64));
+              data.insert(#field_name_str, walrs_validation::Value::Str(value.#field_name.to_string()));
             },
             "u8" | "u16" | "u32" => quote! {
               data.insert(#field_name_str, walrs_validation::Value::U64(value.#field_name as u64));
@@ -49,7 +49,7 @@ pub fn gen_into_form_data(
               data.insert(#field_name_str, walrs_validation::Value::U64(value.#field_name as u64));
             },
             "u128" => quote! {
-              data.insert(#field_name_str, walrs_validation::Value::U64(value.#field_name as u64));
+              data.insert(#field_name_str, walrs_validation::Value::Str(value.#field_name.to_string()));
             },
             "f32" => quote! {
               data.insert(#field_name_str, walrs_validation::Value::F64(value.#field_name as f64));
@@ -86,16 +86,30 @@ pub fn gen_into_form_data(
         FieldType::OptionNumeric(num_type) => {
           let num_type_str = num_type.to_string();
           match num_type_str.as_str() {
-            "i8" | "i16" | "i32" | "i64" | "isize" | "i128" => quote! {
+            "i8" | "i16" | "i32" | "i64" | "isize" => quote! {
               if let Some(val) = value.#field_name {
                 data.insert(#field_name_str, walrs_validation::Value::I64(val as i64));
               } else {
                 data.insert(#field_name_str, walrs_validation::Value::Null);
               }
             },
-            "u8" | "u16" | "u32" | "u64" | "usize" | "u128" => quote! {
+            "i128" => quote! {
+              if let Some(val) = value.#field_name {
+                data.insert(#field_name_str, walrs_validation::Value::Str(val.to_string()));
+              } else {
+                data.insert(#field_name_str, walrs_validation::Value::Null);
+              }
+            },
+            "u8" | "u16" | "u32" | "u64" | "usize" => quote! {
               if let Some(val) = value.#field_name {
                 data.insert(#field_name_str, walrs_validation::Value::U64(val as u64));
+              } else {
+                data.insert(#field_name_str, walrs_validation::Value::Null);
+              }
+            },
+            "u128" => quote! {
+              if let Some(val) = value.#field_name {
+                data.insert(#field_name_str, walrs_validation::Value::Str(val.to_string()));
               } else {
                 data.insert(#field_name_str, walrs_validation::Value::Null);
               }
@@ -341,16 +355,27 @@ fn gen_numeric_extraction(
   };
 
   match num_type_str.as_str() {
-    "i8" | "i16" | "i32" | "i64" | "i128" | "isize" => {
+    "i128" => {
       if is_option {
         quote! {
           let #field_name = match data.get_direct(#field_name_str) {
-            Some(walrs_validation::Value::I64(n)) => {
-              Some(*n as #num_type)
+            Some(walrs_validation::Value::Str(s)) => {
+              match s.parse::<i128>() {
+                Ok(v) => Some(v),
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Expected valid ", #num_type_str, " string")
+                    )
+                  );
+                  None
+                }
+              }
             }
-            Some(walrs_validation::Value::U64(n)) => {
-              Some(*n as #num_type)
-            }
+            Some(walrs_validation::Value::I64(n)) => Some(*n as i128),
+            Some(walrs_validation::Value::U64(n)) => Some(*n as i128),
             Some(walrs_validation::Value::Null) | None => None,
             Some(_) => {
               violations.add(
@@ -367,8 +392,23 @@ fn gen_numeric_extraction(
       } else {
         quote! {
           let #field_name = match data.get_direct(#field_name_str) {
-            Some(walrs_validation::Value::I64(n)) => *n as #num_type,
-            Some(walrs_validation::Value::U64(n)) => *n as #num_type,
+            Some(walrs_validation::Value::Str(s)) => {
+              match s.parse::<i128>() {
+                Ok(v) => v,
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Expected valid ", #num_type_str, " string")
+                    )
+                  );
+                  #default_value
+                }
+              }
+            }
+            Some(walrs_validation::Value::I64(n)) => *n as i128,
+            Some(walrs_validation::Value::U64(n)) => *n as i128,
             Some(_) => {
               violations.add(
                 #field_name_str,
@@ -387,12 +427,40 @@ fn gen_numeric_extraction(
         }
       }
     }
-    "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+    "i8" | "i16" | "i32" | "i64" | "isize" => {
       if is_option {
         quote! {
           let #field_name = match data.get_direct(#field_name_str) {
-            Some(walrs_validation::Value::U64(n)) => Some(*n as #num_type),
-            Some(walrs_validation::Value::I64(n)) if *n >= 0 => Some(*n as #num_type),
+            Some(walrs_validation::Value::I64(n)) => {
+              match #num_type::try_from(*n) {
+                Ok(v) => Some(v),
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  None
+                }
+              }
+            }
+            Some(walrs_validation::Value::U64(n)) => {
+              match #num_type::try_from(*n) {
+                Ok(v) => Some(v),
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  None
+                }
+              }
+            }
             Some(walrs_validation::Value::Null) | None => None,
             Some(_) => {
               violations.add(
@@ -409,8 +477,206 @@ fn gen_numeric_extraction(
       } else {
         quote! {
           let #field_name = match data.get_direct(#field_name_str) {
-            Some(walrs_validation::Value::U64(n)) => *n as #num_type,
-            Some(walrs_validation::Value::I64(n)) if *n >= 0 => *n as #num_type,
+            Some(walrs_validation::Value::I64(n)) => {
+              match #num_type::try_from(*n) {
+                Ok(v) => v,
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  #default_value
+                }
+              }
+            }
+            Some(walrs_validation::Value::U64(n)) => {
+              match #num_type::try_from(*n) {
+                Ok(v) => v,
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  #default_value
+                }
+              }
+            }
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str)
+                )
+              );
+              #default_value
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              #default_value
+            }
+          };
+        }
+      }
+    }
+    "u128" => {
+      if is_option {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Str(s)) => {
+              match s.parse::<u128>() {
+                Ok(v) => Some(v),
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Expected valid ", #num_type_str, " string")
+                    )
+                  );
+                  None
+                }
+              }
+            }
+            Some(walrs_validation::Value::U64(n)) => Some(*n as u128),
+            Some(walrs_validation::Value::I64(n)) if *n >= 0 => Some(*n as u128),
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str, " or null")
+                )
+              );
+              None
+            }
+          };
+        }
+      } else {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Str(s)) => {
+              match s.parse::<u128>() {
+                Ok(v) => v,
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Expected valid ", #num_type_str, " string")
+                    )
+                  );
+                  #default_value
+                }
+              }
+            }
+            Some(walrs_validation::Value::U64(n)) => *n as u128,
+            Some(walrs_validation::Value::I64(n)) if *n >= 0 => *n as u128,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str)
+                )
+              );
+              #default_value
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              #default_value
+            }
+          };
+        }
+      }
+    }
+    "u8" | "u16" | "u32" | "u64" | "usize" => {
+      if is_option {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::U64(n)) => {
+              match #num_type::try_from(*n) {
+                Ok(v) => Some(v),
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  None
+                }
+              }
+            }
+            Some(walrs_validation::Value::I64(n)) if *n >= 0 => {
+              match #num_type::try_from(*n) {
+                Ok(v) => Some(v),
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  None
+                }
+              }
+            }
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str, " or null")
+                )
+              );
+              None
+            }
+          };
+        }
+      } else {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::U64(n)) => {
+              match #num_type::try_from(*n) {
+                Ok(v) => v,
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  #default_value
+                }
+              }
+            }
+            Some(walrs_validation::Value::I64(n)) if *n >= 0 => {
+              match #num_type::try_from(*n) {
+                Ok(v) => v,
+                Err(_) => {
+                  violations.add(
+                    #field_name_str,
+                    walrs_validation::Violation::new(
+                      walrs_validation::ViolationType::TypeMismatch,
+                      concat!("Value out of range for ", #num_type_str)
+                    )
+                  );
+                  #default_value
+                }
+              }
+            }
             Some(_) => {
               violations.add(
                 #field_name_str,

--- a/crates/fieldset_derive/src/gen_form_data.rs
+++ b/crates/fieldset_derive/src/gen_form_data.rs
@@ -1,0 +1,483 @@
+//! Code generation for FormData bridge (`into_form_data`, `try_from_form_data`).
+
+use crate::parse::{FieldInfo, FieldType};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+/// Generate `impl From<&T> for walrs_form::FormData` if requested.
+pub fn gen_into_form_data(
+  struct_name: &Ident,
+  field_infos: &[FieldInfo],
+  impl_generics: &syn::ImplGenerics,
+  ty_generics: &syn::TypeGenerics,
+  where_clause: Option<&syn::WhereClause>,
+) -> TokenStream {
+  let field_conversions: Vec<TokenStream> = field_infos
+    .iter()
+    .map(|field| {
+      let field_name = &field.ident;
+      let field_name_str = field_name.to_string();
+      
+      match &field.ty {
+        FieldType::String => quote! {
+          data.insert(#field_name_str, walrs_validation::Value::Str(value.#field_name.clone()));
+        },
+        FieldType::Bool => quote! {
+          data.insert(#field_name_str, walrs_validation::Value::Bool(value.#field_name));
+        },
+        FieldType::Char => quote! {
+          data.insert(#field_name_str, walrs_validation::Value::Str(value.#field_name.to_string()));
+        },
+        FieldType::Numeric(num_type) => {
+          // Cast to the appropriate Value-compatible type
+          let num_type_str = num_type.to_string();
+          match num_type_str.as_str() {
+            "i8" | "i16" | "i32" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::I64(value.#field_name as i64));
+            },
+            "i64" | "isize" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::I64(value.#field_name as i64));
+            },
+            "i128" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::I64(value.#field_name as i64));
+            },
+            "u8" | "u16" | "u32" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::U64(value.#field_name as u64));
+            },
+            "u64" | "usize" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::U64(value.#field_name as u64));
+            },
+            "u128" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::U64(value.#field_name as u64));
+            },
+            "f32" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::F64(value.#field_name as f64));
+            },
+            "f64" => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::F64(value.#field_name));
+            },
+            _ => quote! {
+              data.insert(#field_name_str, walrs_validation::Value::from(value.#field_name));
+            },
+          }
+        },
+        FieldType::OptionString => quote! {
+          if let Some(ref val) = value.#field_name {
+            data.insert(#field_name_str, walrs_validation::Value::Str(val.clone()));
+          } else {
+            data.insert(#field_name_str, walrs_validation::Value::Null);
+          }
+        },
+        FieldType::OptionBool => quote! {
+          if let Some(val) = value.#field_name {
+            data.insert(#field_name_str, walrs_validation::Value::Bool(val));
+          } else {
+            data.insert(#field_name_str, walrs_validation::Value::Null);
+          }
+        },
+        FieldType::OptionChar => quote! {
+          if let Some(val) = value.#field_name {
+            data.insert(#field_name_str, walrs_validation::Value::Str(val.to_string()));
+          } else {
+            data.insert(#field_name_str, walrs_validation::Value::Null);
+          }
+        },
+        FieldType::OptionNumeric(num_type) => {
+          let num_type_str = num_type.to_string();
+          match num_type_str.as_str() {
+            "i8" | "i16" | "i32" | "i64" | "isize" | "i128" => quote! {
+              if let Some(val) = value.#field_name {
+                data.insert(#field_name_str, walrs_validation::Value::I64(val as i64));
+              } else {
+                data.insert(#field_name_str, walrs_validation::Value::Null);
+              }
+            },
+            "u8" | "u16" | "u32" | "u64" | "usize" | "u128" => quote! {
+              if let Some(val) = value.#field_name {
+                data.insert(#field_name_str, walrs_validation::Value::U64(val as u64));
+              } else {
+                data.insert(#field_name_str, walrs_validation::Value::Null);
+              }
+            },
+            "f32" | "f64" => quote! {
+              if let Some(val) = value.#field_name {
+                data.insert(#field_name_str, walrs_validation::Value::F64(val as f64));
+              } else {
+                data.insert(#field_name_str, walrs_validation::Value::Null);
+              }
+            },
+            _ => quote! {
+              if let Some(val) = value.#field_name {
+                data.insert(#field_name_str, walrs_validation::Value::from(val));
+              } else {
+                data.insert(#field_name_str, walrs_validation::Value::Null);
+              }
+            },
+          }
+        },
+        FieldType::Other(_) | FieldType::OptionOther(_) => {
+          // For nested types, we skip them for now or could try to recursively convert
+          // if they also implement into_form_data. For simplicity, we'll skip.
+          quote! {
+            // Nested type conversion not yet implemented for #field_name_str
+          }
+        }
+      }
+    })
+    .collect();
+
+  quote! {
+    impl #impl_generics From<&#struct_name #ty_generics> for walrs_form::FormData #where_clause {
+      fn from(value: &#struct_name #ty_generics) -> Self {
+        let mut data = walrs_form::FormData::new();
+        #(#field_conversions)*
+        data
+      }
+    }
+  }
+}
+
+/// Generate `impl TryFrom<walrs_form::FormData> for T` if requested.
+pub fn gen_try_from_form_data(
+  struct_name: &Ident,
+  field_infos: &[FieldInfo],
+  impl_generics: &syn::ImplGenerics,
+  ty_generics: &syn::TypeGenerics,
+  where_clause: Option<&syn::WhereClause>,
+) -> TokenStream {
+  let field_extractions: Vec<TokenStream> = field_infos
+    .iter()
+    .map(|field| {
+      let field_name = &field.ident;
+      let field_name_str = field_name.to_string();
+      
+      match &field.ty {
+        FieldType::String => quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Str(s)) => s.clone(),
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  "Expected string"
+                )
+              );
+              String::new()
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              String::new()
+            }
+          };
+        },
+        FieldType::Bool => quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Bool(b)) => *b,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  "Expected boolean"
+                )
+              );
+              false
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              false
+            }
+          };
+        },
+        FieldType::Char => quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Str(s)) => {
+              if s.len() == 1 {
+                s.chars().next().unwrap()
+              } else {
+                violations.add(
+                  #field_name_str,
+                  walrs_validation::Violation::new(
+                    walrs_validation::ViolationType::TypeMismatch,
+                    "Expected single character"
+                  )
+                );
+                '\0'
+              }
+            }
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  "Expected string"
+                )
+              );
+              '\0'
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              '\0'
+            }
+          };
+        },
+        FieldType::Numeric(num_type) => {
+          gen_numeric_extraction(field_name, &field_name_str, num_type, false)
+        },
+        FieldType::OptionString => quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Str(s)) => Some(s.clone()),
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  "Expected string or null"
+                )
+              );
+              None
+            }
+          };
+        },
+        FieldType::OptionBool => quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Bool(b)) => Some(*b),
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  "Expected boolean or null"
+                )
+              );
+              None
+            }
+          };
+        },
+        FieldType::OptionChar => quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::Str(s)) => {
+              if s.len() == 1 {
+                s.chars().next()
+              } else {
+                violations.add(
+                  #field_name_str,
+                  walrs_validation::Violation::new(
+                    walrs_validation::ViolationType::TypeMismatch,
+                    "Expected single character"
+                  )
+                );
+                None
+              }
+            }
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  "Expected string or null"
+                )
+              );
+              None
+            }
+          };
+        },
+        FieldType::OptionNumeric(num_type) => {
+          gen_numeric_extraction(field_name, &field_name_str, num_type, true)
+        },
+        FieldType::Other(_) | FieldType::OptionOther(_) => {
+          // For nested types, we skip them for now
+          quote! {
+            let #field_name = Default::default();
+          }
+        }
+      }
+    })
+    .collect();
+
+  let field_names: Vec<_> = field_infos.iter().map(|f| &f.ident).collect();
+
+  quote! {
+    impl #impl_generics TryFrom<walrs_form::FormData> for #struct_name #ty_generics #where_clause {
+      type Error = walrs_validation::FieldsetViolations;
+
+      fn try_from(data: walrs_form::FormData) -> Result<Self, Self::Error> {
+        let mut violations = walrs_validation::FieldsetViolations::new();
+        
+        #(#field_extractions)*
+        
+        if !violations.is_empty() {
+          return Err(violations);
+        }
+        
+        Ok(Self {
+          #(#field_names),*
+        })
+      }
+    }
+  }
+}
+
+/// Helper to generate numeric extraction code.
+fn gen_numeric_extraction(
+  field_name: &Ident,
+  field_name_str: &str,
+  num_type: &Ident,
+  is_option: bool,
+) -> TokenStream {
+  let num_type_str = num_type.to_string();
+  let default_value = if is_option {
+    quote! { None }
+  } else {
+    match num_type_str.as_str() {
+      "f32" | "f64" => quote! { 0.0 },
+      _ => quote! { 0 },
+    }
+  };
+
+  match num_type_str.as_str() {
+    "i8" | "i16" | "i32" | "i64" | "i128" | "isize" => {
+      if is_option {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::I64(n)) => {
+              Some(*n as #num_type)
+            }
+            Some(walrs_validation::Value::U64(n)) => {
+              Some(*n as #num_type)
+            }
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str, " or null")
+                )
+              );
+              None
+            }
+          };
+        }
+      } else {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::I64(n)) => *n as #num_type,
+            Some(walrs_validation::Value::U64(n)) => *n as #num_type,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str)
+                )
+              );
+              #default_value
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              #default_value
+            }
+          };
+        }
+      }
+    }
+    "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+      if is_option {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::U64(n)) => Some(*n as #num_type),
+            Some(walrs_validation::Value::I64(n)) if *n >= 0 => Some(*n as #num_type),
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str, " or null")
+                )
+              );
+              None
+            }
+          };
+        }
+      } else {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::U64(n)) => *n as #num_type,
+            Some(walrs_validation::Value::I64(n)) if *n >= 0 => *n as #num_type,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str)
+                )
+              );
+              #default_value
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              #default_value
+            }
+          };
+        }
+      }
+    }
+    "f32" | "f64" => {
+      if is_option {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::F64(n)) => Some(*n as #num_type),
+            Some(walrs_validation::Value::I64(n)) => Some(*n as #num_type),
+            Some(walrs_validation::Value::U64(n)) => Some(*n as #num_type),
+            Some(walrs_validation::Value::Null) | None => None,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str, " or null")
+                )
+              );
+              None
+            }
+          };
+        }
+      } else {
+        quote! {
+          let #field_name = match data.get_direct(#field_name_str) {
+            Some(walrs_validation::Value::F64(n)) => *n as #num_type,
+            Some(walrs_validation::Value::I64(n)) => *n as #num_type,
+            Some(walrs_validation::Value::U64(n)) => *n as #num_type,
+            Some(_) => {
+              violations.add(
+                #field_name_str,
+                walrs_validation::Violation::new(
+                  walrs_validation::ViolationType::TypeMismatch,
+                  concat!("Expected ", #num_type_str)
+                )
+              );
+              #default_value
+            }
+            None => {
+              violations.add(#field_name_str, walrs_validation::Violation::value_missing());
+              #default_value
+            }
+          };
+        }
+      }
+    }
+    _ => {
+      // Unknown numeric type, generate a default
+      quote! {
+        let #field_name = #default_value;
+      }
+    }
+  }
+}

--- a/crates/fieldset_derive/src/lib.rs
+++ b/crates/fieldset_derive/src/lib.rs
@@ -1,4 +1,5 @@
 mod gen_filter;
+mod gen_form_data;
 mod gen_validate;
 mod parse;
 
@@ -7,6 +8,7 @@ use quote::quote;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 use gen_filter::gen_filter;
+use gen_form_data::{gen_into_form_data, gen_try_from_form_data};
 use gen_validate::gen_validate;
 use parse::{parse_cross_validate_attrs, parse_field_info, parse_fieldset_struct_attrs};
 
@@ -17,6 +19,8 @@ use parse::{parse_cross_validate_attrs, parse_field_info, parse_fieldset_struct_
 /// ## Struct-level
 ///
 /// - `#[fieldset(break_on_failure)]` — stop validation after the first field with violations
+/// - `#[fieldset(into_form_data)]` — generate `impl From<&T> for walrs_form::FormData`
+/// - `#[fieldset(try_from_form_data)]` — generate `impl TryFrom<walrs_form::FormData> for T`
 /// - `#[cross_validate(fn_name)]` — call `fn_name(&self) -> RuleResult` after per-field validation
 ///
 /// ## Field-level validation (`#[validate(...)]`)
@@ -106,6 +110,19 @@ fn derive_fieldset_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStr
   );
   let filter_fn = gen_filter(&field_infos);
 
+  // Generate FormData bridge impls if requested
+  let into_form_data_impl = if struct_attrs.into_form_data {
+    gen_into_form_data(struct_name, &field_infos, &impl_generics, &ty_generics, where_clause)
+  } else {
+    quote! {}
+  };
+
+  let try_from_form_data_impl = if struct_attrs.try_from_form_data {
+    gen_try_from_form_data(struct_name, &field_infos, &impl_generics, &ty_generics, where_clause)
+  } else {
+    quote! {}
+  };
+
   Ok(quote! {
     impl #impl_generics walrs_fieldfilter::Fieldset for #struct_name #ty_generics #where_clause {
       const BREAK_ON_FAILURE: bool = #break_on_failure;
@@ -113,5 +130,8 @@ fn derive_fieldset_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStr
       #validate_fn
       #filter_fn
     }
+
+    #into_form_data_impl
+    #try_from_form_data_impl
   })
 }

--- a/crates/fieldset_derive/src/parse.rs
+++ b/crates/fieldset_derive/src/parse.rs
@@ -12,6 +12,8 @@ use syn::{
 #[derive(Debug, Default)]
 pub struct FieldsetStructAttrs {
   pub break_on_failure: bool,
+  pub into_form_data: bool,
+  pub try_from_form_data: bool,
 }
 
 /// Parsed `#[cross_validate(fn_name)]` on the struct.
@@ -185,6 +187,10 @@ pub fn parse_fieldset_struct_attrs(attrs: &[Attribute]) -> FieldsetStructAttrs {
       let _ = attr.parse_nested_meta(|meta| {
         if meta.path.is_ident("break_on_failure") {
           result.break_on_failure = true;
+        } else if meta.path.is_ident("into_form_data") {
+          result.into_form_data = true;
+        } else if meta.path.is_ident("try_from_form_data") {
+          result.try_from_form_data = true;
         }
         Ok(())
       });

--- a/crates/form/Cargo.toml
+++ b/crates/form/Cargo.toml
@@ -27,3 +27,7 @@ default = ["std"]
 std = []
 wasm = []
 
+[dev-dependencies]
+walrs_fieldfilter = { path = "../fieldfilter", features = ["derive"] }
+walrs_fieldset_derive = { path = "../fieldset_derive" }
+

--- a/crates/form/tests/derive_fieldset_formdata.rs
+++ b/crates/form/tests/derive_fieldset_formdata.rs
@@ -1,0 +1,218 @@
+//! Integration tests for FormData bridge in derive(Fieldset).
+
+use walrs_fieldfilter::DeriveFieldset as Fieldset;
+use walrs_form::FormData;
+use walrs_validation::Value;
+
+#[derive(Debug, Fieldset, PartialEq)]
+#[fieldset(into_form_data, try_from_form_data)]
+struct UserProfile {
+  username: String,
+  age: i64,
+  score: f64,
+  is_active: bool,
+  middle_initial: char,
+}
+
+#[derive(Debug, Fieldset, PartialEq)]
+#[fieldset(into_form_data, try_from_form_data)]
+struct OptionalFields {
+  name: Option<String>,
+  age: Option<i32>,
+  score: Option<f64>,
+  active: Option<bool>,
+}
+
+#[test]
+fn test_into_form_data_required_fields() {
+  let profile = UserProfile {
+    username: "alice".to_string(),
+    age: 30,
+    score: 95.5,
+    is_active: true,
+    middle_initial: 'M',
+  };
+
+  let form_data = FormData::from(&profile);
+
+  assert_eq!(
+    form_data.get_direct("username"),
+    Some(&Value::Str("alice".to_string()))
+  );
+  assert_eq!(form_data.get_direct("age"), Some(&Value::I64(30)));
+  assert_eq!(form_data.get_direct("score"), Some(&Value::F64(95.5)));
+  assert_eq!(form_data.get_direct("is_active"), Some(&Value::Bool(true)));
+  assert_eq!(
+    form_data.get_direct("middle_initial"),
+    Some(&Value::Str("M".to_string()))
+  );
+}
+
+#[test]
+fn test_try_from_form_data_required_fields() {
+  let mut form_data = FormData::new();
+  form_data.insert("username", Value::Str("bob".to_string()));
+  form_data.insert("age", Value::I64(25));
+  form_data.insert("score", Value::F64(88.0));
+  form_data.insert("is_active", Value::Bool(false));
+  form_data.insert("middle_initial", Value::Str("J".to_string()));
+
+  let profile = UserProfile::try_from(form_data).expect("Should convert successfully");
+
+  assert_eq!(profile.username, "bob");
+  assert_eq!(profile.age, 25);
+  assert_eq!(profile.score, 88.0);
+  assert!(!profile.is_active);
+  assert_eq!(profile.middle_initial, 'J');
+}
+
+#[test]
+fn test_into_form_data_optional_fields() {
+  let data = OptionalFields {
+    name: Some("test".to_string()),
+    age: Some(42),
+    score: None,
+    active: Some(true),
+  };
+
+  let form_data = FormData::from(&data);
+
+  assert_eq!(
+    form_data.get_direct("name"),
+    Some(&Value::Str("test".to_string()))
+  );
+  assert_eq!(form_data.get_direct("age"), Some(&Value::I64(42)));
+  assert_eq!(form_data.get_direct("score"), Some(&Value::Null));
+  assert_eq!(form_data.get_direct("active"), Some(&Value::Bool(true)));
+}
+
+#[test]
+fn test_try_from_form_data_optional_fields() {
+  let mut form_data = FormData::new();
+  form_data.insert("name", Value::Str("charlie".to_string()));
+  form_data.insert("age", Value::Null);
+  form_data.insert("score", Value::F64(99.9));
+  form_data.insert("active", Value::Bool(false));
+
+  let data = OptionalFields::try_from(form_data).expect("Should convert successfully");
+
+  assert_eq!(data.name, Some("charlie".to_string()));
+  assert_eq!(data.age, None);
+  assert_eq!(data.score, Some(99.9));
+  assert_eq!(data.active, Some(false));
+}
+
+#[test]
+fn test_try_from_form_data_missing_fields() {
+  let form_data = FormData::new();
+
+  let result = UserProfile::try_from(form_data);
+
+  assert!(result.is_err());
+  let violations = result.unwrap_err();
+  assert!(!violations.is_empty());
+  // Should have violations for all required fields
+  assert!(violations.get("username").is_some());
+  assert!(violations.get("age").is_some());
+  assert!(violations.get("score").is_some());
+  assert!(violations.get("is_active").is_some());
+  assert!(violations.get("middle_initial").is_some());
+}
+
+#[test]
+fn test_try_from_form_data_type_mismatch() {
+  let mut form_data = FormData::new();
+  form_data.insert("username", Value::I64(123)); // Wrong type
+  form_data.insert("age", Value::Str("not a number".to_string())); // Wrong type
+  form_data.insert("score", Value::Bool(true)); // Wrong type
+  form_data.insert("is_active", Value::Str("yes".to_string())); // Wrong type
+  form_data.insert("middle_initial", Value::I64(77)); // Wrong type
+
+  let result = UserProfile::try_from(form_data);
+
+  assert!(result.is_err());
+  let violations = result.unwrap_err();
+  assert!(!violations.is_empty());
+  // Should have type mismatch violations for all fields
+  assert!(violations.get("username").is_some());
+  assert!(violations.get("age").is_some());
+  assert!(violations.get("score").is_some());
+  assert!(violations.get("is_active").is_some());
+  assert!(violations.get("middle_initial").is_some());
+}
+
+#[test]
+fn test_roundtrip_conversion() {
+  let original = UserProfile {
+    username: "dave".to_string(),
+    age: 35,
+    score: 92.3,
+    is_active: true,
+    middle_initial: 'X',
+  };
+
+  let form_data = FormData::from(&original);
+  let restored = UserProfile::try_from(form_data).expect("Should convert back successfully");
+
+  assert_eq!(original, restored);
+}
+
+#[test]
+fn test_optional_roundtrip() {
+  let original = OptionalFields {
+    name: Some("eve".to_string()),
+    age: None,
+    score: Some(87.5),
+    active: None,
+  };
+
+  let form_data = FormData::from(&original);
+  let restored = OptionalFields::try_from(form_data).expect("Should convert back successfully");
+
+  assert_eq!(original, restored);
+}
+
+#[test]
+fn test_numeric_type_conversions() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct NumericTypes {
+    i8_val: i8,
+    i16_val: i16,
+    i32_val: i32,
+    i64_val: i64,
+    u8_val: u8,
+    u16_val: u16,
+    u32_val: u32,
+    u64_val: u64,
+    f32_val: f32,
+    f64_val: f64,
+  }
+
+  let data = NumericTypes {
+    i8_val: -10,
+    i16_val: -1000,
+    i32_val: -100000,
+    i64_val: -10000000,
+    u8_val: 10,
+    u16_val: 1000,
+    u32_val: 100000,
+    u64_val: 10000000,
+    f32_val: 3.14,
+    f64_val: 2.71828,
+  };
+
+  let form_data = FormData::from(&data);
+  let restored = NumericTypes::try_from(form_data).expect("Should convert successfully");
+
+  assert_eq!(data.i8_val, restored.i8_val);
+  assert_eq!(data.i16_val, restored.i16_val);
+  assert_eq!(data.i32_val, restored.i32_val);
+  assert_eq!(data.i64_val, restored.i64_val);
+  assert_eq!(data.u8_val, restored.u8_val);
+  assert_eq!(data.u16_val, restored.u16_val);
+  assert_eq!(data.u32_val, restored.u32_val);
+  assert_eq!(data.u64_val, restored.u64_val);
+  assert!((data.f32_val - restored.f32_val).abs() < 0.0001);
+  assert!((data.f64_val - restored.f64_val).abs() < 0.0001);
+}

--- a/crates/form/tests/derive_fieldset_formdata.rs
+++ b/crates/form/tests/derive_fieldset_formdata.rs
@@ -2,7 +2,7 @@
 
 use walrs_fieldfilter::DeriveFieldset as Fieldset;
 use walrs_form::FormData;
-use walrs_validation::Value;
+use walrs_validation::{Value, ViolationType};
 
 #[derive(Debug, Fieldset, PartialEq)]
 #[fieldset(into_form_data, try_from_form_data)]
@@ -215,4 +215,169 @@ fn test_numeric_type_conversions() {
   assert_eq!(data.u64_val, restored.u64_val);
   assert!((data.f32_val - restored.f32_val).abs() < 0.0001);
   assert!((data.f64_val - restored.f64_val).abs() < 0.0001);
+}
+
+#[test]
+fn test_overflow_i8_produces_violation() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct SmallInts {
+    val_i8: i8,
+    val_u8: u8,
+  }
+
+  // 200 overflows i8 (max 127)
+  let mut form_data = FormData::new();
+  form_data.insert("val_i8", Value::I64(200));
+  form_data.insert("val_u8", Value::U64(10));
+
+  let result = SmallInts::try_from(form_data);
+  assert!(result.is_err());
+  let violations = result.unwrap_err();
+  let v = violations.get("val_i8").expect("should have val_i8 violation");
+  assert_eq!(v[0].violation_type(), ViolationType::TypeMismatch);
+}
+
+#[test]
+fn test_overflow_u8_produces_violation() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct SmallUints {
+    val: u8,
+  }
+
+  // 300 overflows u8 (max 255)
+  let mut form_data = FormData::new();
+  form_data.insert("val", Value::U64(300));
+
+  let result = SmallUints::try_from(form_data);
+  assert!(result.is_err());
+  let violations = result.unwrap_err();
+  let v = violations.get("val").expect("should have val violation");
+  assert_eq!(v[0].violation_type(), ViolationType::TypeMismatch);
+}
+
+#[test]
+fn test_negative_to_unsigned_produces_violation() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct UnsignedField {
+    val: u32,
+  }
+
+  let mut form_data = FormData::new();
+  form_data.insert("val", Value::I64(-5));
+
+  let result = UnsignedField::try_from(form_data);
+  assert!(result.is_err());
+}
+
+#[test]
+fn test_i128_u128_roundtrip() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct BigInts {
+    signed: i128,
+    unsigned: u128,
+  }
+
+  let original = BigInts {
+    signed: i128::MAX,
+    unsigned: u128::MAX,
+  };
+
+  let form_data = FormData::from(&original);
+
+  // Should be stored as strings
+  assert!(matches!(
+    form_data.get_direct("signed"),
+    Some(Value::Str(_))
+  ));
+  assert!(matches!(
+    form_data.get_direct("unsigned"),
+    Some(Value::Str(_))
+  ));
+
+  let restored = BigInts::try_from(form_data).expect("Should roundtrip successfully");
+  assert_eq!(original, restored);
+}
+
+#[test]
+fn test_option_i128_u128_roundtrip() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct OptBigInts {
+    signed: Option<i128>,
+    unsigned: Option<u128>,
+  }
+
+  let original = OptBigInts {
+    signed: Some(i128::MIN),
+    unsigned: Some(u128::MAX),
+  };
+
+  let form_data = FormData::from(&original);
+  let restored = OptBigInts::try_from(form_data).expect("Should roundtrip successfully");
+  assert_eq!(original, restored);
+
+  // Test None roundtrip
+  let none_data = OptBigInts {
+    signed: None,
+    unsigned: None,
+  };
+  let form_data = FormData::from(&none_data);
+  let restored = OptBigInts::try_from(form_data).expect("Should roundtrip None successfully");
+  assert_eq!(none_data, restored);
+}
+
+#[test]
+fn test_i128_invalid_string_produces_violation() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct I128Field {
+    val: i128,
+  }
+
+  let mut form_data = FormData::new();
+  form_data.insert("val", Value::Str("not_a_number".to_string()));
+
+  let result = I128Field::try_from(form_data);
+  assert!(result.is_err());
+  let violations = result.unwrap_err();
+  assert!(violations.get("val").is_some());
+}
+
+#[test]
+fn test_i128_from_i64_value() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct I128Field {
+    val: i128,
+  }
+
+  // i128 should also accept I64 values (widening)
+  let mut form_data = FormData::new();
+  form_data.insert("val", Value::I64(42));
+
+  let result = I128Field::try_from(form_data).expect("Should accept I64 for i128");
+  assert_eq!(result.val, 42i128);
+}
+
+#[test]
+fn test_option_overflow_i16_produces_violation() {
+  #[derive(Debug, Fieldset, PartialEq)]
+  #[fieldset(into_form_data, try_from_form_data)]
+  struct OptSmall {
+    val: Option<i16>,
+  }
+
+  // 40000 overflows i16 (max 32767)
+  let mut form_data = FormData::new();
+  form_data.insert("val", Value::I64(40000));
+
+  let result = OptSmall::try_from(form_data);
+  assert!(result.is_err());
+  let violations = result.unwrap_err();
+  let v = violations.get("val").expect("should have val violation");
+  assert_eq!(v[0].violation_type(), ViolationType::TypeMismatch);
 }


### PR DESCRIPTION
## Summary

Adds opt-in FormData bridge to the derive(Fieldset) macro, enabling conversion between typed structs and dynamic FormData.

## Related Issue

Part of #197 (Phase 6)

## Changes

- New `gen_form_data.rs` module in fieldset_derive
- `#[fieldset(into_form_data)]` generates `impl From<&T> for FormData`
- `#[fieldset(try_from_form_data)]` generates `impl TryFrom<FormData> for T`
- Updated parse.rs for new struct-level attributes
- Integration tests in walrs_form crate

## Testing

- 9 integration tests for into_form_data and try_from_form_data
- Tests cover required fields, optional fields, type mismatches, and numeric conversions
- cargo test --workspace passes (all 1287 tests pass)