### PR TITLE
fix(walrs_filter): #233 HtmlEntities filter preserves existing entities

### DIFF
--- a/crates/filter/README.md
+++ b/crates/filter/README.md
@@ -8,7 +8,7 @@ This crate provides reusable filter implementations that can transform input val
 
 - **`SlugFilter`** - Converts strings to URL-friendly slugs.
 - **`StripTagsFilter`** - Removes/sanitizes HTML tags using [Ammonia](https://docs.rs/ammonia).
-- **`XmlEntitiesFilter`** - Encodes special characters as XML entities.
+- **`XmlEntitiesFilter`** - Encodes special characters as XML entities. Existing named, decimal, and hex entity references are preserved, so repeated application does not double-encode.
 
 ## FilterOp Enum
 

--- a/crates/filter/benches/filter_benchmarks.rs
+++ b/crates/filter/benches/filter_benchmarks.rs
@@ -83,6 +83,14 @@ fn bench_xml_entities_filter(c: &mut Criterion) {
     ("all_special", "<>&\"'<>&\"'<>&\"'"),
     ("noop_plain", "Already clean text no special chars"),
     ("noop_numbers", "12345678901234567890"),
+    (
+      "noop_already_encoded",
+      "Tom &amp; Jerry &#38; friends &#x26; co",
+    ),
+    (
+      "mixed_raw_and_encoded",
+      "Tom &amp; Jerry & AT&T with <b>tags</b>",
+    ),
   ];
 
   for (name, input) in inputs {

--- a/crates/filter/examples/basic_filters.rs
+++ b/crates/filter/examples/basic_filters.rs
@@ -67,6 +67,9 @@ fn main() {
     "He said \"Hello\"",
     "It's a test",
     "<script>alert('xss')</script>",
+    // Already-encoded input is preserved verbatim (no double-encoding).
+    "Tom &amp; Jerry",
+    "path &#x2F; segment",
   ];
 
   for s in strings {

--- a/crates/filter/src/filter_op.rs
+++ b/crates/filter/src/filter_op.rs
@@ -92,7 +92,9 @@ pub enum FilterOp<T> {
   /// Remove HTML tags using Ammonia sanitizer.
   StripTags,
 
-  /// Encode special characters as XML/HTML entities.
+  /// Encode special characters as XML/HTML entities. Existing named,
+  /// decimal, and hex entity references in the input are preserved
+  /// verbatim so repeated application does not double-encode.
   HtmlEntities,
 
   /// Convert to URL-friendly slug.
@@ -646,6 +648,22 @@ mod tests {
     let result = filter.apply_ref("<b>Hello</b>");
     assert!(result.contains("&lt;"));
     assert!(result.contains("&gt;"));
+  }
+
+  #[test]
+  fn test_html_entities_preserves_existing_entities() {
+    let filter = FilterOp::<String>::HtmlEntities;
+
+    // Already-encoded input should pass through unchanged (no double-encoding).
+    assert_eq!(filter.apply_ref("Tom &amp; Jerry"), "Tom &amp; Jerry");
+    assert_eq!(filter.apply_ref("&#39;hi&#39;"), "&#39;hi&#39;");
+    assert_eq!(filter.apply_ref("&#x2F;path"), "&#x2F;path");
+
+    // Raw specials around an existing entity — only the raw ones get encoded.
+    assert_eq!(
+      filter.apply_ref("<b>Tom &amp; Jerry</b>"),
+      "&lt;b&gt;Tom &amp; Jerry&lt;/b&gt;"
+    );
   }
 
   #[test]

--- a/crates/filter/src/xml_entities.rs
+++ b/crates/filter/src/xml_entities.rs
@@ -31,16 +31,26 @@ fn scan_entity(bytes: &[u8], start: usize) -> Option<usize> {
   if first == b'#' {
     j += 1;
     let next = *bytes.get(j)?;
-    let (digits_start, max_len, is_valid): (usize, usize, fn(u8) -> bool) =
-      if next == b'x' || next == b'X' {
-        j += 1;
-        (j, MAX_HEX_ENTITY_DIGITS, |b: u8| b.is_ascii_hexdigit())
-      } else {
-        (j, MAX_DECIMAL_ENTITY_DIGITS, |b: u8| b.is_ascii_digit())
-      };
-
-    while j < bytes.len() && is_valid(bytes[j]) && (j - digits_start) < max_len {
+    let is_hex = next == b'x' || next == b'X';
+    if is_hex {
       j += 1;
+    }
+    let digits_start = j;
+
+    if is_hex {
+      while j < bytes.len()
+        && bytes[j].is_ascii_hexdigit()
+        && (j - digits_start) < MAX_HEX_ENTITY_DIGITS
+      {
+        j += 1;
+      }
+    } else {
+      while j < bytes.len()
+        && bytes[j].is_ascii_digit()
+        && (j - digits_start) < MAX_DECIMAL_ENTITY_DIGITS
+      {
+        j += 1;
+      }
     }
 
     if j > digits_start && bytes.get(j).copied() == Some(b';') {

--- a/crates/filter/src/xml_entities.rs
+++ b/crates/filter/src/xml_entities.rs
@@ -5,13 +5,75 @@ use std::sync::OnceLock;
 
 static DEFAULT_CHARS_ASSOC_MAP: OnceLock<HashMap<char, &'static str>> = OnceLock::new();
 
-/// Encodes >, <, &, ', and " as XML entities.
+/// Maximum length of the name portion of a named entity (e.g. `amp`, `CounterClockwiseContourIntegral`).
+const MAX_NAMED_ENTITY_LEN: usize = 32;
+
+/// Maximum digits recognized in a decimal numeric character reference (`&#NNN;`).
+const MAX_DECIMAL_ENTITY_DIGITS: usize = 10;
+
+/// Maximum digits recognized in a hexadecimal numeric character reference (`&#xHHH;`).
+const MAX_HEX_ENTITY_DIGITS: usize = 8;
+
+/// Detects a well-formed HTML/XML entity reference starting at `bytes[start]`.
 ///
-/// Note: This filter does not skip already (XML) encoded characters;
-///   E.g., the `&` in `&amp;` will get encoded as well resulting in the value `&amp;amp;`.
+/// Returns the byte index immediately after the terminating `;` when a valid entity
+/// is found, otherwise `None`. Only lexical validation is performed; the entity name
+/// itself is not checked against a dictionary of known entities. This is intentional —
+/// the filter's goal is to avoid double-encoding syntactically valid entity references
+/// regardless of whether they resolve to a named character.
+fn scan_entity(bytes: &[u8], start: usize) -> Option<usize> {
+  if bytes.get(start).copied() != Some(b'&') {
+    return None;
+  }
+  let mut j = start + 1;
+  let first = *bytes.get(j)?;
+
+  if first == b'#' {
+    j += 1;
+    let next = *bytes.get(j)?;
+    let (digits_start, max_len, is_valid): (usize, usize, fn(u8) -> bool) =
+      if next == b'x' || next == b'X' {
+        j += 1;
+        (j, MAX_HEX_ENTITY_DIGITS, |b: u8| b.is_ascii_hexdigit())
+      } else {
+        (j, MAX_DECIMAL_ENTITY_DIGITS, |b: u8| b.is_ascii_digit())
+      };
+
+    while j < bytes.len() && is_valid(bytes[j]) && (j - digits_start) < max_len {
+      j += 1;
+    }
+
+    if j > digits_start && bytes.get(j).copied() == Some(b';') {
+      return Some(j + 1);
+    }
+    None
+  } else if first.is_ascii_alphabetic() {
+    let name_start = j;
+    while j < bytes.len()
+      && bytes[j].is_ascii_alphanumeric()
+      && (j - name_start) < MAX_NAMED_ENTITY_LEN
+    {
+      j += 1;
+    }
+    if j > name_start && bytes.get(j).copied() == Some(b';') {
+      return Some(j + 1);
+    }
+    None
+  } else {
+    None
+  }
+}
+
+/// Encodes `<`, `>`, `&`, `'`, and `"` as XML/HTML entities.
 ///
-/// @todo Update algorithm to skip over existing XML entity declarations, or use a third-party lib.;
-///   E.g., ignore results like `&amp;amp;` for string `&amp;`, etc.
+/// Existing entity references in the input are preserved verbatim so the filter never
+/// double-encodes. Recognized forms:
+/// - Named entities: `&name;` where `name` is ASCII alphanumeric (e.g. `&amp;`, `&lt;`, `&copy;`).
+/// - Decimal numeric: `&#NNNN;` (e.g. `&#39;`).
+/// - Hexadecimal numeric: `&#xHHHH;` / `&#XHHHH;` (e.g. `&#x2F;`).
+///
+/// Malformed entity-like sequences (e.g. `&foo`, `&;`, `&#;`) are treated as raw
+/// characters and the leading `&` is encoded as `&amp;`.
 ///
 /// ```rust
 /// use walrs_filter::{Filter, XmlEntitiesFilter};
@@ -24,7 +86,10 @@ static DEFAULT_CHARS_ASSOC_MAP: OnceLock<HashMap<char, &'static str>> = OnceLock
 ///  ("\"Hello\"", "&quot;Hello&quot;"),
 ///  ("Hello", "Hello"),
 ///  ("S & P", "S &amp; P"),
-///  ("S &amp; P", "S &amp;amp; P"),
+///  // Already-encoded entities are preserved (no double-encoding).
+///  ("S &amp; P", "S &amp; P"),
+///  ("Tom &#38; Jerry", "Tom &#38; Jerry"),
+///  ("AT&T", "AT&amp;T"),
 ///  ("<script>alert('hello');</script>", "&lt;script&gt;alert(&apos;hello&apos;);&lt;/script&gt;"),
 /// ] {
 ///  assert_eq!(filter.filter(incoming_src.into()), expected_src.to_string());
@@ -50,13 +115,49 @@ impl XmlEntitiesFilter<'_> {
       }),
     }
   }
+
+  /// Returns true when any character in `input` requires encoding. Existing entity
+  /// references are skipped so inputs composed entirely of already-encoded text
+  /// take the zero-copy fast path.
+  fn needs_encoding(&self, input: &str) -> bool {
+    let bytes = input.as_bytes();
+    let encodes_ampersand = self.chars_assoc_map.contains_key(&'&');
+    let mut i = 0;
+    while i < bytes.len() {
+      let b = bytes[i];
+      if b == b'&' {
+        if let Some(end) = scan_entity(bytes, i) {
+          i = end;
+          continue;
+        }
+        if encodes_ampersand {
+          return true;
+        }
+        i += 1;
+        continue;
+      }
+      if b < 0x80 {
+        if self.chars_assoc_map.contains_key(&(b as char)) {
+          return true;
+        }
+        i += 1;
+      } else {
+        let ch = input[i..].chars().next().unwrap();
+        if self.chars_assoc_map.contains_key(&ch) {
+          return true;
+        }
+        i += ch.len_utf8();
+      }
+    }
+    false
+  }
 }
 
 impl<'a> Filter<Cow<'a, str>> for XmlEntitiesFilter<'_> {
   type Output = Cow<'a, str>;
 
-  /// Uses contained character association map to encode characters matching contained characters as
-  /// xml entities.
+  /// Encodes special characters as XML/HTML entities while preserving any existing
+  /// entity references in the input so the filter never double-encodes.
   ///
   /// ```rust
   /// use walrs_filter::{Filter, XmlEntitiesFilter};
@@ -72,22 +173,49 @@ impl<'a> Filter<Cow<'a, str>> for XmlEntitiesFilter<'_> {
   ///   ("<", "&lt;"),
   ///   (">", "&gt;"),
   ///   ("&", "&amp;"),
+  ///   ("&amp;", "&amp;"),
+  ///   ("&#x2F;", "&#x2F;"),
   ///   ("<script></script>", "&lt;script&gt;&lt;/script&gt;"),
   /// ] {
   ///   assert_eq!(filter.filter(incoming_src.into()), expected_src.to_string());
   /// }
   ///```
   fn filter(&self, input: Cow<'a, str>) -> Self::Output {
-    // Fast path: if no characters need encoding, return input as-is (zero-copy)
-    if !input.chars().any(|c| self.chars_assoc_map.contains_key(&c)) {
+    if !self.needs_encoding(&input) {
       return input;
     }
 
+    let bytes = input.as_bytes();
     let mut output = String::with_capacity(input.len() + input.len() / 5 * 3);
-    for c in input.chars() {
-      match self.chars_assoc_map.get(&c) {
-        Some(entity) => output.push_str(entity),
-        None => output.push(c),
+    let mut i = 0;
+    while i < bytes.len() {
+      let b = bytes[i];
+      if b == b'&' {
+        if let Some(end) = scan_entity(bytes, i) {
+          output.push_str(&input[i..end]);
+          i = end;
+          continue;
+        }
+        match self.chars_assoc_map.get(&'&') {
+          Some(entity) => output.push_str(entity),
+          None => output.push('&'),
+        }
+        i += 1;
+      } else if b < 0x80 {
+        let ch = b as char;
+        match self.chars_assoc_map.get(&ch) {
+          Some(entity) => output.push_str(entity),
+          None => output.push(ch),
+        }
+        i += 1;
+      } else {
+        let ch = input[i..].chars().next().unwrap();
+        let ch_len = ch.len_utf8();
+        match self.chars_assoc_map.get(&ch) {
+          Some(entity) => output.push_str(entity),
+          None => output.push_str(&input[i..i + ch_len]),
+        }
+        i += ch_len;
       }
     }
 
@@ -195,6 +323,167 @@ mod test {
     let input = "&&&&&";
     let expected = "&amp;&amp;&amp;&amp;&amp;";
     assert_eq!(filter.filter(input.into()), expected);
+  }
+
+  // ---- Entity-preserving behavior (issue #233) ----
+
+  #[test]
+  fn test_preserves_existing_named_entities() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    for (input, expected) in [
+      ("&amp;", "&amp;"),
+      ("&lt;", "&lt;"),
+      ("&gt;", "&gt;"),
+      ("&quot;", "&quot;"),
+      ("&apos;", "&apos;"),
+      ("&copy;", "&copy;"),
+      ("&nbsp;", "&nbsp;"),
+      ("Tom &amp; Jerry", "Tom &amp; Jerry"),
+      ("&amp;&lt;&gt;&quot;&apos;", "&amp;&lt;&gt;&quot;&apos;"),
+    ] {
+      assert_eq!(
+        filter.filter(input.into()),
+        expected,
+        "input was {:?}",
+        input
+      );
+    }
+  }
+
+  #[test]
+  fn test_preserves_numeric_decimal_entities() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    for (input, expected) in [
+      ("&#38;", "&#38;"),
+      ("&#39;", "&#39;"),
+      ("&#60;", "&#60;"),
+      ("&#169;", "&#169;"),
+      ("Tom &#38; Jerry", "Tom &#38; Jerry"),
+    ] {
+      assert_eq!(filter.filter(input.into()), expected);
+    }
+  }
+
+  #[test]
+  fn test_preserves_numeric_hex_entities() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    for (input, expected) in [
+      ("&#x2F;", "&#x2F;"),
+      ("&#X2F;", "&#X2F;"),
+      ("&#x26;", "&#x26;"),
+      ("&#xA9;", "&#xA9;"),
+      ("path &#x2F; segment", "path &#x2F; segment"),
+    ] {
+      assert_eq!(filter.filter(input.into()), expected);
+    }
+  }
+
+  #[test]
+  fn test_mixed_raw_and_encoded() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    // Raw specials around an existing entity — only the raw ones get encoded.
+    assert_eq!(
+      filter.filter("<b>Tom &amp; Jerry</b>".into()),
+      "&lt;b&gt;Tom &amp; Jerry&lt;/b&gt;"
+    );
+
+    // Ampersand followed by a space: bare `&`, should be encoded.
+    assert_eq!(filter.filter("AT&T".into()), "AT&amp;T");
+    assert_eq!(filter.filter("foo & bar".into()), "foo &amp; bar");
+
+    // Mix of encoded and raw ampersands.
+    assert_eq!(
+      filter.filter("&amp; AT&T &#38;".into()),
+      "&amp; AT&amp;T &#38;"
+    );
+  }
+
+  #[test]
+  fn test_malformed_entity_like_sequences_are_encoded() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    // Missing terminating `;`.
+    assert_eq!(filter.filter("&amp".into()), "&amp;amp");
+    // Empty name.
+    assert_eq!(filter.filter("&;".into()), "&amp;;");
+    // `#` with no digits.
+    assert_eq!(filter.filter("&#;".into()), "&amp;#;");
+    // Hex marker with no digits.
+    assert_eq!(filter.filter("&#x;".into()), "&amp;#x;");
+    // Digits interrupted by non-digit.
+    assert_eq!(filter.filter("&#3A;".into()), "&amp;#3A;");
+    // Trailing lone `&`.
+    assert_eq!(filter.filter("a & b &".into()), "a &amp; b &amp;");
+    // `&` followed by non-alphabetic.
+    assert_eq!(filter.filter("& foo".into()), "&amp; foo");
+  }
+
+  #[test]
+  fn test_already_encoded_input_is_noop() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    // Fully encoded input should take the zero-copy fast path.
+    for input in [
+      "&amp;",
+      "Tom &amp; Jerry",
+      "&lt;script&gt;&lt;/script&gt;",
+      "&#39;hello&#39;",
+      "&#x2F;path&#x2F;",
+    ] {
+      let cow_input = std::borrow::Cow::Borrowed(input);
+      let result = filter.filter(cow_input);
+      assert_eq!(result, input);
+      assert!(
+        matches!(result, std::borrow::Cow::Borrowed(_)),
+        "Expected Cow::Borrowed for already-encoded input {:?}",
+        input
+      );
+    }
+  }
+
+  #[test]
+  fn test_unicode_passthrough() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    // Non-ASCII characters with no encodable specials — zero-copy.
+    let input = "héllo wörld — naïve";
+    let result = filter.filter(std::borrow::Cow::Borrowed(input));
+    assert_eq!(result, input);
+    assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+
+    // Non-ASCII mixed with encodable characters.
+    assert_eq!(
+      filter.filter("héllo <b>wörld</b>".into()),
+      "héllo &lt;b&gt;wörld&lt;/b&gt;"
+    );
+  }
+
+  #[test]
+  fn test_entity_at_string_boundary() {
+    let filter = super::XmlEntitiesFilter::new();
+
+    // Bare `&` at end of input must be encoded.
+    assert_eq!(filter.filter("foo&".into()), "foo&amp;");
+    // `&` followed by `#` at end of input — malformed.
+    assert_eq!(filter.filter("foo&#".into()), "foo&amp;#");
+    assert_eq!(filter.filter("foo&#x".into()), "foo&amp;#x");
+  }
+
+  #[test]
+  fn test_scan_entity_rejects_overlong_names() {
+    use super::scan_entity;
+
+    // Name longer than MAX_NAMED_ENTITY_LEN (32) — should not match.
+    let long = format!("&{};", "a".repeat(40));
+    assert_eq!(scan_entity(long.as_bytes(), 0), None);
+
+    // Name of exactly 32 chars — accepted.
+    let ok = format!("&{};", "a".repeat(32));
+    assert_eq!(scan_entity(ok.as_bytes(), 0), Some(ok.len()));
   }
 
   #[cfg(feature = "fn_traits")]


