### PR TITLE
refactor(walrs_validation): #229 replace Message sentinel with Option<Message<T>> in WithMessage

### DIFF
--- a/crates/validation/src/rule.rs
+++ b/crates/validation/src/rule.rs
@@ -372,8 +372,8 @@ pub enum Rule<T> {
   WithMessage {
     /// The wrapped rule
     rule: Box<Rule<T>>,
-    /// The custom message to use on failure
-    message: Message<T>,
+    /// The custom message to use on failure (None = pass through inner message)
+    message: Option<Message<T>>,
     /// Optional locale for i18n support (e.g., "es", "en-US", "fr", etc.)
     locale: Option<String>,
   },
@@ -695,7 +695,7 @@ impl<T> Rule<T> {
   pub fn with_message(self, msg: impl Into<String>) -> Rule<T> {
     Rule::WithMessage {
       rule: Box::new(self),
-      message: Message::Static(msg.into()),
+      message: Some(Message::Static(msg.into())),
       locale: None,
     }
   }
@@ -728,7 +728,7 @@ impl<T> Rule<T> {
   {
     Rule::WithMessage {
       rule: Box::new(self),
-      message: Message::Provider(Arc::new(f)),
+      message: Some(Message::Provider(Arc::new(f))),
       locale: locale.map(String::from),
     }
   }
@@ -736,7 +736,7 @@ impl<T> Rule<T> {
   /// Attaches a locale to this rule for internationalized error messages.
   ///
   /// If this rule is already a `WithMessage` variant, updates its locale.
-  /// Otherwise wraps the rule in a `WithMessage` with an empty static message
+  /// Otherwise wraps the rule in a `WithMessage` with `None` message
   /// (which will pass through the inner rule's violation message) and the given locale.
   ///
   /// # Example
@@ -763,7 +763,7 @@ impl<T> Rule<T> {
       },
       other => Rule::WithMessage {
         rule: Box::new(other),
-        message: Message::Static(String::new()),
+        message: None,
         locale: Some(locale_str),
       },
     }
@@ -1061,7 +1061,7 @@ mod tests {
         locale,
       } => {
         assert_eq!(*inner, Rule::MinLength(8));
-        assert_eq!(message, Message::from("Password too short."));
+        assert_eq!(message, Some(Message::from("Password too short.")));
         assert_eq!(locale, None);
       }
       _ => panic!("Expected Rule::WithMessage"),
@@ -1080,8 +1080,8 @@ mod tests {
         locale,
       } => {
         assert_eq!(*inner, Rule::Min(0));
-        assert!(message.is_provider());
-        assert_eq!(message.resolve(&-5, None), "Got -5, expected >= 0.");
+        assert!(message.as_ref().unwrap().is_provider());
+        assert_eq!(message.as_ref().unwrap().resolve(&-5, None), "Got -5, expected >= 0.");
         assert_eq!(locale, None);
       }
       _ => panic!("Expected Rule::WithMessage"),
@@ -1126,7 +1126,7 @@ mod tests {
           _ => panic!("Expected Rule::All inside WithMessage"),
         }
         assert_eq!(
-          message.resolve(&"".to_string(), None),
+          message.as_ref().unwrap().resolve(&"".to_string(), None),
           "Length must be between 3 and 10."
         );
         assert_eq!(locale, None);

--- a/crates/validation/src/rule_impls/attributes.rs
+++ b/crates/validation/src/rule_impls/attributes.rs
@@ -314,7 +314,7 @@ mod tests {
     let inner_rule = Rule::<String>::MinLength(5);
     let rule = Rule::WithMessage {
       rule: Box::new(inner_rule),
-      message: Message::Static("Custom message.".to_string()),
+      message: Some(Message::Static("Custom message.".to_string())),
       locale: None,
     };
     let attrs = rule.to_attributes_list().unwrap();

--- a/crates/validation/src/rule_impls/date_chrono.rs
+++ b/crates/validation/src/rule_impls/date_chrono.rs
@@ -302,7 +302,10 @@ impl Rule<NaiveDate> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_date_inner(value, eff), value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_date_inner(value, eff), value, eff),
+          None => rule.validate_date_inner(value, eff),
+        }
       }
       // Inapplicable rules pass through
       _ => Ok(()),
@@ -423,7 +426,10 @@ impl Rule<NaiveDate> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(rule.validate_date_async_inner(value, eff).await, value, eff)
+          match message {
+            Some(msg) => msg.wrap_result(rule.validate_date_async_inner(value, eff).await, value, eff),
+            None => rule.validate_date_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation
@@ -556,7 +562,10 @@ impl Rule<NaiveDateTime> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_datetime_inner(value, eff), value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_datetime_inner(value, eff), value, eff),
+          None => rule.validate_datetime_inner(value, eff),
+        }
       }
       _ => Ok(()),
     }
