### PR TITLE
fix(walrs_validation): #208 fix grammar and README examples

### DIFF
--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -175,8 +175,8 @@ Use `.with_message_provider()` for dynamic messages based on the failing value:
 use walrs_validation::{Rule, ValidateRef};
 
 let rule = Rule::<String>::MinLength(5).with_message_provider(
-    |value: &String, _locale| {
-        format!("\"{}\" is too short (minimum 5 characters).", value)
+    |ctx| {
+        format!("\"{}\" is too short (minimum 5 characters).", ctx.value)
     },
     None,
 );

--- a/crates/validation/src/rule_impls/length.rs
+++ b/crates/validation/src/rule_impls/length.rs
@@ -405,7 +405,7 @@ mod tests {
     let violation = result.unwrap_err();
     assert_eq!(
       violation.message(),
-      "Value length must at most 2;  Received 4."
+      "Value length must be at most 2;  Received 4."
     );
 
     let rule = Rule::<Vec<i32>>::ExactLength(3);

--- a/crates/validation/src/violation.rs
+++ b/crates/validation/src/violation.rs
@@ -69,7 +69,7 @@ impl Violation {
   pub fn too_long(max: usize, actual: usize) -> Self {
     Self::new(
       ViolationType::TooLong,
-      format!("Value length must at most {};  Received {}.", max, actual),
+      format!("Value length must be at most {};  Received {}.", max, actual),
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes high-priority issues found during forms ecosystem review (#208).

## Changes

- **Grammar bug (High)**: Fixed 'must at most' → 'must be at most' in too_long() violation message
- **README examples (High)**: Fixed with_message_provider closure signature to use MessageContext

## Related Issue

Closes part of #208

## Testing

- Updated tests to match corrected message
- All existing tests pass (43/43)