### PR TITLE
chore: #230 finalize license references across all crates

### DIFF
--- a/crates/acl/README.md
+++ b/crates/acl/README.md
@@ -134,4 +134,4 @@ walrs_acl = { version = "0.1.0", default-features = false, features = ["wasm"] }
 
 ## License
 
-Apache + GPL v3 Clause
+Elastic-2.0

--- a/crates/digraph/README.md
+++ b/crates/digraph/README.md
@@ -14,3 +14,7 @@ TODO
 
 - Algorithms 4th Ed. - Chapters on 'graphs' - https://algs4.cs.princeton.edu/40graphs/ - namely
   https://algs4.cs.princeton.edu/42digraph/Digraph.java.html implementation.
+
+## License
+
+Elastic-2.0

--- a/crates/rbac/README.md
+++ b/crates/rbac/README.md
@@ -159,4 +159,4 @@ This crate is inspired by:
 
 ## License
 
-Apache-2.0 AND GPL-3.0-only
+Elastic-2.0

--- a/crates/validation/README.md
+++ b/crates/validation/README.md
@@ -272,5 +272,5 @@ When both features are enabled, `chrono` takes precedence for string parsing.
 
 ## License
 
-MIT & Apache-2.0
+Elastic-2.0
 


### PR DESCRIPTION
## Summary

Ensures every crate in the walrs workspace has consistent Elastic License 2.0 (ELv2) references.

## Related Issue

Closes #230

## Changes

- **fieldset_derive**: Added missing LICENSE file (copied from root)
- **acl/README.md**: Corrected license from 'Apache + GPL v3 Clause' to root LICENSE reference
- **digraph/README.md**: Added missing license section with root LICENSE reference
- **rbac/README.md**: Corrected license from 'Apache-2.0 AND GPL-3.0-only' to root LICENSE reference
- **validation/README.md**: Corrected license from 'MIT & Apache-2.0' to root LICENSE reference

## Testing

Documentation-only changes — no code modified.