### PR TITLE
fix(walrs_form): #208 fix form recursion, bounds, and quality issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,7 +2148,6 @@ dependencies = [
  "derive_builder",
  "indexmap",
  "js-sys",
- "regex",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/crates/form/Cargo.toml
+++ b/crates/form/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 derive_builder = "0.13.0"
 thiserror = "1.0"
-regex = "1.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/crates/form/README.md
+++ b/crates/form/README.md
@@ -83,12 +83,11 @@ data.set("address.city", json!("New York"));
 Elements can have `Field<Value>` configurations for validation:
 ```rust
 use walrs_form::{InputElement, InputType, Field, FieldBuilder};
-use walrs_filter::FilterOp;
+
 let mut input = InputElement::new("email", InputType::Email);
 input.field = Some(
     FieldBuilder::default()
         .required(true)
-        .filters(vec![FilterOp::Trim, FilterOp::Lowercase])
         .build()
         .unwrap()
 );
@@ -98,7 +97,6 @@ This crate is part of the walrs form ecosystem:
 - `walrs_validation`: Shared types (`Value`, `Attributes`) and validation rules
 - `walrs_fieldfilter`: Field-level validation (`Field<T>`, `FieldFilter`)
 - `walrs_form`: Form structure and elements (this crate)
-- `walrs_validation`: Validation rules
 - `walrs_filter`: Value transformation filters
 ## License
-MIT OR Apache-2.0
+Elastic-2.0

--- a/crates/form/src/button_element.rs
+++ b/crates/form/src/button_element.rs
@@ -37,7 +37,7 @@ use walrs_validation::Attributes;
 /// let button = ButtonElement::new("action", ButtonType::Button);
 /// assert_eq!(button._type, ButtonType::Button);
 /// ```
