### PR TITLE
fix(walrs_graph): #162 correct critical bugs and improve test coverage

### DIFF
--- a/crates/graph/src/graph/graph.rs
+++ b/crates/graph/src/graph/graph.rs
@@ -131,37 +131,65 @@ impl Graph {
   }
 
   /// Returns a boolean indicating whether or not graph contains given vertex, `v`, or not.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use walrs_graph::Graph;
+  ///
+  /// let g = Graph::new(5);
+  /// assert!(g.has_vertex(0));
+  /// assert!(g.has_vertex(4));
+  /// assert!(!g.has_vertex(5));
+  /// assert!(!g.has_vertex(99));
+  ///
+  /// let empty = Graph::new(0);
+  /// assert!(!empty.has_vertex(0));
+  /// ```
   pub fn has_vertex(&self, v: usize) -> bool {
-    let len = self._adj_lists.len();
-    len > 0 && len <= v + 1
+    v < self._adj_lists.len()
   }
 
-  /// Removes a vertex from the graph.
+  /// Removes a vertex from the graph, adjusting all adjacency list indices accordingly.
+  ///
+  /// After removal, vertices with indices greater than `v` are decremented by one
+  /// across **all** adjacency lists, not just neighbors of `v`.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use walrs_graph::Graph;
+  ///
+  /// let mut g = Graph::new(4);
+  /// g.add_edge(0, 1).unwrap();
+  /// g.add_edge(2, 3).unwrap();
+  ///
+  /// g.remove_vertex(0).unwrap();
+  /// assert_eq!(g.vert_count(), 3);
+  /// // Vertex formerly at index 2 is now at 1, and formerly 3 is now 2
+  /// assert!(g.has_edge(1, 2));
+  /// ```
   pub fn remove_vertex(&mut self, v: usize) -> Result<&mut Self, String> {
     self.validate_vertex(v)?;
 
-    let target_v_adj = self.adj(v).unwrap();
+    // Remove all edges involving v
+    let neighbors: Vec<usize> = self._adj_lists[v].clone();
+    for w in neighbors {
+      self.remove_edge(v, w)?;
+    }
 
-    // Remove related edges and offset vertices greater than target, in adj lists
-    target_v_adj.to_owned().into_iter().for_each(|w| {
-      // Remove edge
-      let found_v_idx = match self.remove_edge(v, w) {
-        Ok(val) => val,
-        Err(err) => panic!("{}", err),
-      };
+    // Remove v's adjacency list
+    self._adj_lists.remove(v);
 
-      let w_adj = &mut self._adj_lists[w];
-
-      // Offset vertices greater than target
-      for i in found_v_idx..w_adj.len() {
-        let target = w_adj[i];
-        if target >= v && target > 0 {
-          w_adj[i] = target - 1;
+    // Decrement all references > v in all remaining adjacency lists
+    for adj_list in &mut self._adj_lists {
+      for idx in adj_list.iter_mut() {
+        if *idx > v {
+          *idx -= 1;
         }
       }
-    });
+    }
 
-    self._adj_lists.remove(v);
     Ok(self)
   }
 
@@ -229,6 +257,25 @@ impl Graph {
   }
 
   /// Removes edge `v` to `w` from graph.
+  ///
+  /// Returns the index where `v` was found in `w`'s adjacency list, or an error
+  /// if the edge does not exist or the vertices are invalid.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use walrs_graph::Graph;
+  ///
+  /// let mut g = Graph::new(3);
+  /// g.add_edge(0, 1).unwrap();
+  ///
+  /// // Removing an existing edge succeeds
+  /// assert!(g.remove_edge(0, 1).is_ok());
+  /// assert!(!g.has_edge(0, 1));
+  ///
+  /// // Removing a non-existent edge returns an error
+  /// assert!(g.remove_edge(0, 2).is_err());
+  /// ```
   pub fn remove_edge(&mut self, v: usize, w: usize) -> Result<usize, String> {
     self
       .validate_vertex(v)
@@ -236,10 +283,15 @@ impl Graph {
     let adj = &mut self._adj_lists;
 
     let adj_v = &mut adj[v];
-    adj_v.remove(adj_v.binary_search(&w).unwrap());
+    let v_in_w_pos = adj_v
+      .binary_search(&w)
+      .map_err(|_| format!("Edge {} -> {} not found", v, w))?;
+    adj_v.remove(v_in_w_pos);
 
     let adj_w = &mut adj[w];
-    let found_v_idx = adj_w.binary_search(&v).unwrap();
+    let found_v_idx = adj_w
+      .binary_search(&v)
+      .map_err(|_| format!("Edge {} -> {} not found", w, v))?;
     adj_w.remove(found_v_idx);
 
     self._edge_count -= 2;
@@ -274,7 +326,7 @@ impl Graph {
     lines: Lines<&mut BufReader<R>>,
   ) -> Result<&mut Self, Box<dyn std::error::Error>> {
     // Loop through lines
-    for line in lines {
+    for (line_num, line) in lines.enumerate() {
       // For each edge definition, enter them into graph
       match line {
         // If line
@@ -282,8 +334,26 @@ impl Graph {
           // Split and parse edge values to integers
           let verts: Vec<usize> = _line
             .split_ascii_whitespace()
-            .map(|x| x.parse::<usize>().unwrap())
-            .collect();
+            .map(|x| {
+              x.parse::<usize>().map_err(|e| {
+                std::io::Error::new(
+                  std::io::ErrorKind::InvalidData,
+                  format!("Failed to parse \"{}\" as vertex index at line {}: {}", x, line_num, e),
+                )
+              })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+          if verts.len() < 2 {
+            return Err(Box::new(std::io::Error::new(
+              std::io::ErrorKind::InvalidData,
+              format!(
+                "Expected at least 2 vertex indices at line {}, found {}",
+                line_num,
+                verts.len()
+              ),
+            )));
+          }
 
           if let Err(err) = self.add_edge(verts[0], verts[1]) {
             return Err(Box::new(std::io::Error::new(
@@ -362,7 +432,7 @@ impl TryFrom<File> for Graph {
 mod test {
   use crate::graph::{Graph, invalid_vertex_msg};
   use std::fs::File;
-  use std::io::BufReader;
+  use std::io::{BufRead, BufReader};
 
   #[test]
   pub fn test_new() {
@@ -882,5 +952,138 @@ mod test {
     let _: Graph = BufReader::new(f).try_into().unwrap();
 
     Ok(())
+  }
+
+  #[test]
+  pub fn test_has_vertex() {
+    let g = Graph::new(5);
+    // Valid vertices
+    assert!(g.has_vertex(0));
+    assert!(g.has_vertex(1));
+    assert!(g.has_vertex(4));
+    // Invalid vertices
+    assert!(!g.has_vertex(5));
+    assert!(!g.has_vertex(99));
+    // Empty graph
+    let empty = Graph::new(0);
+    assert!(!empty.has_vertex(0));
+  }
+
+  #[test]
+  pub fn test_remove_vertex_disconnected_graph() {
+    // Graph {0-1, 2-3}: remove vertex 0
+    let mut g = Graph::new(4);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(2, 3).unwrap();
+
+    assert_eq!(g.vert_count(), 4);
+    assert_eq!(g.edge_count(), 4); // 2 logical edges × 2
+
+    g.remove_vertex(0).unwrap();
+
+    assert_eq!(g.vert_count(), 3);
+    // Edge 0-1 removed; vertex 2→1, vertex 3→2; edge 2-3 becomes 1-2
+    assert!(g.has_edge(1, 2), "formerly 2-3 should now be 1-2");
+    assert!(!g.has_edge(0, 1), "vertex 0 is now formerly-vertex-1 (isolated)");
+    assert_eq!(g.edge_count(), 2); // only the 2-3 edge (now 1-2) remains
+  }
+
+  #[test]
+  pub fn test_remove_vertex_middle() {
+    // 0-1, 1-2, 2-3 (chain): remove vertex 1
+    let mut g = Graph::new(4);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(1, 2).unwrap();
+    g.add_edge(2, 3).unwrap();
+
+    g.remove_vertex(1).unwrap();
+
+    assert_eq!(g.vert_count(), 3);
+    // Former vertex 2 → now 1, former 3 → now 2
+    assert!(g.has_edge(1, 2), "formerly 2-3 should now be 1-2");
+    // 0 had edge to removed vertex 1, so 0 should have no neighbors now
+    assert_eq!(g.adj(0).unwrap().len(), 0);
+  }
+
+  #[test]
+  pub fn test_remove_edge_non_existent() {
+    let mut g = Graph::new(3);
+    g.add_edge(0, 1).unwrap();
+
+    // Edge 0-2 doesn't exist
+    let result = g.remove_edge(0, 2);
+    assert!(result.is_err(), "Removing a non-existent edge should return Err");
+    assert!(
+      result.unwrap_err().contains("not found"),
+      "Error message should indicate edge not found"
+    );
+
+    // Ensure original edge is still intact
+    assert!(g.has_edge(0, 1));
+    assert_eq!(g.edge_count(), 2);
+  }
+
+  #[test]
+  pub fn test_remove_edge_invalid_vertex() {
+    let mut g = Graph::new(3);
+    let result = g.remove_edge(0, 99);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  pub fn test_self_loop() {
+    let mut g = Graph::new(3);
+    // Self-loop: add edge 0-0
+    g.add_edge(0, 0).unwrap();
+    // Should have 2 entries in adj list for vertex 0 (both directions of self-loop)
+    assert_eq!(g.adj(0).unwrap().len(), 2);
+    assert_eq!(g.edge_count(), 2);
+    assert!(g.has_edge(0, 0));
+  }
+
+  #[test]
+  pub fn test_duplicate_edge() {
+    let mut g = Graph::new(3);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(0, 1).unwrap(); // duplicate
+    // Both edges are added (multigraph behavior)
+    assert_eq!(g.adj(0).unwrap().len(), 2);
+    assert_eq!(g.edge_count(), 4);
+  }
+
+  #[test]
+  pub fn test_digest_lines_malformed_input() {
+    // Non-numeric input
+    let data = b"hello world\n";
+    let mut reader = BufReader::new(&data[..]);
+    let mut g = Graph::new(5);
+    let result = g.digest_lines((&mut reader).lines());
+    assert!(result.is_err(), "Non-numeric input should return Err");
+
+    // Single token line (< 2 vertices)
+    let data2 = b"0\n";
+    let mut reader2 = BufReader::new(&data2[..]);
+    let mut g2 = Graph::new(5);
+    let result2 = g2.digest_lines((&mut reader2).lines());
+    assert!(result2.is_err(), "Single token should return Err");
+
+    // Empty line
+    let data3 = b"\n";
+    let mut reader3 = BufReader::new(&data3[..]);
+    let mut g3 = Graph::new(5);
+    let result3 = g3.digest_lines((&mut reader3).lines());
+    assert!(result3.is_err(), "Empty line should return Err");
+  }
+
+  #[test]
+  pub fn test_digest_lines_valid_input() {
+    let data = b"0 1\n1 2\n0 2\n";
+    let mut reader = BufReader::new(&data[..]);
+    let mut g = Graph::new(3);
+    g.digest_lines((&mut reader).lines()).unwrap();
+    assert_eq!(g.edge_count(), 6);
+    assert!(g.has_edge(0, 1));
+    assert!(g.has_edge(1, 2));
+    assert!(g.has_edge(0, 2));
   }
 }

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod graph;
 pub mod shared_utils;
 pub mod single_source_dfs;

--- a/crates/graph/src/graph/shared_utils.rs
+++ b/crates/graph/src/graph/shared_utils.rs
@@ -21,15 +21,79 @@ pub fn extract_vert_and_edge_counts_from_bufreader<R: std::io::Read>(
   // Extract vertices count
   reader
     .read_line(&mut s)
-    .expect("Unable to read \"vertex count\" line from buffer");
-  let vertices_count = s.trim().parse::<usize>().unwrap();
+    .map_err(|e| format!("Unable to read \"vertex count\" line from buffer: {}", e))?;
+  let vertices_count = s
+    .trim()
+    .parse::<usize>()
+    .map_err(|e| format!("Failed to parse vertex count \"{}\": {}", s.trim(), e))?;
   s.clear();
 
   // Edge count currently, not required
   reader
     .read_line(&mut s)
-    .expect("Unable to read \"edge count\" line  from buffer");
-  let edges_count = s.trim().parse::<usize>().unwrap();
+    .map_err(|e| format!("Unable to read \"edge count\" line from buffer: {}", e))?;
+  let edges_count = s
+    .trim()
+    .parse::<usize>()
+    .map_err(|e| format!("Failed to parse edge count \"{}\": {}", s.trim(), e))?;
 
   Ok((vertices_count, edges_count))
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn test_extract_valid_counts() {
+    let data = b"13\n13\n0 5\n";
+    let mut reader = BufReader::new(&data[..]);
+    let (verts, edges) = extract_vert_and_edge_counts_from_bufreader(&mut reader).unwrap();
+    assert_eq!(verts, 13);
+    assert_eq!(edges, 13);
+  }
+
+  #[test]
+  fn test_extract_malformed_vertex_line() {
+    let data = b"abc\n10\n";
+    let mut reader = BufReader::new(&data[..]);
+    let result = extract_vert_and_edge_counts_from_bufreader(&mut reader);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Failed to parse vertex count"));
+  }
+
+  #[test]
+  fn test_extract_malformed_edge_line() {
+    let data = b"10\nxyz\n";
+    let mut reader = BufReader::new(&data[..]);
+    let result = extract_vert_and_edge_counts_from_bufreader(&mut reader);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Failed to parse edge count"));
+  }
+
+  #[test]
+  fn test_extract_empty_input() {
+    let data = b"";
+    let mut reader = BufReader::new(&data[..]);
+    let result = extract_vert_and_edge_counts_from_bufreader(&mut reader);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_extract_single_line_only() {
+    let data = b"5\n";
+    let mut reader = BufReader::new(&data[..]);
+    let result = extract_vert_and_edge_counts_from_bufreader(&mut reader);
+    // Second line is empty → parse error
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_extract_with_whitespace() {
+    let data = b"  7  \n  3  \n";
+    let mut reader = BufReader::new(&data[..]);
+    let (verts, edges) = extract_vert_and_edge_counts_from_bufreader(&mut reader).unwrap();
+    assert_eq!(verts, 7);
+    assert_eq!(edges, 3);
+  }
 }

--- a/crates/graph/src/graph/single_source_dfs.rs
+++ b/crates/graph/src/graph/single_source_dfs.rs
@@ -57,7 +57,7 @@ impl<'a> DFS<'a> {
   }
 
   /// Runs 'depth-first-search' algorithm on contained graph and stores results on `self`.
-  pub fn dfs(&mut self, v: usize) -> &Self {
+  fn dfs(&mut self, v: usize) -> &Self {
     if let Err(err) = self._graph.validate_vertex(v) {
       panic!("{}", err);
     }
@@ -93,10 +93,26 @@ impl<'a> DFS<'a> {
     self._count
   }
 
+  /// Returns `true` if vertex `i` is reachable from the source vertex,
+  /// or `false` if `i` is out of range or not reachable.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use walrs_graph::{Graph, DFS};
+  ///
+  /// let mut g = Graph::new(3);
+  /// g.add_edge(0, 1).unwrap();
+  ///
+  /// let dfs = DFS::new(&g, 0);
+  /// assert!(dfs.marked(0));
+  /// assert!(dfs.marked(1));
+  /// assert!(!dfs.marked(2));
+  /// assert!(!dfs.marked(99)); // Out-of-range returns false
+  /// ```
   pub fn marked(&self, i: usize) -> bool {
     if i >= self._marked.len() {
-      // @todo shouldn't 'panic!' here
-      panic!("{} is out of range", i);
+      return false;
     }
     self._marked[i]
   }
@@ -194,5 +210,119 @@ mod test {
     println!("{:?}", &_dfs.has_path_to(3));
 
     Ok(())
+  }
+
+  #[test]
+  pub fn test_dfs_disconnected_graph() {
+    // Two components: {0-1-2} and {3-4}
+    let mut g = Graph::new(5);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(1, 2).unwrap();
+    g.add_edge(3, 4).unwrap();
+
+    let dfs = DFS::new(&g, 0);
+    assert!(dfs.marked(0));
+    assert!(dfs.marked(1));
+    assert!(dfs.marked(2));
+    assert!(!dfs.marked(3), "Vertex 3 is in a different component");
+    assert!(!dfs.marked(4), "Vertex 4 is in a different component");
+    assert_eq!(dfs.count(), 3);
+  }
+
+  #[test]
+  pub fn test_dfs_single_vertex() {
+    let g = Graph::new(1);
+    let dfs = DFS::new(&g, 0);
+    assert!(dfs.marked(0));
+    assert_eq!(dfs.count(), 1);
+    assert_eq!(dfs.source_vertex(), 0);
+  }
+
+  #[test]
+  pub fn test_dfs_isolated_vertices() {
+    let g = Graph::new(5);
+    // No edges — all vertices isolated
+    let dfs = DFS::new(&g, 2);
+    assert!(dfs.marked(2));
+    assert!(!dfs.marked(0));
+    assert!(!dfs.marked(1));
+    assert!(!dfs.marked(3));
+    assert!(!dfs.marked(4));
+    assert_eq!(dfs.count(), 1);
+  }
+
+  #[test]
+  pub fn test_dfs_marked_out_of_range() {
+    let g = Graph::new(3);
+    let dfs = DFS::new(&g, 0);
+    // Out-of-range should return false, not panic
+    assert!(!dfs.marked(3));
+    assert!(!dfs.marked(99));
+    assert!(!dfs.marked(usize::MAX));
+  }
+
+  #[test]
+  pub fn test_dfs_path_to_direct() {
+    let mut g = Graph::new(4);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(1, 2).unwrap();
+    g.add_edge(2, 3).unwrap();
+
+    let dfs = DFS::new(&g, 0);
+
+    // Path to source is just the source
+    let path_to_source = dfs.path_to(0).unwrap();
+    assert_eq!(path_to_source, vec![0]);
+
+    // Path to 3 should end at source 0
+    let path = dfs.path_to(3).unwrap();
+    assert_eq!(*path.last().unwrap(), 0);
+    assert_eq!(*path.first().unwrap(), 3);
+  }
+
+  #[test]
+  pub fn test_dfs_path_to_unreachable() {
+    let mut g = Graph::new(4);
+    g.add_edge(0, 1).unwrap();
+    // Vertices 2 and 3 are isolated
+
+    let dfs = DFS::new(&g, 0);
+    assert_eq!(dfs.path_to(2), None);
+    assert_eq!(dfs.path_to(3), None);
+  }
+
+  #[test]
+  pub fn test_dfs_has_path_to() {
+    let mut g = Graph::new(5);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(1, 2).unwrap();
+
+    let dfs = DFS::new(&g, 0);
+    assert!(dfs.has_path_to(0));
+    assert!(dfs.has_path_to(1));
+    assert!(dfs.has_path_to(2));
+    assert!(!dfs.has_path_to(3));
+    assert!(!dfs.has_path_to(4));
+    // Out-of-range
+    assert!(!dfs.has_path_to(99));
+  }
+
+  #[test]
+  pub fn test_dfs_graph_accessor() {
+    let mut g = Graph::new(3);
+    g.add_edge(0, 1).unwrap();
+    let dfs = DFS::new(&g, 0);
+    assert_eq!(dfs.graph().vert_count(), 3);
+  }
+
+  #[test]
+  pub fn test_dfs_count() {
+    let mut g = Graph::new(5);
+    g.add_edge(0, 1).unwrap();
+    g.add_edge(1, 2).unwrap();
+    // Vertices 3 and 4 are isolated
+
+    let dfs = DFS::new(&g, 0);
+    assert_eq!(dfs.count(), 3); // 0, 1, 2 are reachable
   }
 }

--- a/crates/graph/src/graph/symbol_graph.rs
+++ b/crates/graph/src/graph/symbol_graph.rs
@@ -38,9 +38,25 @@ impl From<String> for GenericSymbol {
   }
 }
 
-/// `SymbolGraph` A Directed Acyclic Graph (B-DAG) data structure.
-/// ```rust
-/// // @todo
+/// An undirected symbol graph that maps named symbols to graph vertex indices.
+///
+/// `SymbolGraph` wraps a [`Graph`] and associates each vertex with a typed symbol `T`.
+/// Symbols are deduplicated on insertion: adding the same symbol twice returns its existing index.
+///
+/// # Examples
+///
+/// ```
+/// use walrs_graph::{SymbolGraph, GenericSymbol};
+///
+/// let mut sg: SymbolGraph<GenericSymbol> = SymbolGraph::new();
+/// sg.add_edge("A".to_string().into(), Some(vec!["B".to_string().into()])).unwrap();
+/// sg.add_edge("B".to_string().into(), Some(vec!["C".to_string().into()])).unwrap();
+///
+/// assert_eq!(sg.vert_count(), 3);
+/// assert!(sg.contains("A"));
+/// assert!(sg.contains("B"));
+/// assert!(sg.contains("C"));
+/// assert!(!sg.contains("D"));
 /// ```
 #[derive(Debug)]
 pub struct SymbolGraph<T>
@@ -53,6 +69,15 @@ where
 
 /// @todo Methods here should take an `&T` instead of an `&str` when working with vertices,
 ///   since vertices here are actually `T` - Makes methods more straight forward.
+impl<T> Default for SymbolGraph<T>
+where
+  T: Symbol,
+{
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl<T> SymbolGraph<T>
 where
   T: Symbol,
@@ -290,7 +315,41 @@ mod test {
   }
 
   #[test]
-  pub fn test_symbol_graph_builder_from_buf_reader() {}
+  pub fn test_symbol_graph_builder_from_buf_reader() {
+    use crate::graph::symbol_graph::SymbolGraph;
+    use crate::graph::GenericSymbol;
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let f = File::open("./test-fixtures/acl_roles_symbol_graph.txt").unwrap();
+    let mut reader = BufReader::new(f);
+    let sg: SymbolGraph<GenericSymbol> = (&mut reader).try_into().unwrap();
+
+    // Verify vertex count matches unique symbols in fixture
+    assert!(sg.vert_count() > 0, "Symbol graph should have vertices");
+
+    // Verify known symbols from the fixture are present
+    assert!(sg.contains("guest"), "Should contain 'guest'");
+    assert!(sg.contains("user"), "Should contain 'user'");
+    assert!(sg.contains("tester"), "Should contain 'tester'");
+    assert!(sg.contains("developer"), "Should contain 'developer'");
+    assert!(sg.contains("editor"), "Should contain 'editor'");
+    assert!(sg.contains("publisher"), "Should contain 'publisher'");
+
+    // Verify known edges
+    let user_adj = sg.adj("user").unwrap();
+    let user_adj_ids: Vec<String> = user_adj.iter().map(|s| s.id()).collect();
+    assert!(
+      user_adj_ids.contains(&"guest".to_string()),
+      "user should be adjacent to guest"
+    );
+
+    // Verify non-existent symbol
+    assert!(!sg.contains("nonexistent"));
+
+    // Verify edge count is positive
+    assert!(sg.edge_count() > 0, "Should have edges");
+  }
 
   #[test]
   pub fn test_add_edge() -> Result<(), String> {
@@ -351,5 +410,98 @@ mod test {
     // println!("{:?}", &graph);
 
     Ok(())
+  }
+
+  #[test]
+  pub fn test_default() {
+    let sg: SymbolGraph<String> = SymbolGraph::default();
+    assert_eq!(sg.vert_count(), 0);
+    assert_eq!(sg.edge_count(), 0);
+  }
+
+  #[test]
+  pub fn test_adj_indices() {
+    let mut sg: SymbolGraph<String> = SymbolGraph::new();
+    sg.add_edge("a".to_string(), Some(vec!["b".to_string(), "c".to_string()]))
+      .unwrap();
+
+    let indices = sg.adj_indices("a").unwrap();
+    assert_eq!(indices.len(), 2);
+
+    // Non-existent symbol
+    let err = sg.adj_indices("z");
+    assert!(err.is_err());
+  }
+
+  #[test]
+  pub fn test_adj_nonexistent() {
+    let sg: SymbolGraph<String> = SymbolGraph::new();
+    assert!(sg.adj("nonexistent").is_err());
+  }
+
+  #[test]
+  pub fn test_degree() {
+    let mut sg: SymbolGraph<String> = SymbolGraph::new();
+    sg.add_edge("a".to_string(), Some(vec!["b".to_string(), "c".to_string()]))
+      .unwrap();
+
+    assert_eq!(sg.degree("a").unwrap(), 2);
+    assert_eq!(sg.degree("b").unwrap(), 1);
+    assert!(sg.degree("nonexistent").is_err());
+  }
+
+  #[test]
+  pub fn test_indices() {
+    let mut sg: SymbolGraph<String> = SymbolGraph::new();
+    sg.add_vertex("x".to_string());
+    sg.add_vertex("y".to_string());
+    sg.add_vertex("z".to_string());
+
+    let indices = sg.indices(&["x", "z", "missing"]);
+    assert_eq!(indices.len(), 2); // "missing" is skipped
+    assert_eq!(indices[0], sg.index("x").unwrap());
+    assert_eq!(indices[1], sg.index("z").unwrap());
+  }
+
+  #[test]
+  pub fn test_name_and_names() {
+    let mut sg: SymbolGraph<String> = SymbolGraph::new();
+    sg.add_vertex("alpha".to_string());
+    sg.add_vertex("beta".to_string());
+
+    assert_eq!(sg.name(0).unwrap().as_ref(), "alpha");
+    assert_eq!(sg.name(1).unwrap().as_ref(), "beta");
+    assert!(sg.name(99).is_none());
+
+    let names = sg.names(&[0, 1, 99]);
+    assert_eq!(names.len(), 2); // 99 is skipped
+    assert_eq!(names[0].as_ref(), "alpha");
+    assert_eq!(names[1].as_ref(), "beta");
+  }
+
+  #[test]
+  pub fn test_generic_symbol_from_str() {
+    use crate::graph::GenericSymbol;
+    use std::str::FromStr;
+
+    let gs = GenericSymbol::from_str("hello").unwrap();
+    assert_eq!(gs.id(), "hello");
+  }
+
+  #[test]
+  pub fn test_add_vertex_dedup() {
+    let mut sg: SymbolGraph<String> = SymbolGraph::new();
+    let i1 = sg.add_vertex("a".to_string());
+    let i2 = sg.add_vertex("a".to_string());
+    assert_eq!(i1, i2);
+    assert_eq!(sg.vert_count(), 1);
+  }
+
+  #[test]
+  pub fn test_add_edge_no_weights() {
+    let mut sg: SymbolGraph<String> = SymbolGraph::new();
+    sg.add_edge("a".to_string(), None).unwrap();
+    assert_eq!(sg.vert_count(), 1);
+    assert_eq!(sg.edge_count(), 0);
   }
 }


### PR DESCRIPTION
## Summary

Fixes critical and major bugs found during the walrs_graph crate review (issue #162).

## Related Issue

Closes #162

## Changes

### Critical Fixes
- **`has_vertex()`**: Logic was inverted — returned `true` for out-of-bounds indices and `false` for valid ones
- **`remove_vertex()`**: Only adjusted neighbor adj lists, leaving stale indices in non-neighbor vertices

### Major Fixes
- **`remove_edge()`**: Panicked via `unwrap()` on non-existent edge instead of returning `Err`
- **`shared_utils`**: `extract_vert_and_edge_counts_from_bufreader` panicked on IO/parse errors despite returning `Result`
- **`digest_lines()`**: Panicked on non-numeric or malformed input lines

### High Priority Fixes
- **`DFS::dfs()`**: Changed from `pub` to private — external calls could corrupt internal state
- **`DFS::marked()`**: Returns `false` for out-of-range indices instead of panicking
- **`SymbolGraph`**: Doc comment incorrectly said "DAG" — corrected to undirected graph
- **Empty test**: Filled `test_symbol_graph_builder_from_buf_reader` with actual assertions

### Test Coverage
- Added tests for `has_vertex`, disconnected graph removal, non-existent edge removal
- Added DFS tests for disconnected graphs, isolated vertices, path_to, edge cases
- Added coverage for error paths in shared_utils and digest_lines
- Added tests for symbol_graph: adj_indices, degree, indices, name/names, default, from_str
- All graph crate files above 80% line coverage (graph.rs: 96%, shared_utils: 97%, dfs: 98%, symbol_graph: 90%)

## Testing

- `cargo test -p walrs_graph` — 50 unit tests + 16 doc-tests pass
- `cargo test --workspace` — all workspace tests pass
- `cargo clippy -p walrs_graph -- -D warnings` — clean
- `cargo llvm-cov -p walrs_graph` — all source files above 80% coverage