### PR TITLE
fix(walrs_digraph): #224 replace panicking paths with proper error propagation

### DIFF
--- a/crates/digraph/src/digraph.rs
+++ b/crates/digraph/src/digraph.rs
@@ -180,9 +180,7 @@ impl<R: std::io::Read> TryFrom<&mut BufReader<R>> for Digraph {
   ///
   fn try_from(reader: &mut BufReader<R>) -> Result<Self, Self::Error> {
     // Extract vert count, and move cursor passed edge count line, for reader
-    let vert_count = extract_vert_and_edge_counts_from_bufreader(reader)
-      .unwrap()
-      .0;
+    let vert_count = extract_vert_and_edge_counts_from_bufreader(reader)?.0;
 
     // Construct digraph
     let mut dg = Digraph::new(vert_count);
@@ -194,10 +192,20 @@ impl<R: std::io::Read> TryFrom<&mut BufReader<R>> for Digraph {
       // Split and parse edge values to integers
       let verts: Vec<usize> = _line
         .split_ascii_whitespace()
-        .map(|x| x.parse::<usize>().unwrap())
-        .collect();
+        .map(|x| x.parse::<usize>())
+        .collect::<Result<Vec<usize>, _>>()?;
 
-      // Add edge, and panic if unable to add it
+      if verts.len() < 2 {
+        return Err(
+          format!(
+            "Edge line must contain at least 2 vertices, got {}: '{}'",
+            verts.len(),
+            _line
+          )
+          .into(),
+        );
+      }
+
       dg.add_edge(verts[0], verts[1])?;
     }
 
@@ -553,5 +561,37 @@ mod test {
     let _: Digraph = BufReader::new(f).try_into().unwrap();
 
     Ok(())
+  }
+
+  #[test]
+  fn test_try_from_malformed_non_numeric_vertex_count() {
+    let data = b"abc\n5\n0 1\n";
+    let mut reader = BufReader::new(std::io::Cursor::new(data));
+    let result = Digraph::try_from(&mut reader);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_try_from_malformed_non_numeric_edge_definition() {
+    let data = b"3\n2\na b\n";
+    let mut reader = BufReader::new(std::io::Cursor::new(data));
+    let result = Digraph::try_from(&mut reader);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_try_from_malformed_single_value_edge_line() {
+    let data = b"3\n2\n0\n";
+    let mut reader = BufReader::new(std::io::Cursor::new(data));
+    let result = Digraph::try_from(&mut reader);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_try_from_malformed_empty_input() {
+    let data = b"";
+    let mut reader = BufReader::new(std::io::Cursor::new(data));
+    let result = Digraph::try_from(&mut reader);
+    assert!(result.is_err());
   }
 }

--- a/crates/digraph/src/utils.rs
+++ b/crates/digraph/src/utils.rs
@@ -26,15 +26,21 @@ pub fn extract_vert_and_edge_counts_from_bufreader<R: std::io::Read>(
   // Extract vertices count
   reader
     .read_line(&mut s)
-    .expect("Unable to read \"vertex count\" line from buffer");
-  let vertices_count = s.trim().parse::<usize>().unwrap();
+    .map_err(|e| format!("Unable to read \"vertex count\" line from buffer: {}", e))?;
+  let vertices_count = s
+    .trim()
+    .parse::<usize>()
+    .map_err(|e| format!("Failed to parse vertex count '{}': {}", s.trim(), e))?;
   s.clear();
 
-  // Edge count currently, not required
+  // Extract edge count
   reader
     .read_line(&mut s)
-    .expect("Unable to read \"edge count\" line  from buffer");
-  let edges_count = s.trim().parse::<usize>().unwrap();
+    .map_err(|e| format!("Unable to read \"edge count\" line from buffer: {}", e))?;
+  let edges_count = s
+    .trim()
+    .parse::<usize>()
+    .map_err(|e| format!("Failed to parse edge count '{}': {}", s.trim(), e))?;
 
   Ok((vertices_count, edges_count))
 }


### PR DESCRIPTION
## Summary

Addresses High #2 from the digraph crate review. Replaces all `unwrap()`/`expect()` calls in `Result`-returning paths with proper error propagation using `?` and `map_err`.

## Related Issue

Part of #224

## Work Unit

**ID**: error-handling
**Scope**: `crates/digraph/src/digraph.rs`, `crates/digraph/src/utils.rs`

## Changes

- `utils.rs`: Change `extract_vert_and_edge_counts_from_bufreader` to return `Result<_, Box<dyn Error>>` and use `?` for I/O and parse errors
- `digraph.rs`: Use `?` instead of `unwrap()` in TryFrom impl
- `digraph.rs`: Collect parse results properly for edge lines
- `digraph.rs`: Validate edge lines have ≥2 values before indexing
- Added tests for malformed input handling

## Testing

- All existing tests pass (86 unit + 23 doc-tests)
- New tests verify Err returns for: non-numeric vertex count, non-numeric edge data, single-value edge lines, empty input