### PR DESCRIPTION
Closes #233

## Summary
- `XmlEntitiesFilter` now detects already-encoded entity references (named, decimal, and hex numeric) and passes them through verbatim instead of re-encoding the leading `&` as `&amp;`.
- Fully-encoded inputs continue to take the zero-copy `Cow::Borrowed` fast path.
- Malformed entity-like sequences (e.g. `&foo`, `&;`, `&#;`, `&#x;`, trailing lone `&`) still treat the `&` as raw and encode it.
- Applies to `FilterOp::HtmlEntities` since that variant delegates to `XmlEntitiesFilter`.

### Before / After
Input: `Tom &amp; Jerry`
- Before: `Tom &amp;amp; Jerry`
- After:  `Tom &amp; Jerry`

Input: `<b>Tom &amp; Jerry</b>`
- Before: `&lt;b&gt;Tom &amp;amp; Jerry&lt;/b&gt;`
- After:  `&lt;b&gt;Tom &amp; Jerry&lt;/b&gt;`

## Implementation notes
Entity detection is lexical (no dictionary lookup) — any syntactically valid `&name;`, `&#NNN;`, or `&#xHHH;` / `&#XHHH;` is preserved. Rationale is documented on `scan_entity`. Bounds:
- Named entity: 1–32 ASCII alphanumeric characters.
- Decimal numeric: 1–10 ASCII digits.
- Hex numeric: 1–8 ASCII hex digits.

## Files touched
- `crates/filter/src/xml_entities.rs` — filter logic + new `scan_entity` + extended tests.
- `crates/filter/src/filter_op.rs` — doc update on `HtmlEntities` variant + test.
- `crates/filter/README.md` — filter description updated.
- `crates/filter/benches/filter_benchmarks.rs` — bench cases for already-encoded + mixed inputs.
- `crates/filter/examples/basic_filters.rs` — showcase of preserved-entity behavior.

## Test plan
- [x] `cargo fmt -p walrs_filter -- --check` clean
- [x] `cargo clippy -p walrs_filter --all-targets -- -D warnings` clean
- [x] `cargo test -p walrs_filter` — 145 unit tests + 12 doctests pass
- [x] `cargo run -p walrs_filter --example basic_filters` — confirms `Tom &amp; Jerry` preserved
- [x] `cargo llvm-cov -p walrs_filter` — `xml_entities.rs` at 96.20% line coverage (above 80% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)