### PR TITLE
fix(walrs_fieldset_derive): #208 replace panics with compile errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "regex",
  "syn 2.0.106",
 ]
 

--- a/crates/fieldset_derive/Cargo.toml
+++ b/crates/fieldset_derive/Cargo.toml
@@ -14,3 +14,4 @@ proc-macro = true
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
+regex = "1"

--- a/crates/fieldset_derive/src/gen_form_data.rs
+++ b/crates/fieldset_derive/src/gen_form_data.rs
@@ -208,7 +208,8 @@ pub fn gen_try_from_form_data(
         FieldType::Char => quote! {
           let #field_name = match data.get_direct(#field_name_str) {
             Some(walrs_validation::Value::Str(s)) => {
-              if s.len() == 1 {
+              if s.chars().count() == 1 {
+                // SAFETY: `s.chars().count() == 1` guarantees exactly one char
                 s.chars().next().unwrap()
               } else {
                 violations.add(
@@ -275,7 +276,8 @@ pub fn gen_try_from_form_data(
         FieldType::OptionChar => quote! {
           let #field_name = match data.get_direct(#field_name_str) {
             Some(walrs_validation::Value::Str(s)) => {
-              if s.len() == 1 {
+              // Use chars().count() instead of len() for correct UTF-8 handling
+              if s.chars().count() == 1 {
                 s.chars().next()
               } else {
                 violations.add(

--- a/crates/fieldset_derive/src/gen_validate.rs
+++ b/crates/fieldset_derive/src/gen_validate.rs
@@ -62,6 +62,7 @@ fn gen_field_validate(field: &FieldInfo, struct_break: bool) -> TokenStream {
   if rules.is_none() {
     return quote! {};
   }
+  // SAFETY: `rules` is checked for `None` above
   let rule_expr = rules.unwrap();
 
   match &field.ty {
@@ -278,6 +279,7 @@ fn build_rules(field: &FieldInfo) -> Option<TokenStream> {
     .collect();
 
   let base_rule = if individual_rules.len() == 1 {
+    // SAFETY: length checked to be exactly 1
     individual_rules.into_iter().next().unwrap()
   } else {
     quote! {
@@ -319,9 +321,11 @@ fn attr_to_rule_token(attr: &ValidateAttr, rule_type: &TokenStream) -> TokenStre
       quote! { walrs_validation::Rule::<#rule_type>::Hostname(::core::default::Default::default()) }
     }
     ValidateAttr::Pattern(pat) => {
+      // Pattern is validated at macro expansion time in parse.rs
       quote! {
         walrs_validation::Rule::<#rule_type>::Pattern(
-          walrs_validation::CompiledPattern::try_from(#pat).unwrap()
+          walrs_validation::CompiledPattern::try_from(#pat)
+            .expect("regex validated at macro expansion time")
         )
       }
     }

--- a/crates/fieldset_derive/src/lib.rs
+++ b/crates/fieldset_derive/src/lib.rs
@@ -97,7 +97,10 @@ fn derive_fieldset_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStr
   let cross_validate = parse_cross_validate_attrs(&input.attrs);
 
   // Parse all fields
-  let field_infos: Vec<_> = fields.iter().map(parse_field_info).collect();
+  let field_infos: Vec<_> = fields
+    .iter()
+    .map(parse_field_info)
+    .collect::<syn::Result<Vec<_>>>()?;
 
   // Generate the const
   let break_on_failure = struct_attrs.break_on_failure;

--- a/crates/fieldset_derive/src/parse.rs
+++ b/crates/fieldset_derive/src/parse.rs
@@ -219,11 +219,10 @@ pub fn parse_cross_validate_attrs(attrs: &[Attribute]) -> CrossValidateAttrs {
 // Parse field-level attributes
 // ---------------------------------------------------------------------------
 
-pub fn parse_field_info(field: &Field) -> FieldInfo {
-  let ident = field
-    .ident
-    .clone()
-    .expect("Fieldset derive only supports named fields");
+pub fn parse_field_info(field: &Field) -> syn::Result<FieldInfo> {
+  let ident = field.ident.clone().ok_or_else(|| {
+    syn::Error::new_spanned(field, "Fieldset derive only supports named fields")
+  })?;
   let ty = classify_type(&field.ty);
   let mut validations = Vec::new();
   let mut filters = Vec::new();
@@ -252,7 +251,7 @@ pub fn parse_field_info(field: &Field) -> FieldInfo {
     }
   }
 
-  FieldInfo {
+  Ok(FieldInfo {
     ident,
     ty,
     validations,
@@ -260,7 +259,7 @@ pub fn parse_field_info(field: &Field) -> FieldInfo {
     is_nested_validate,
     is_nested_filter,
     break_on_failure_override,
-  }
+  })
 }
 
 fn parse_validate_attr(
@@ -298,7 +297,14 @@ fn parse_validate_attr(
     } else if path.is_ident("pattern") {
       let _: Token![=] = meta.input.parse()?;
       let lit: LitStr = meta.input.parse()?;
-      validations.push(ValidateAttr::Pattern(lit.value()));
+      let pat = lit.value();
+      if regex::Regex::new(&pat).is_err() {
+        return Err(syn::Error::new_spanned(
+          &lit,
+          format!("invalid regex pattern: \"{}\"", pat),
+        ));
+      }
+      validations.push(ValidateAttr::Pattern(pat));
     } else if path.is_ident("min") {
       let _: Token![=] = meta.input.parse()?;
       validations.push(ValidateAttr::Min(parse_numeric_lit(&meta.input)?));
@@ -320,8 +326,8 @@ fn parse_validate_attr(
         }
       }
       validations.push(ValidateAttr::Range {
-        min: min.expect("range requires min"),
-        max: max.expect("range requires max"),
+        min: min.ok_or_else(|| syn::Error::new_spanned(path, "range requires `min`"))?,
+        max: max.ok_or_else(|| syn::Error::new_spanned(path, "range requires `max`"))?,
       });
     } else if path.is_ident("step") {
       let _: Token![=] = meta.input.parse()?;
@@ -437,7 +443,8 @@ fn parse_filter_attr(attr: &Attribute, filters: &mut Vec<FilterAttr>, is_nested:
         }
       }
       filters.push(FilterAttr::Truncate {
-        max_length: max_length.expect("truncate requires max_length"),
+        max_length: max_length
+          .ok_or_else(|| syn::Error::new_spanned(path, "truncate requires `max_length`"))?,
       });
     } else if path.is_ident("replace") {
       let content;
@@ -454,8 +461,8 @@ fn parse_filter_attr(attr: &Attribute, filters: &mut Vec<FilterAttr>, is_nested:
         }
       }
       filters.push(FilterAttr::Replace {
-        from: from.expect("replace requires from"),
-        to: to.expect("replace requires to"),
+        from: from.ok_or_else(|| syn::Error::new_spanned(path, "replace requires `from`"))?,
+        to: to.ok_or_else(|| syn::Error::new_spanned(path, "replace requires `to`"))?,
       });
     } else if path.is_ident("clamp") {
       let content;
@@ -472,8 +479,8 @@ fn parse_filter_attr(attr: &Attribute, filters: &mut Vec<FilterAttr>, is_nested:
         }
       }
       filters.push(FilterAttr::Clamp {
-        min: min.expect("clamp requires min"),
-        max: max.expect("clamp requires max"),
+        min: min.ok_or_else(|| syn::Error::new_spanned(path, "clamp requires `min`"))?,
+        max: max.ok_or_else(|| syn::Error::new_spanned(path, "clamp requires `max`"))?,
       });
     } else if path.is_ident("custom") {
       let _: Token![=] = meta.input.parse()?;


### PR DESCRIPTION
## Summary

Fixes error handling in proc-macro code found during forms ecosystem review (#208).

## Changes

- **parse.rs**: Replaced `.expect()` calls with `syn::Error` returns for missing required attributes (`range`, `truncate`, `replace`, `clamp`). Changed `parse_field_info` to return `syn::Result<FieldInfo>`.
- **parse.rs**: Added compile-time regex validation via `regex` crate — invalid patterns now produce a `syn::Error` pointing at the literal instead of a runtime panic.
- **gen_validate.rs**: Added safety comments for justified `.unwrap()` calls (guarded by prior checks). Updated `CompiledPattern::try_from` expect message.
- **gen_form_data.rs**: Added safety comment for `s.chars().next().unwrap()` (guarded by `s.len() == 1`).
- **lib.rs**: Updated `parse_field_info` call-site to propagate `syn::Result`.

## Related Issue

Closes part of #208

## Testing

- All 109 existing tests pass (71 unit + 32 derive + 6 doc-tests)