@@ -676,11 +685,14 @@ impl Rule<NaiveDateTime> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(
-            rule.validate_datetime_async_inner(value, eff).await,
-            value,
-            eff,
-          )
+          match message {
+            Some(msg) => msg.wrap_result(
+              rule.validate_datetime_async_inner(value, eff).await,
+              value,
+              eff,
+            ),
+            None => rule.validate_datetime_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation

--- a/crates/validation/src/rule_impls/date_jiff.rs
+++ b/crates/validation/src/rule_impls/date_jiff.rs
@@ -303,7 +303,10 @@ impl Rule<Date> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_date_inner(value, eff), value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_date_inner(value, eff), value, eff),
+          None => rule.validate_date_inner(value, eff),
+        }
       }
       _ => Ok(()),
     }
@@ -423,7 +426,10 @@ impl Rule<Date> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(rule.validate_date_async_inner(value, eff).await, value, eff)
+          match message {
+            Some(msg) => msg.wrap_result(rule.validate_date_async_inner(value, eff).await, value, eff),
+            None => rule.validate_date_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation
@@ -556,7 +562,10 @@ impl Rule<DateTime> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_datetime_inner(value, eff), value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_datetime_inner(value, eff), value, eff),
+          None => rule.validate_datetime_inner(value, eff),
+        }
       }
       _ => Ok(()),
     }
@@ -676,11 +685,14 @@ impl Rule<DateTime> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(
-            rule.validate_datetime_async_inner(value, eff).await,
-            value,
-            eff,
-          )
+          match message {
+            Some(msg) => msg.wrap_result(
+              rule.validate_datetime_async_inner(value, eff).await,
+              value,
+              eff,
+            ),
+            None => rule.validate_datetime_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation

--- a/crates/validation/src/rule_impls/length.rs
+++ b/crates/validation/src/rule_impls/length.rs
@@ -93,7 +93,10 @@ impl<T: WithLength> Rule<T> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_len_inner(value, eff), value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_len_inner(value, eff), value, eff),
+          None => rule.validate_len_inner(value, eff),
+        }
       }
       // Non-length rules don't apply to collections - pass through
       Rule::Pattern(_)
@@ -192,9 +195,14 @@ impl<T: WithLength> Rule<T> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        let mut inner_violations = crate::Violations::default();
-        rule.collect_len_violations(value, eff, &mut inner_violations);
-        message.wrap_violations(inner_violations, value, eff, violations);
+        match message {
+          Some(msg) => {
+            let mut inner_violations = crate::Violations::default();
+            rule.collect_len_violations(value, eff, &mut inner_violations);
+            msg.wrap_violations(inner_violations, value, eff, violations);
+          }
+          None => rule.collect_len_violations(value, eff, violations),
+        }
       }
       _ => {
         if let Err(v) = self.validate_len_inner(value, inherited_locale) {

--- a/crates/validation/src/rule_impls/scalar.rs
+++ b/crates/validation/src/rule_impls/scalar.rs
@@ -124,7 +124,10 @@ impl<T: ScalarValue + IsEmpty> Rule<T> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_scalar_inner(value, eff), &value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_scalar_inner(value, eff), &value, eff),
+          None => rule.validate_scalar_inner(value, eff),
+        }
       }
 
       // Step and string-only rules are pass-through for scalar types.
@@ -232,9 +235,14 @@ impl<T: ScalarValue + IsEmpty> Rule<T> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        let mut inner_violations = Violations::default();
-        rule.collect_violations_scalar(value, eff, &mut inner_violations);
-        message.wrap_violations(inner_violations, &value, eff, violations);
+        match message {
+          Some(msg) => {
+            let mut inner_violations = Violations::default();
+            rule.collect_violations_scalar(value, eff, &mut inner_violations);
+            msg.wrap_violations(inner_violations, &value, eff, violations);
+          }
+          None => rule.collect_violations_scalar(value, eff, violations),
+        }
       }
 
       _ => {
@@ -399,11 +407,14 @@ impl<T: ScalarValue + IsEmpty + Send + Sync> Rule<T> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(
-            rule.validate_scalar_async_inner(value, eff).await,
-            &value,
-            eff,
-          )
+          match message {
+            Some(msg) => msg.wrap_result(
+              rule.validate_scalar_async_inner(value, eff).await,
+              &value,
+              eff,
+            ),
+            None => rule.validate_scalar_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation
@@ -623,7 +634,7 @@ mod tests {
     // WithMessage wrapping an All — all collected violations get the custom msg.
     let rule = Rule::<i32>::WithMessage {
       rule: Box::new(Rule::Min(0).and(Rule::Max(10))),
-      message: crate::Message::from("Out of range."),
+      message: Some(crate::Message::from("Out of range.")),
       locale: None,
     };
     assert!(rule.validate_scalar(5).is_ok());

--- a/crates/validation/src/rule_impls/steppable.rs
+++ b/crates/validation/src/rule_impls/steppable.rs
@@ -117,7 +117,10 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_step_inner(value, eff), &value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_step_inner(value, eff), &value, eff),
+          None => rule.validate_step_inner(value, eff),
+        }
       }
       // String rules don't apply to numbers - pass through
       Rule::MinLength(_)
