### PR TITLE
chore: #161 fuzz CI workflows and documentation

### DIFF
--- a/.github/workflows/fuzz-scheduled.yml
+++ b/.github/workflows/fuzz-scheduled.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * 1'  # Weekly on Mondays at 3 AM UTC
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/fuzz-scheduled.yml
+++ b/.github/workflows/fuzz-scheduled.yml
@@ -1,0 +1,86 @@
+name: Scheduled Deep Fuzz
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Weekly on Mondays at 3 AM UTC
+  workflow_dispatch:  # Allow manual triggering
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: Deep fuzz ${{ matrix.crate }}/${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # walrs_validation targets
+          - crate: validation
+            target: fuzz_email
+          - crate: validation
+            target: fuzz_url
+          - crate: validation
+            target: fuzz_ip
+          - crate: validation
+            target: fuzz_hostname
+          - crate: validation
+            target: fuzz_date
+          - crate: validation
+            target: fuzz_rule_composition
+          # walrs_filter targets
+          - crate: filter
+            target: fuzz_strip_tags
+          - crate: filter
+            target: fuzz_slug
+          - crate: filter
+            target: fuzz_filter_op_string
+          # walrs_fieldfilter targets
+          - crate: fieldfilter
+            target: fuzz_field_string_clean
+          - crate: fieldfilter
+            target: fuzz_fieldfilter_validate
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Restore fuzz corpus
+        uses: actions/cache@v4
+        with:
+          path: crates/${{ matrix.crate }}/fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.crate }}-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.crate }}-${{ matrix.target }}-
+
+      - name: Run deep fuzz
+        working-directory: crates/${{ matrix.crate }}
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=1800
+
+      - name: Save fuzz corpus
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: crates/${{ matrix.crate }}/fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.crate }}-${{ matrix.target }}-${{ github.sha }}
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash-${{ matrix.crate }}-${{ matrix.target }}
+          path: |
+            crates/${{ matrix.crate }}/fuzz/artifacts/${{ matrix.target }}/
+          retention-days: 30

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,52 @@
+name: Fuzz Testing
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'crates/validation/**'
+      - 'crates/filter/**'
+      - 'crates/fieldfilter/**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.crate }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - validation
+          - filter
+          - fieldfilter
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: List fuzz targets
+        working-directory: crates/${{ matrix.crate }}
+        run: cargo fuzz list
+
+      - name: Run fuzz targets (smoke test)
+        working-directory: crates/${{ matrix.crate }}
+        run: |
+          for target in $(cargo fuzz list); do
+            echo "::group::Fuzzing $target"
+            cargo fuzz run "$target" -- -max_total_time=60
+            echo "::endgroup::"
+          done

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,6 +8,9 @@ on:
       - 'crates/filter/**'
       - 'crates/fieldfilter/**'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,48 @@ Note: branch and functions tracking is not supported with this method (currently
 
 Reference: https://github.com/mozilla/grcov?tab=readme-ov-file#how-to-get-grcov
 
+### Fuzz testing with `cargo-fuzz`
+
+The workspace includes [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) targets for crates that handle untrusted input.
+
+#### Prerequisites
+
+```bash
+# cargo-fuzz requires nightly Rust
+rustup install nightly
+
+# Install cargo-fuzz
+cargo install cargo-fuzz
+```
+
+#### Running fuzz targets locally
+
+```bash
+# List available targets for a crate
+cd crates/validation
+cargo fuzz list
+
+# Run a specific target for 60 seconds
+cargo fuzz run fuzz_email -- -max_total_time=60
+
+# Run with a specific corpus directory
+cargo fuzz run fuzz_email fuzz/corpus/fuzz_email/ -- -max_total_time=60
+```
+
+#### Fuzz target crates
+
+| Crate | Targets | Focus |
+|---|---|---|
+| `walrs_validation` | `fuzz_email`, `fuzz_url`, `fuzz_ip`, `fuzz_hostname`, `fuzz_date`, `fuzz_rule_composition` | String parsers, rule composition |
+| `walrs_filter` | `fuzz_strip_tags`, `fuzz_slug`, `fuzz_filter_op_string` | HTML sanitization, slug generation, filter chains |
+| `walrs_fieldfilter` | `fuzz_field_string_clean`, `fuzz_fieldfilter_validate` | Field validation pipelines, multi-field validation |
+
+#### CI integration
+
+- **Per-PR smoke runs**: Every PR touching validation/filter/fieldfilter crates triggers 60-second fuzz runs per target.
+- **Scheduled deep runs**: Weekly 30-minute runs per target on Mondays at 3 AM UTC (also manually triggerable).
+- Crash artifacts are uploaded on failure for investigation.
+
 ## License
 
 [Elastic License 2.0 (ELv2)](./LICENSE)


### PR DESCRIPTION
## Summary

Adds CI workflows for fuzz testing and fuzz testing documentation to the README.

## Related Issue

Part of #161

## Work Unit

**ID**: ci-fuzz-docs
**Scope**: .github/workflows/, README.md

## Changes

- Added `.github/workflows/fuzz.yml` — per-PR smoke fuzz runs (60s per target)
- Added `.github/workflows/fuzz-scheduled.yml` — weekly deep fuzz runs (30min per target)
- Added fuzz testing section to README.md under Development

## Testing

- YAML syntax validated
- README section visually verified