### PR TITLE
fix(walrs_filter): #208 fix README license, derives, and visibility

### DIFF
--- a/crates/filter/README.md
+++ b/crates/filter/README.md
@@ -338,5 +338,5 @@ Benchmark groups include:
 
 ## License
 
-MIT & Apache-2.0
+Elastic-2.0
 

--- a/crates/filter/src/filter_error.rs
+++ b/crates/filter/src/filter_error.rs
@@ -23,7 +23,7 @@ use std::fmt;
 /// assert_eq!(err.filter_name(), Some("Base64Decode"));
 /// assert_eq!(err.to_string(), "Filter 'Base64Decode' failed: invalid base64 input");
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FilterError {
   message: String,
   filter_name: Option<String>,

--- a/crates/filter/src/slug.rs
+++ b/crates/filter/src/slug.rs
@@ -9,12 +9,12 @@ static DASH_FILTER_REGEX: OnceLock<Regex> = OnceLock::new();
 static DASH_FILTER_REGEX_STR: &str = r"(?i)\-{2,}";
 
 /// Returns the static regex used for filtering a string to slug.
-pub fn get_slug_filter_regex() -> &'static Regex {
+pub(crate) fn get_slug_filter_regex() -> &'static Regex {
   SLUG_FILTER_REGEX.get_or_init(|| Regex::new(SLUG_FILTER_REGEX_STR).unwrap())
 }
 
 /// Returns the static regex used for filtering out multiple dashes for one dash.
-pub fn get_dash_filter_regex() -> &'static Regex {
+pub(crate) fn get_dash_filter_regex() -> &'static Regex {
   DASH_FILTER_REGEX.get_or_init(|| Regex::new(DASH_FILTER_REGEX_STR).unwrap())
 }
 

--- a/crates/filter/src/xml_entities.rs
+++ b/crates/filter/src/xml_entities.rs
@@ -30,6 +30,7 @@ static DEFAULT_CHARS_ASSOC_MAP: OnceLock<HashMap<char, &'static str>> = OnceLock
 ///  assert_eq!(filter.filter(incoming_src.into()), expected_src.to_string());
 /// }
 /// ```
+#[derive(Clone, Debug)]
 #[must_use]
 pub struct XmlEntitiesFilter<'a> {
   pub chars_assoc_map: &'a HashMap<char, &'static str>,


### PR DESCRIPTION
## Summary

Fixes medium and low priority issues found during forms ecosystem review (#208).

## Changes

- **README license (High)**: Fixed mismatch — now says Elastic-2.0
- **XmlEntitiesFilter derives (Medium)**: Added Clone/Debug for composability
- **Regex function visibility (Medium)**: Made internal functions pub(crate)
- **FilterError Eq (Low)**: Added Eq derive

## Related Issue

Closes part of #208

## Testing

- All existing tests pass
- No behavior changes