@@ -210,9 +213,14 @@ impl<T: SteppableValue + IsEmpty> Rule<T> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        let mut inner_violations = crate::Violations::default();
-        rule.collect_violations(value, eff, &mut inner_violations);
-        message.wrap_violations(inner_violations, &value, eff, violations);
+        match message {
+          Some(msg) => {
+            let mut inner_violations = crate::Violations::default();
+            rule.collect_violations(value, eff, &mut inner_violations);
+            msg.wrap_violations(inner_violations, &value, eff, violations);
+          }
+          None => rule.collect_violations(value, eff, violations),
+        }
       }
       _ => {
         if let Err(v) = self.validate_step_inner(value, inherited_locale) {
@@ -341,11 +349,14 @@ impl<T: SteppableValue + IsEmpty + Clone + Send + Sync> Rule<T> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(
-            rule.validate_step_async_inner(value, eff).await,
-            &value,
-            eff,
-          )
+          match message {
+            Some(msg) => msg.wrap_result(
+              rule.validate_step_async_inner(value, eff).await,
+              &value,
+              eff,
+            ),
+            None => rule.validate_step_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation

--- a/crates/validation/src/rule_impls/string.rs
+++ b/crates/validation/src/rule_impls/string.rs
@@ -500,7 +500,10 @@ impl Rule<String> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_str_inner(value, eff), &value.to_string(), eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_str_inner(value, eff), &value.to_string(), eff),
+          None => rule.validate_str_inner(value, eff),
+        }
       }
       // Numeric rules don't apply to strings - pass through
       Rule::Min(_) | Rule::Max(_) | Rule::Range { .. } | Rule::Step(_) => Ok(()),
@@ -591,9 +594,14 @@ impl Rule<String> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        let mut inner_violations = crate::Violations::default();
-        rule.collect_violations_str(value, eff, &mut inner_violations);
-        message.wrap_violations(inner_violations, &value.to_string(), eff, violations);
+        match message {
+          Some(msg) => {
+            let mut inner_violations = crate::Violations::default();
+            rule.collect_violations_str(value, eff, &mut inner_violations);
+            msg.wrap_violations(inner_violations, &value.to_string(), eff, violations);
+          }
+          None => rule.collect_violations_str(value, eff, violations),
+        }
       }
       _ => {
         if let Err(v) = self.validate_str_inner(value, inherited_locale) {
@@ -706,11 +714,14 @@ impl Rule<String> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(
-            rule.validate_str_async_inner(value, eff).await,
-            &value.to_string(),
-            eff,
-          )
+          match message {
+            Some(msg) => msg.wrap_result(
+              rule.validate_str_async_inner(value, eff).await,
+              &value.to_string(),
+              eff,
+            ),
+            None => rule.validate_str_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation

--- a/crates/validation/src/rule_impls/value.rs
+++ b/crates/validation/src/rule_impls/value.rs
@@ -278,7 +278,10 @@ impl Rule<Value> {
         locale,
       } => {
         let eff = locale.as_deref().or(inherited_locale);
-        message.wrap_result(rule.validate_value_inner(value, eff), value, eff)
+        match message {
+          Some(msg) => msg.wrap_result(rule.validate_value_inner(value, eff), value, eff),
+          None => rule.validate_value_inner(value, eff),
+        }
       }
     }
   }
@@ -399,11 +402,14 @@ impl Rule<Value> {
           locale,
         } => {
           let eff = locale.as_deref().or(inherited_locale);
-          message.wrap_result(
-            rule.validate_value_async_inner(value, eff).await,
-            value,
-            eff,
-          )
+          match message {
+            Some(msg) => msg.wrap_result(
+              rule.validate_value_async_inner(value, eff).await,
+              value,
+              eff,
+            ),
+            None => rule.validate_value_async_inner(value, eff).await,
+          }
         }
 
         // All sync rules — delegate to sync validation


### PR DESCRIPTION
## Summary

Replaces the `Message::Static(String::new())` sentinel pattern in `Rule::WithMessage` with `Option<Message<T>>`. This makes the "no custom message" case explicit at the type level.

## Related Issue

Closes #229

## Changes

- `WithMessage.message` is now `Option<Message<T>>`
- `with_locale()` uses `None` instead of empty string sentinel
- `with_message()` / `with_message_provider()` wrap in `Some(...)`
- All rule_impl WithMessage match arms updated
- `None` case is more efficient (no temporary violation buffer)

## Testing

- All existing tests pass (`cargo test -p walrs_validation`)
- Full workspace build and test pass