### PR TITLE
refactor(walrs_validation): #218 rename FieldsetViolations::fields() to field_names()

### DIFF
--- a/crates/fieldfilter/examples/field_filter.rs
+++ b/crates/fieldfilter/examples/field_filter.rs
@@ -214,7 +214,7 @@ fn make_data(pairs: &[(&str, &str)]) -> IndexMap<String, Value> {
 
 fn print_violations(violations: &walrs_validation::FieldsetViolations) {
   println!("   ✗ Validation failed:");
-  for field_name in violations.fields().filter(|f| !f.is_empty()) {
+  for field_name in violations.field_names().filter(|f| !f.is_empty()) {
     if let Some(field_violations) = violations.get(field_name) {
       for v in field_violations.iter() {
         println!("      - {}: {}", field_name, v.message());

--- a/crates/validation/src/fieldset_violations.rs
+++ b/crates/validation/src/fieldset_violations.rs
@@ -117,7 +117,7 @@ impl FieldsetViolations {
   }
 
   /// Returns an iterator over the field names.
-  pub fn fields(&self) -> impl Iterator<Item = &String> {
+  pub fn field_names(&self) -> impl Iterator<Item = &String> {
     self.0.keys()
   }
 
@@ -332,7 +332,7 @@ mod tests {
     fv.add("email", Violation::invalid_email());
     fv.add("name", Violation::value_missing());
 
-    let fields: Vec<&String> = fv.fields().collect();
+    let fields: Vec<&String> = fv.field_names().collect();
     assert_eq!(fields.len(), 2);
     assert!(fields.contains(&&"email".to_string()));
     assert!(fields.contains(&&"name".to_string()));


### PR DESCRIPTION
## Summary

Renames `FieldsetViolations::fields()` to `FieldsetViolations::field_names()` for clarity — the method returns an iterator over field **names** (keys), not field data.

## Related Issue

Closes #218

## Changes

- `crates/validation/src/fieldset_violations.rs`: renamed method definition + updated test
- `crates/fieldfilter/examples/field_filter.rs`: updated call site

## Testing

- `cargo test -p walrs_validation -p walrs_fieldfilter` — all pass
- `cargo build --examples -p walrs_fieldfilter` — builds clean
- `cargo clippy -p walrs_validation -p walrs_fieldfilter -- -D warnings` — no warnings