### PR TITLE
fix(walrs_digraph): #224 digraph performance and error message fixes

### DIFF
--- a/crates/digraph/src/digraph.rs
+++ b/crates/digraph/src/digraph.rs
@@ -111,16 +111,9 @@ impl Digraph {
   /// representation's length if vertex is greater than contained adjacency's list until index is
   /// valid, allows graph to grow arbitrarily.
   pub fn add_vertex(&mut self, v: usize) -> usize {
-    let mut v_len = self._adj_lists.len();
-    if v >= v_len {
-      loop {
-        if v_len > v {
-          break;
-        }
-        self._adj_lists.push(Vec::new());
-        self._in_degree.push(0);
-        v_len += 1;
-      }
+    if v >= self._adj_lists.len() {
+      self._adj_lists.resize_with(v + 1, Vec::new);
+      self._in_degree.resize(v + 1, 0);
     }
     v
   }
@@ -133,7 +126,6 @@ impl Digraph {
 
     let adj = &mut self._adj_lists[v];
     adj.push(w);
-    adj.sort_unstable();
     self._edge_count += 1;
     self._in_degree[w] += 1;
     Ok(self)
@@ -143,7 +135,11 @@ impl Digraph {
   pub fn validate_vertex(&self, v: usize) -> Result<&Self, String> {
     let len = self._adj_lists.len();
     if v >= len {
-      return Err(invalid_vertex_msg(v, if len > 0 { len - 1 } else { 0 }));
+      return Err(if len == 0 {
+        format!("Vertex {} is invalid: graph has no vertices", v)
+      } else {
+        invalid_vertex_msg(v, len - 1)
+      });
     }
     Ok(self)
   }
@@ -356,7 +352,7 @@ mod test {
   }
 
   #[test]
-  #[should_panic(expected = "Vertex 99 is outside defined range 0-0")]
+  #[should_panic(expected = "Vertex 99 is invalid: graph has no vertices")]
   pub fn test_adj_invalid() {
     let g = Digraph::new(0);
     g.adj(99).unwrap();
@@ -431,7 +427,7 @@ mod test {
   }
 
   #[test]
-  #[should_panic(expected = "Vertex 99 is outside defined range 0-0")]
+  #[should_panic(expected = "Vertex 99 is invalid: graph has no vertices")]
   pub fn test_validate_vertex_invalid() {
     let g = Digraph::new(0);
     g.validate_vertex(99).unwrap();
@@ -593,5 +589,43 @@ mod test {
     let mut reader = BufReader::new(std::io::Cursor::new(data));
     let result = Digraph::try_from(&mut reader);
     assert!(result.is_err());
+  }
+
+  #[test]
+  pub fn test_duplicate_edges() -> Result<(), String> {
+    let mut g = Digraph::new(3);
+
+    g.add_edge(0, 1)?;
+    g.add_edge(0, 1)?;
+
+    // Both entries are kept
+    assert_eq!(g.adj(0)?, &vec![1, 1]);
+    assert_eq!(g.edge_count(), 2);
+    assert_eq!(g.indegree(1)?, 2);
+    assert_eq!(g.outdegree(0)?, 2);
+
+    Ok(())
+  }
+
+  #[test]
+  pub fn test_self_loop_degree() -> Result<(), String> {
+    let mut g = Digraph::new(3);
+
+    g.add_edge(1, 1)?;
+
+    // Self-loop increments in_degree and appears in adjacency list
+    assert_eq!(g.adj(1)?, &vec![1]);
+    assert_eq!(g.indegree(1)?, 1);
+    assert_eq!(g.outdegree(1)?, 1);
+    assert_eq!(g.edge_count(), 1);
+
+    Ok(())
+  }
+
+  #[test]
+  pub fn test_validate_vertex_empty_graph() {
+    let g = Digraph::new(0);
+    let err = g.validate_vertex(5).unwrap_err();
+    assert_eq!(err, "Vertex 5 is invalid: graph has no vertices");
   }
 }


### PR DESCRIPTION
## Summary

Addresses High #1, Low #7, and Low #12 from the digraph crate review.

## Related Issue

Part of #224

## Work Unit

**ID**: digraph-perf
**Scope**: crates/digraph/src/digraph.rs

## Changes

- Remove `sort_unstable()` from `add_edge` — O(1) per insertion instead of O(d log d)
- Replace manual loop in `add_vertex` with `Vec::resize_with`/`resize`
- Improve `validate_vertex` error message for empty graphs ("graph has no vertices" instead of misleading "range 0-0")
- Add tests for duplicate edges, self-loops degree counts, and empty graph validation

## Testing

- All existing tests pass (with updated expected messages for empty graph cases)
- New tests added for edge cases