-#[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Builder, Serialize, Deserialize)]
 #[builder(setter(into, strip_option), default)]
 pub struct ButtonElement {
   /// Element name attribute.

--- a/crates/form/src/element.rs
+++ b/crates/form/src/element.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 ///     _ => {}
 /// }
 /// ```
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "element")]
 pub enum Element {
   /// Button element.

--- a/crates/form/src/fieldset_element.rs
+++ b/crates/form/src/fieldset_element.rs
@@ -34,7 +34,7 @@ use walrs_validation::Attributes;
 ///
 /// assert_eq!(fieldset.iter_elements().count(), 2);
 /// ```
-#[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Builder, Serialize, Deserialize)]
 #[builder(setter(into, strip_option), default)]
 pub struct FieldsetElement {
   /// Fieldset name.

--- a/crates/form/src/form.rs
+++ b/crates/form/src/form.rs
@@ -61,15 +61,27 @@ impl Form {
   }
   pub fn bind_data(&mut self, data: FormData) -> &mut Self {
     if let Some(ref mut elements) = self.elements {
-      for element in elements.iter_mut() {
-        if let Some(name) = element.name()
-          && let Some(value) = data.get(name)
-        {
-          Self::set_element_value(element, value.clone());
+      Self::bind_data_recursive(elements, &data);
+    }
+    self
+  }
+  fn bind_data_recursive(elements: &mut [Element], data: &FormData) {
+    for element in elements.iter_mut() {
+      match element {
+        Element::Fieldset(fs) => {
+          if let Some(ref mut children) = fs.elements {
+            Self::bind_data_recursive(children, data);
+          }
+        }
+        _ => {
+          if let Some(name) = element.name()
+            && let Some(value) = data.get(name)
+          {
+            Self::set_element_value(element, value.clone());
+          }
         }
       }
     }
-    self
   }
   fn set_element_value(element: &mut Element, value: walrs_validation::Value) {
     match element {
@@ -89,7 +101,28 @@ impl Form {
     } else {
       let mut violations = FormViolations::new();
       if let Some(ref elements) = self.elements {
-        for element in elements {
+        Self::validate_recursive(elements, data, &mut violations);
+      }
+      if violations.is_empty() {
+        Ok(())
+      } else {
+        Err(violations)
+      }
+    }
+  }
+  fn validate_recursive(
+    elements: &[Element],
+    data: &FormData,
+    violations: &mut FormViolations,
+  ) {
+    for element in elements {
+      match element {
+        Element::Fieldset(fs) => {
+          if let Some(ref children) = fs.elements {
+            Self::validate_recursive(children, data, violations);
+          }
+        }
+        _ => {
           if let Some(name) = element.name() {
             let value = data
               .get(name)
@@ -106,11 +139,6 @@ impl Form {
             }
           }
         }
-      }
-      if violations.is_empty() {
-        Ok(())
-      } else {
-        Err(violations)
       }
     }
   }
@@ -132,6 +160,7 @@ impl Form {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::fieldset_element::FieldsetElement;
   use crate::input_element::InputElement;
   use crate::input_type::InputType;
   use walrs_validation::Value;
@@ -161,5 +190,87 @@ mod tests {
     } else {
       panic!("Element not found");
     }
+  }
+  #[test]
+  fn test_bind_data_nested_fieldset() {
+    let mut form = Form::new("test");
+    let mut fieldset = FieldsetElement::new("personal");
+    fieldset.add_element(InputElement::new("name", InputType::Text).into());
+    fieldset.add_element(InputElement::new("age", InputType::Number).into());
+    form.add_element(fieldset.into());
+    let mut data = FormData::new();
+    data.insert("name", Value::Str("Alice".to_string()));
+    data.insert("age", Value::from(30i32));
+    form.bind_data(data);
+    // Verify nested elements were bound
+    if let Some(Element::Fieldset(fs)) = form.elements.as_ref().and_then(|e| e.first()) {
+      let children = fs.elements.as_ref().unwrap();
+      if let Element::Input(input) = &children[0] {
+        assert_eq!(input.value.as_ref().unwrap().as_str(), Some("Alice"));
+      } else {
+        panic!("Expected Input element");
+      }
+      if let Element::Input(input) = &children[1] {
+        assert_eq!(input.value.as_ref().unwrap().as_i64(), Some(30));
+      } else {
+        panic!("Expected Input element");
+      }
+    } else {
+      panic!("Expected Fieldset element");
+    }
+  }
+  #[test]
+  fn test_bind_data_deeply_nested_fieldset() {
+    let mut form = Form::new("test");
+    let mut inner_fs = FieldsetElement::new("inner");
+    inner_fs.add_element(InputElement::new("deep_field", InputType::Text).into());
+    let mut outer_fs = FieldsetElement::new("outer");
+    outer_fs.add_element(inner_fs.into());
+    form.add_element(outer_fs.into());
+    let mut data = FormData::new();
+    data.insert("deep_field", Value::Str("deep_value".to_string()));
+    form.bind_data(data);
+    if let Some(Element::Fieldset(outer)) = form.elements.as_ref().and_then(|e| e.first()) {
+      if let Some(Element::Fieldset(inner)) =
+        outer.elements.as_ref().and_then(|e| e.first())
+      {
+        if let Some(Element::Input(input)) =
+          inner.elements.as_ref().and_then(|e| e.first())
+        {
+          assert_eq!(input.value.as_ref().unwrap().as_str(), Some("deep_value"));
+        } else {
+          panic!("Expected Input element");
+        }
+      } else {
+        panic!("Expected inner Fieldset");
+      }
+    } else {
+      panic!("Expected outer Fieldset");
+    }
+  }
+  #[test]
+  fn test_validate_nested_fieldset() {
+    use walrs_fieldfilter::FieldBuilder;
+    use walrs_validation::Rule;
+    let mut form = Form::new("test");
+    let mut email_input = InputElement::new("email", InputType::Email);
+    email_input.field = Some(
+      FieldBuilder::default()
+        .rule(Rule::required())
+        .build()
+        .unwrap(),
+    );
+    let mut fieldset = FieldsetElement::new("contact");
+    fieldset.add_element(email_input.into());
+    form.add_element(fieldset.into());
+    // Validate with empty data - should fail since email is required
+    let data = FormData::new();
+    let result = form.validate(&data);
+    assert!(result.is_err());
+    // Validate with valid data
+    let mut data = FormData::new();
+    data.insert("email", Value::Str("test@example.com".to_string()));
+    let result = form.validate(&data);
+    assert!(result.is_ok());
   }
 }

--- a/crates/form/src/form_data.rs
+++ b/crates/form/src/form_data.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use walrs_validation::Value;
 /// Form data transfer object.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct FormData(IndexMap<String, Value>);
 impl FormData {
   pub fn new() -> Self {
@@ -87,6 +87,9 @@ impl FormData {
     &self.0
   }
 }
+/// Maximum allowed array index to prevent unbounded allocation.
+const MAX_INDEX: usize = 10_000;
+
 fn set_nested(current: &mut Value, segments: &[PathSegment], value: Value) {
   if segments.is_empty() {
     *current = value;
@@ -112,6 +115,9 @@ fn set_nested(current: &mut Value, segments: &[PathSegment], value: Value) {
       }
     }
     PathSegment::Index(idx) => {
+      if *idx >= MAX_INDEX {
+        return;
+      }
       if !matches!(current, Value::Array(_)) {
         *current = Value::Array(Vec::new());
       }
@@ -176,5 +182,18 @@ mod tests {
       data.get("user.email").unwrap().as_str(),
       Some("test@example.com")
     );
+  }
+  #[test]
+  fn test_set_nested_index_bounds() {
+    let mut data = FormData::new();
+    // Index within bounds should work
+    data.set("items[5]", Value::Str("ok".to_string()));
+    assert_eq!(data.get("items[5]").unwrap().as_str(), Some("ok"));
+    // Index equal to MAX_INDEX should be silently ignored (>= MAX_INDEX is out of bounds)
+    data.set("big[10000]", Value::Str("bad".to_string()));
+    assert!(data.get("big[10000]").is_none());
+    // Index exceeding MAX_INDEX should be silently ignored
+    data.set("big[99999]", Value::Str("bad".to_string()));
+    assert!(data.get("big[99999]").is_none());
   }
 }

--- a/crates/form/src/input_element.rs
+++ b/crates/form/src/input_element.rs
@@ -37,7 +37,7 @@ use walrs_validation::{Attributes, Value};
 ///
 /// assert_eq!(input.name.as_deref(), Some("username"));
 /// ```
-#[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Builder, Serialize, Deserialize)]
 #[builder(setter(into, strip_option), default)]
 pub struct InputElement {
   /// Element name attribute.

--- a/crates/form/src/lib.rs
+++ b/crates/form/src/lib.rs
@@ -47,7 +47,6 @@
 //! - `walrs_validation`: Shared types (`Value`, `Attributes`) and validation rules
 //! - `walrs_fieldfilter`: Field-level validation (`Field<T>`, `FieldFilter`)
 //! - `walrs_form`: Form structure and elements (this crate)
-//! - `walrs_validation`: Validation rules
 //! - `walrs_filter`: Value transformation filters
 // Type enums
 pub mod button_type;

--- a/crates/form/src/path.rs
+++ b/crates/form/src/path.rs
@@ -36,11 +36,16 @@ pub fn parse_path(path: &str) -> Result<Vec<PathSegment>, PathError> {
           current.clear();
         }
         let mut index_str = String::new();
+        let mut found_close = false;
         for ic in chars.by_ref() {
           if ic == ']' {
+            found_close = true;
             break;
           }
           index_str.push(ic);
+        }
+        if !found_close {
+          return Err(PathError::InvalidSyntax("Unclosed '['".to_string()));
         }
         let index: usize = index_str
           .parse()
@@ -89,5 +94,17 @@ mod tests {
         PathSegment::Index(0),
       ]
     );
+  }
+  #[test]
+  fn test_unclosed_bracket_error() {
+    let result = parse_path("items[0");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("Unclosed '['"));
+  }
+  #[test]
+  fn test_unexpected_close_bracket_error() {
+    let result = parse_path("items]0");
+    assert!(result.is_err());
   }
 }

--- a/crates/form/src/select_element.rs
+++ b/crates/form/src/select_element.rs
@@ -40,7 +40,7 @@ use walrs_validation::{Attributes, Value};
 ///
 /// assert_eq!(select._type, SelectType::Single);
 /// ```
-#[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Builder, Serialize, Deserialize)]
 #[builder(setter(into, strip_option), default)]
 pub struct SelectElement {
   /// Element name attribute.

--- a/crates/form/src/select_option.rs
+++ b/crates/form/src/select_option.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 /// ]);
 /// assert!(group.options.is_some());
 /// ```
-#[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Builder, Serialize, Deserialize)]
 #[builder(setter(into, strip_option), default)]
 pub struct SelectOption {
   /// Option value attribute.

--- a/crates/form/src/textarea_element.rs
+++ b/crates/form/src/textarea_element.rs
@@ -33,7 +33,7 @@ use walrs_validation::{Attributes, Value};
 ///
 /// assert_eq!(textarea.rows, Some(5));
 /// ```
-#[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Builder, Serialize, Deserialize)]
 #[builder(setter(into, strip_option), default)]
 pub struct TextareaElement {
   /// Element name attribute.


### PR DESCRIPTION
## Summary

Fixes high and medium priority bugs found during forms ecosystem review (#208).

## Changes

- **bind_data recursion (High)**: Now recurses into FieldsetElement children
- **validate recursion (High)**: Now validates nested fieldset elements
- **set_nested bounds (Medium)**: Added MAX_INDEX to prevent OOM from untrusted input
- **parse_path bracket validation (Medium)**: Rejects unclosed brackets
- **Unused regex dep (Medium)**: Removed
- **PartialEq (Medium)**: Added to FormData, Element, and all element types
- **README (Low)**: Fixed license, duplicate entries, example

## Related Issue

Closes part of #208

## Testing

- Added tests for nested fieldset bind_data and validate
- Added tests for set_nested bounds check
- Added tests for parse_path error cases
- All existing tests pass (38 total)