### PR TITLE
feat(walrs_filter): #235 add common sanitize filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ dependencies = [
  "ammonia",
  "criterion",
  "derive_builder",
+ "percent-encoding",
  "regex",
  "serde",
  "serde_json",

--- a/crates/filter/Cargo.toml
+++ b/crates/filter/Cargo.toml
@@ -20,6 +20,7 @@ validation = ["dep:walrs_validation"]
 [dependencies]
 ammonia = "3.3.1"
 derive_builder = "0.13.0"
+percent-encoding = "2"
 regex = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 walrs_validation = { path = "../validation", optional = true }

--- a/crates/filter/README.md
+++ b/crates/filter/README.md
@@ -29,7 +29,7 @@ Available operations:
 - `NormalizeWhitespace` - Collapse runs of whitespace to a single space and trim
 - `AllowChars { set }` - Keep only characters that appear in `set`
 - `DenyChars { set }` - Drop characters that appear in `set`
-- `UrlEncode` - Percent-encode non-alphanumeric characters
+- `UrlEncode { encode_unreserved }` - Percent-encode. With `encode_unreserved: false` (RFC 3986), keeps `-._~` unencoded; with `true`, matches the stricter `NON_ALPHANUMERIC` set
 - `Clamp { min, max }` - Numeric clamping
 - `Chain(ops)` - Sequential filter chain
 - `Custom(fn)` - Runtime filter function (not serializable — see [Serde notes](#serde-notes))
@@ -137,7 +137,7 @@ Supported JSON variant types: `Trim`, `Lowercase`, `Uppercase`, `StripTags`, `Ht
 `Slug` (with `max_length`), `Truncate` (with `max_length`), `Replace` (with `from`/`to`),
 `Digits`, `Alnum` (with `allow_whitespace`), `Alpha` (with `allow_whitespace`),
 `StripNewlines`, `NormalizeWhitespace`, `AllowChars` (with `set`), `DenyChars` (with `set`),
-`UrlEncode`, `Clamp` (with `min`/`max`), `Chain` (with array of ops).
+`UrlEncode` (with `encode_unreserved`), `Clamp` (with `min`/`max`), `Chain` (with array of ops).
 
 ## TryFilterOp Enum (Fallible Filters)
 

--- a/crates/filter/README.md
+++ b/crates/filter/README.md
@@ -22,6 +22,14 @@ Available operations:
 - `Slug { max_length }` - URL-safe slug generation
 - `Truncate { max_length }` - Clip string to at most `max_length` characters
 - `Replace { from, to }` - Replace all occurrences of a substring
+- `Digits` - Keep ASCII digits only
+- `Alnum { allow_whitespace }` - Keep Unicode alphanumerics (optionally whitespace)
+- `Alpha { allow_whitespace }` - Keep Unicode letters (optionally whitespace)
+- `StripNewlines` - Remove `\r` and `\n`
+- `NormalizeWhitespace` - Collapse runs of whitespace to a single space and trim
+- `AllowChars { set }` - Keep only characters that appear in `set`
+- `DenyChars { set }` - Drop characters that appear in `set`
+- `UrlEncode` - Percent-encode non-alphanumeric characters
 - `Clamp { min, max }` - Numeric clamping
 - `Chain(ops)` - Sequential filter chain
 - `Custom(fn)` - Runtime filter function (not serializable — see [Serde notes](#serde-notes))
@@ -127,7 +135,9 @@ fn main() {
 
 Supported JSON variant types: `Trim`, `Lowercase`, `Uppercase`, `StripTags`, `HtmlEntities`,
 `Slug` (with `max_length`), `Truncate` (with `max_length`), `Replace` (with `from`/`to`),
-`Clamp` (with `min`/`max`), `Chain` (with array of ops).
+`Digits`, `Alnum` (with `allow_whitespace`), `Alpha` (with `allow_whitespace`),
+`StripNewlines`, `NormalizeWhitespace`, `AllowChars` (with `set`), `DenyChars` (with `set`),
+`UrlEncode`, `Clamp` (with `min`/`max`), `Chain` (with array of ops).
 
 ## TryFilterOp Enum (Fallible Filters)
 
@@ -139,6 +149,14 @@ validation error pipeline.
 Available variants:
 - `Infallible(FilterOp<T>)` - Wraps an infallible filter, lifting it into the fallible pipeline
 - `Chain(Vec<TryFilterOp<T>>)` - Sequential filter chain that short-circuits on the first error
+- `ToBool` - Parse `"1"`/`"0"`/`"true"`/`"false"`/`"yes"`/`"no"`/`"on"`/`"off"` (case-insensitive).
+  On `TryFilterOp<String>`, normalises to canonical `"true"`/`"false"`; on
+  `TryFilterOp<Value>`, converts `Value::Str` → `Value::Bool`.
+- `ToInt` - Parse a decimal `i64`. Canonicalises on `String`; converts `Value::Str` →
+  `Value::I64` on `Value`.
+- `ToFloat` - Parse an `f64`. Canonicalises on `String`; converts `Value::Str` →
+  `Value::F64` on `Value`.
+- `UrlDecode` - Percent-decode, validating as UTF-8 (errors on invalid byte sequences).
 - `TryCustom(Arc<dyn Fn(T) -> Result<T, FilterError>>)` - Custom fallible filter function (not serializable)
 
 ```rust

--- a/crates/filter/benches/filter_benchmarks.rs
+++ b/crates/filter/benches/filter_benchmarks.rs
@@ -210,6 +210,123 @@ fn bench_filter_op_chain(c: &mut Criterion) {
   group.finish();
 }
 
+fn bench_filter_op_sanitize(c: &mut Criterion) {
+  let mut group = c.benchmark_group("FilterOp_Sanitize");
+
+  // Digits — noop vs mutation
+  let digits = FilterOp::<String>::Digits;
+  group.bench_function("digits_noop", |b| {
+    b.iter(|| digits.apply_ref(black_box("1234567890")))
+  });
+  group.bench_function("digits_mutation", |b| {
+    b.iter(|| digits.apply_ref(black_box("abc123-def!456")))
+  });
+
+  // NormalizeWhitespace — single-pass early-exit scan on clean input,
+  // full rebuild on dirty input.
+  let normalize = FilterOp::<String>::NormalizeWhitespace;
+  group.bench_function("normalize_whitespace_noop", |b| {
+    b.iter(|| normalize.apply_ref(black_box("hello world go")))
+  });
+  group.bench_function("normalize_whitespace_mutation", |b| {
+    b.iter(|| normalize.apply_ref(black_box("  hello    world\n\tgo  ")))
+  });
+
+  // AllowChars / DenyChars
+  let allow = FilterOp::<String>::AllowChars {
+    set: "abcdefghijklmnopqrstuvwxyz ".to_string(),
+  };
+  group.bench_function("allow_chars_noop", |b| {
+    b.iter(|| allow.apply_ref(black_box("hello world")))
+  });
+  group.bench_function("allow_chars_mutation", |b| {
+    b.iter(|| allow.apply_ref(black_box("Hello, World! 123")))
+  });
+
+  let deny = FilterOp::<String>::DenyChars {
+    set: "<>&\"'".to_string(),
+  };
+  group.bench_function("deny_chars_noop", |b| {
+    b.iter(|| deny.apply_ref(black_box("plain safe text")))
+  });
+  group.bench_function("deny_chars_mutation", |b| {
+    b.iter(|| deny.apply_ref(black_box("<script>alert(\"xss\")</script>")))
+  });
+
+  // UrlEncode — RFC 3986 mode, noop vs mutation.
+  let url_encode = FilterOp::<String>::UrlEncode {
+    encode_unreserved: false,
+  };
+  group.bench_function("url_encode_noop_alphanum", |b| {
+    b.iter(|| url_encode.apply_ref(black_box("HelloWorld123")))
+  });
+  group.bench_function("url_encode_mutation", |b| {
+    b.iter(|| url_encode.apply_ref(black_box("hello world&foo=bar")))
+  });
+
+  // StripNewlines
+  let strip_nl = FilterOp::<String>::StripNewlines;
+  group.bench_function("strip_newlines_noop", |b| {
+    b.iter(|| strip_nl.apply_ref(black_box("no newlines here at all")))
+  });
+  group.bench_function("strip_newlines_mutation", |b| {
+    b.iter(|| strip_nl.apply_ref(black_box("line1\nline2\r\nline3\rline4")))
+  });
+
+  // Alnum — Unicode path
+  let alnum = FilterOp::<String>::Alnum {
+    allow_whitespace: false,
+  };
+  group.bench_function("alnum_ascii_noop", |b| {
+    b.iter(|| alnum.apply_ref(black_box("abc123")))
+  });
+  group.bench_function("alnum_unicode_mutation", |b| {
+    b.iter(|| alnum.apply_ref(black_box("café-日本語!")))
+  });
+
+  group.finish();
+}
+
+fn bench_try_filter_op_conversions(c: &mut Criterion) {
+  let mut group = c.benchmark_group("TryFilterOp_Conversions");
+
+  // ToBool — already-canonical (expected borrowed, no alloc) vs permissive.
+  let to_bool = TryFilterOp::<String>::ToBool;
+  group.bench_function("to_bool_canonical_true", |b| {
+    b.iter(|| to_bool.try_apply_ref(black_box("true")).unwrap())
+  });
+  group.bench_function("to_bool_canonical_false", |b| {
+    b.iter(|| to_bool.try_apply_ref(black_box("false")).unwrap())
+  });
+  group.bench_function("to_bool_permissive_yes", |b| {
+    b.iter(|| to_bool.try_apply_ref(black_box("YES")).unwrap())
+  });
+
+  // ToInt — canonical borrowed vs needing trim/strip.
+  let to_int = TryFilterOp::<String>::ToInt;
+  group.bench_function("to_int_canonical", |b| {
+    b.iter(|| to_int.try_apply_ref(black_box("42")).unwrap())
+  });
+  group.bench_function("to_int_with_whitespace", |b| {
+    b.iter(|| to_int.try_apply_ref(black_box("  042  ")).unwrap())
+  });
+
+  // UrlDecode — plain text (borrowed) vs real decoding.
+  let url_decode = TryFilterOp::<String>::UrlDecode;
+  group.bench_function("url_decode_noop", |b| {
+    b.iter(|| url_decode.try_apply_ref(black_box("plaintext")).unwrap())
+  });
+  group.bench_function("url_decode_mutation", |b| {
+    b.iter(|| {
+      url_decode
+        .try_apply_ref(black_box("hello%20world%20caf%C3%A9"))
+        .unwrap()
+    })
+  });
+
+  group.finish();
+}
+
 fn bench_filter_op_clamp(c: &mut Criterion) {
   let mut group = c.benchmark_group("FilterOp_Clamp");
 
@@ -354,6 +471,8 @@ criterion_group!(
   bench_filter_comparison,
   bench_filter_op_noop,
   bench_filter_op_chain,
+  bench_filter_op_sanitize,
+  bench_try_filter_op_conversions,
   bench_filter_op_clamp,
   bench_try_filter_op,
   bench_filter_op_value,

--- a/crates/filter/examples/filter_op_usage.rs
+++ b/crates/filter/examples/filter_op_usage.rs
@@ -50,7 +50,60 @@ fn main() {
 
   println!();
 
-  // ---- Example 2: apply_ref zero-copy optimization ----
+  // ---- Example 2: Sanitize filter variants ----
+  println!("--- Sanitize filters (Digits, Alnum, NormalizeWhitespace, UrlEncode, etc.) ---");
+
+  let sanitizers: &[(&str, FilterOp<String>)] = &[
+    ("Digits", FilterOp::Digits),
+    (
+      "Alnum(ws=false)",
+      FilterOp::Alnum {
+        allow_whitespace: false,
+      },
+    ),
+    (
+      "Alpha(ws=true)",
+      FilterOp::Alpha {
+        allow_whitespace: true,
+      },
+    ),
+    ("StripNewlines", FilterOp::StripNewlines),
+    ("NormalizeWhitespace", FilterOp::NormalizeWhitespace),
+    (
+      "AllowChars(a-z )",
+      FilterOp::AllowChars {
+        set: "abcdefghijklmnopqrstuvwxyz ".to_string(),
+      },
+    ),
+    (
+      "DenyChars(<>&)",
+      FilterOp::DenyChars {
+        set: "<>&".to_string(),
+      },
+    ),
+    (
+      "UrlEncode(rfc3986)",
+      FilterOp::UrlEncode {
+        encode_unreserved: false,
+      },
+    ),
+  ];
+
+  for input in [
+    "  phone: (555) 123-4567  \n",
+    "café-日本語 123!",
+    "<script>alert('x')</script>",
+  ] {
+    println!("\n  Input: {:?}", input);
+    for (name, filter) in sanitizers {
+      let result = filter.apply_ref(input);
+      println!("    {:20} -> {:?}", name, result.as_ref());
+    }
+  }
+
+  println!();
+
+  // ---- Example 3: apply_ref zero-copy optimization ----
   println!("--- apply_ref: Cow::Borrowed (no-op) vs Cow::Owned (mutated) ---");
 
   let trim = FilterOp::<String>::Trim;
@@ -71,7 +124,7 @@ fn main() {
 
   println!();
 
-  // ---- Example 3: Chain multiple operations ----
+  // ---- Example 4: Chain multiple operations ----
   println!("--- Chain: composing multiple filters ---");
 
   let pipeline: FilterOp<String> = FilterOp::Chain(vec![
@@ -92,7 +145,7 @@ fn main() {
 
   println!();
 
-  // ---- Example 4: Numeric clamping ----
+  // ---- Example 5: Numeric clamping ----
   println!("--- Clamp: numeric range clamping ---");
 
   let clamp_i32 = FilterOp::<i32>::Clamp { min: 0, max: 100 };
@@ -115,7 +168,7 @@ fn main() {
 
   println!();
 
-  // ---- Example 5: Custom filter function ----
+  // ---- Example 6: Custom filter function ----
   println!("--- Custom: runtime filter function ---");
 
   let custom: FilterOp<String> = FilterOp::Custom(Arc::new(|s: String| {
@@ -130,7 +183,7 @@ fn main() {
 
   println!();
 
-  // ---- Example 6: Serde JSON round-trip ----
+  // ---- Example 7: Serde JSON round-trip ----
   println!("--- Serde: JSON serialization/deserialization ---");
 
   let chain: FilterOp<String> = FilterOp::Chain(vec![

--- a/crates/filter/examples/try_filters.rs
+++ b/crates/filter/examples/try_filters.rs
@@ -95,5 +95,48 @@ fn main() {
   }
 
   println!();
+
+  // ---- Example 5: Built-in fallible conversions (ToBool / ToInt / ToFloat / UrlDecode) ----
+  println!("--- Built-in Fallible Conversions ---");
+
+  let to_bool = TryFilterOp::<String>::ToBool;
+  for input in ["true", "YES", "0", "off", "maybe"] {
+    match to_bool.try_apply(input.to_string()) {
+      Ok(v) => println!("  ToBool \"{}\" -> Ok(\"{}\")", input, v),
+      Err(e) => println!("  ToBool \"{}\" -> Err({})", input, e),
+    }
+  }
+
+  let to_int = TryFilterOp::<String>::ToInt;
+  for input in ["42", "  -7  ", "042", "abc"] {
+    match to_int.try_apply(input.to_string()) {
+      Ok(v) => println!("  ToInt  \"{}\" -> Ok(\"{}\")", input, v),
+      Err(e) => println!("  ToInt  \"{}\" -> Err({})", input, e),
+    }
+  }
+
+  let url_decode = TryFilterOp::<String>::UrlDecode;
+  for input in ["hello%20world", "caf%C3%A9", "plaintext", "%FF"] {
+    match url_decode.try_apply(input.to_string()) {
+      Ok(v) => println!("  UrlDecode \"{}\" -> Ok(\"{}\")", input, v),
+      Err(e) => println!("  UrlDecode \"{}\" -> Err({})", input, e),
+    }
+  }
+
+  println!();
+
+  // Common pipeline: trim → ToInt for form-input sanitation.
+  let form_int: TryFilterOp<String> = TryFilterOp::Chain(vec![
+    TryFilterOp::Infallible(FilterOp::Trim),
+    TryFilterOp::ToInt,
+  ]);
+  for input in ["  42  ", "  +7  ", "  not-a-number  "] {
+    match form_int.try_apply(input.to_string()) {
+      Ok(v) => println!("  Trim→ToInt \"{}\" -> Ok(\"{}\")", input, v),
+      Err(e) => println!("  Trim→ToInt \"{}\" -> Err({})", input, e),
+    }
+  }
+
+  println!();
   println!("=== Examples Complete ===");
 }

--- a/crates/filter/src/filter_op.rs
+++ b/crates/filter/src/filter_op.rs
@@ -4,6 +4,7 @@
 //! filter operations. Most variants delegate to the filter struct
 //! implementations in this crate (e.g., [`SlugFilter`], [`StripTagsFilter`]).
 
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
@@ -13,6 +14,49 @@ use crate::{Filter, SlugFilter, StripTagsFilter, XmlEntitiesFilter};
 
 #[cfg(feature = "validation")]
 use walrs_validation::Value;
+
+/// Collapse runs of whitespace to a single ASCII space and trim leading/trailing
+/// whitespace. Returns `Cow::Borrowed` when the input is already normalized.
+fn normalize_whitespace(value: &str) -> Cow<'_, str> {
+  let needs_trim = value.chars().next().is_some_and(char::is_whitespace)
+    || value.chars().next_back().is_some_and(char::is_whitespace);
+  let has_run = {
+    let mut prev_ws = false;
+    let mut found = false;
+    for c in value.chars() {
+      let ws = c.is_whitespace();
+      if ws && prev_ws {
+        found = true;
+        break;
+      }
+      prev_ws = ws;
+    }
+    found
+  };
+  let has_non_space_ws = value.chars().any(|c| c.is_whitespace() && c != ' ');
+
+  if !needs_trim && !has_run && !has_non_space_ws {
+    return Cow::Borrowed(value);
+  }
+
+  let mut out = String::with_capacity(value.len());
+  let mut prev_ws = true; // seed `true` so leading whitespace is dropped
+  for c in value.chars() {
+    if c.is_whitespace() {
+      if !prev_ws {
+        out.push(' ');
+      }
+      prev_ws = true;
+    } else {
+      out.push(c);
+      prev_ws = false;
+    }
+  }
+  if out.ends_with(' ') {
+    out.pop();
+  }
+  Cow::Owned(out)
+}
 
 /// Iteratively flatten nested `Chain` variants into a list of non-chain operation references.
 ///
@@ -120,6 +164,55 @@ pub enum FilterOp<T> {
     to: String,
   },
 
+  // ---- Sanitize Filters ----
+  /// Keep only ASCII digit characters (`0`–`9`).
+  ///
+  /// Returns `Cow::Borrowed` when the input is already digits-only.
+  Digits,
+
+  /// Keep only Unicode alphanumeric characters (optionally whitespace).
+  ///
+  /// `char::is_alphanumeric` is used, so non-ASCII letters and digits
+  /// (`é`, `Ⅳ`, `日`) are preserved.
+  Alnum {
+    /// When `true`, whitespace characters are also kept.
+    allow_whitespace: bool,
+  },
+
+  /// Keep only Unicode alphabetic characters (optionally whitespace).
+  ///
+  /// `char::is_alphabetic` is used, so non-ASCII letters (`é`, `日`) are preserved.
+  Alpha {
+    /// When `true`, whitespace characters are also kept.
+    allow_whitespace: bool,
+  },
+
+  /// Remove `\r` and `\n` characters.
+  StripNewlines,
+
+  /// Collapse runs of whitespace to a single space, and trim leading/trailing whitespace.
+  ///
+  /// Mirrors Laminas\Filter\PregReplace-style whitespace normalization. Whitespace is
+  /// detected via `char::is_whitespace` (Unicode-aware).
+  NormalizeWhitespace,
+
+  /// Keep only characters that appear in `set`.
+  AllowChars {
+    /// Characters to keep; any character not in this set is dropped.
+    set: String,
+  },
+
+  /// Remove characters that appear in `set`.
+  DenyChars {
+    /// Characters to drop; any character in this set is removed.
+    set: String,
+  },
+
+  /// Percent-encode the string using `percent-encoding`'s `NON_ALPHANUMERIC` set.
+  ///
+  /// Encodes anything that isn't ASCII alphanumeric. Infallible.
+  UrlEncode,
+
   // ---- Numeric Filters ----
   /// Clamp value to a range (for numeric types).
   ///
@@ -178,6 +271,20 @@ impl<T: Debug> Debug for FilterOp<T> {
         .field("from", from)
         .field("to", to)
         .finish(),
+      Self::Digits => write!(f, "Digits"),
+      Self::Alnum { allow_whitespace } => f
+        .debug_struct("Alnum")
+        .field("allow_whitespace", allow_whitespace)
+        .finish(),
+      Self::Alpha { allow_whitespace } => f
+        .debug_struct("Alpha")
+        .field("allow_whitespace", allow_whitespace)
+        .finish(),
+      Self::StripNewlines => write!(f, "StripNewlines"),
+      Self::NormalizeWhitespace => write!(f, "NormalizeWhitespace"),
+      Self::AllowChars { set } => f.debug_struct("AllowChars").field("set", set).finish(),
+      Self::DenyChars { set } => f.debug_struct("DenyChars").field("set", set).finish(),
+      Self::UrlEncode => write!(f, "UrlEncode"),
       Self::Clamp { min, max } => f
         .debug_struct("Clamp")
         .field("min", min)
@@ -202,6 +309,28 @@ impl<T: PartialEq> PartialEq for FilterOp<T> {
       (Self::Replace { from: fa, to: ta }, Self::Replace { from: fb, to: tb }) => {
         fa == fb && ta == tb
       }
+      (Self::Digits, Self::Digits) => true,
+      (
+        Self::Alnum {
+          allow_whitespace: a,
+        },
+        Self::Alnum {
+          allow_whitespace: b,
+        },
+      ) => a == b,
+      (
+        Self::Alpha {
+          allow_whitespace: a,
+        },
+        Self::Alpha {
+          allow_whitespace: b,
+        },
+      ) => a == b,
+      (Self::StripNewlines, Self::StripNewlines) => true,
+      (Self::NormalizeWhitespace, Self::NormalizeWhitespace) => true,
+      (Self::AllowChars { set: a }, Self::AllowChars { set: b }) => a == b,
+      (Self::DenyChars { set: a }, Self::DenyChars { set: b }) => a == b,
+      (Self::UrlEncode, Self::UrlEncode) => true,
       (Self::Clamp { min: a1, max: a2 }, Self::Clamp { min: b1, max: b2 }) => a1 == b1 && a2 == b2,
       (Self::Chain(a), Self::Chain(b)) => a == b,
       // Custom filters are never equal
@@ -280,6 +409,58 @@ impl FilterOp<String> {
           Cow::Borrowed(value)
         } else {
           Cow::Owned(value.replace(from.as_str(), to.as_str()))
+        }
+      }
+      FilterOp::Digits => {
+        if value.chars().all(|c| c.is_ascii_digit()) {
+          Cow::Borrowed(value)
+        } else {
+          Cow::Owned(value.chars().filter(|c| c.is_ascii_digit()).collect())
+        }
+      }
+      FilterOp::Alnum { allow_whitespace } => {
+        let keep = |c: char| c.is_alphanumeric() || (*allow_whitespace && c.is_whitespace());
+        if value.chars().all(&keep) {
+          Cow::Borrowed(value)
+        } else {
+          Cow::Owned(value.chars().filter(|c| keep(*c)).collect())
+        }
+      }
+      FilterOp::Alpha { allow_whitespace } => {
+        let keep = |c: char| c.is_alphabetic() || (*allow_whitespace && c.is_whitespace());
+        if value.chars().all(&keep) {
+          Cow::Borrowed(value)
+        } else {
+          Cow::Owned(value.chars().filter(|c| keep(*c)).collect())
+        }
+      }
+      FilterOp::StripNewlines => {
+        if !value.chars().any(|c| c == '\n' || c == '\r') {
+          Cow::Borrowed(value)
+        } else {
+          Cow::Owned(value.chars().filter(|c| *c != '\n' && *c != '\r').collect())
+        }
+      }
+      FilterOp::NormalizeWhitespace => normalize_whitespace(value),
+      FilterOp::AllowChars { set } => {
+        if value.chars().all(|c| set.contains(c)) {
+          Cow::Borrowed(value)
+        } else {
+          Cow::Owned(value.chars().filter(|c| set.contains(*c)).collect())
+        }
+      }
+      FilterOp::DenyChars { set } => {
+        if set.is_empty() || !value.chars().any(|c| set.contains(c)) {
+          Cow::Borrowed(value)
+        } else {
+          Cow::Owned(value.chars().filter(|c| !set.contains(*c)).collect())
+        }
+      }
+      FilterOp::UrlEncode => {
+        // percent_encoding returns an iterator adapter that materialises as Cow<str>.
+        match utf8_percent_encode(value, NON_ALPHANUMERIC).into() {
+          Cow::Borrowed(s) => Cow::Borrowed(s),
+          Cow::Owned(s) => Cow::Owned(s),
         }
       }
       FilterOp::Clamp { .. } => Cow::Borrowed(value), // Clamp doesn't apply to strings
@@ -401,6 +582,35 @@ impl FilterOp<Value> {
           } else {
             Value::Str(s.replace(from.as_str(), to.as_str()))
           }
+        } else {
+          value.clone()
+        }
+      }
+      FilterOp::Digits
+      | FilterOp::Alnum { .. }
+      | FilterOp::Alpha { .. }
+      | FilterOp::StripNewlines
+      | FilterOp::NormalizeWhitespace
+      | FilterOp::AllowChars { .. }
+      | FilterOp::DenyChars { .. }
+      | FilterOp::UrlEncode => {
+        if let Value::Str(s) = value {
+          let string_filter: FilterOp<String> = match self {
+            FilterOp::Digits => FilterOp::Digits,
+            FilterOp::Alnum { allow_whitespace } => FilterOp::Alnum {
+              allow_whitespace: *allow_whitespace,
+            },
+            FilterOp::Alpha { allow_whitespace } => FilterOp::Alpha {
+              allow_whitespace: *allow_whitespace,
+            },
+            FilterOp::StripNewlines => FilterOp::StripNewlines,
+            FilterOp::NormalizeWhitespace => FilterOp::NormalizeWhitespace,
+            FilterOp::AllowChars { set } => FilterOp::AllowChars { set: set.clone() },
+            FilterOp::DenyChars { set } => FilterOp::DenyChars { set: set.clone() },
+            FilterOp::UrlEncode => FilterOp::UrlEncode,
+            _ => unreachable!(),
+          };
+          Value::Str(string_filter.apply_ref(s.as_str()).into_owned())
         } else {
           value.clone()
         }
@@ -1198,5 +1408,429 @@ mod tests {
       chain = FilterOp::Chain(vec![chain]);
     }
     assert_eq!(chain.apply("  HELLO  ".to_string()), "hello");
+  }
+
+  // ====================================================================
+  // Sanitize filter tests — #235
+  // ====================================================================
+
+  // ---- Digits ----
+
+  #[test]
+  fn test_digits_strips_non_digits() {
+    let filter = FilterOp::<String>::Digits;
+    assert_eq!(filter.apply("abc123-def!456".to_string()), "123456");
+  }
+
+  #[test]
+  fn test_digits_empty_input() {
+    let filter = FilterOp::<String>::Digits;
+    let result = filter.apply_ref("");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "");
+  }
+
+  #[test]
+  fn test_digits_all_digits_is_borrowed() {
+    let filter = FilterOp::<String>::Digits;
+    let result = filter.apply_ref("1234567890");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "1234567890");
+  }
+
+  #[test]
+  fn test_digits_mutation_is_owned() {
+    let filter = FilterOp::<String>::Digits;
+    let result = filter.apply_ref("a1b2c3");
+    assert!(matches!(result, Cow::Owned(_)));
+    assert_eq!(result, "123");
+  }
+
+  #[test]
+  fn test_digits_unicode_digits_are_dropped() {
+    // `char::is_ascii_digit` rejects Unicode digits like `Ⅳ` and `٣` — design choice
+    // to match PHP's FILTER_SANITIZE_NUMBER_INT semantics.
+    let filter = FilterOp::<String>::Digits;
+    assert_eq!(filter.apply("Ⅳ and 3".to_string()), "3");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_digits() {
+    let op = FilterOp::<String>::Digits;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- Alnum ----
+
+  #[test]
+  fn test_alnum_keeps_letters_and_digits() {
+    let filter = FilterOp::<String>::Alnum {
+      allow_whitespace: false,
+    };
+    assert_eq!(filter.apply("abc 123 !@#".to_string()), "abc123");
+  }
+
+  #[test]
+  fn test_alnum_allow_whitespace() {
+    let filter = FilterOp::<String>::Alnum {
+      allow_whitespace: true,
+    };
+    assert_eq!(filter.apply("abc 123 !@#".to_string()), "abc 123 ");
+  }
+
+  #[test]
+  fn test_alnum_unicode() {
+    // `char::is_alphanumeric` is Unicode-aware: `é`, `日` stay in, `-` drops out.
+    let filter = FilterOp::<String>::Alnum {
+      allow_whitespace: false,
+    };
+    assert_eq!(filter.apply("café-日本語".to_string()), "café日本語");
+  }
+
+  #[test]
+  fn test_alnum_clean_input_is_borrowed() {
+    let filter = FilterOp::<String>::Alnum {
+      allow_whitespace: false,
+    };
+    let result = filter.apply_ref("abc123");
+    assert!(matches!(result, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn test_serde_roundtrip_alnum() {
+    let op = FilterOp::<String>::Alnum {
+      allow_whitespace: true,
+    };
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- Alpha ----
+
+  #[test]
+  fn test_alpha_drops_digits() {
+    let filter = FilterOp::<String>::Alpha {
+      allow_whitespace: false,
+    };
+    assert_eq!(filter.apply("abc 123!".to_string()), "abc");
+  }
+
+  #[test]
+  fn test_alpha_allow_whitespace() {
+    let filter = FilterOp::<String>::Alpha {
+      allow_whitespace: true,
+    };
+    assert_eq!(filter.apply("abc 123 def".to_string()), "abc  def");
+  }
+
+  #[test]
+  fn test_alpha_unicode() {
+    let filter = FilterOp::<String>::Alpha {
+      allow_whitespace: false,
+    };
+    assert_eq!(filter.apply("日本語1-2".to_string()), "日本語");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_alpha() {
+    let op = FilterOp::<String>::Alpha {
+      allow_whitespace: false,
+    };
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- StripNewlines ----
+
+  #[test]
+  fn test_strip_newlines_removes_lf_and_cr() {
+    let filter = FilterOp::<String>::StripNewlines;
+    assert_eq!(filter.apply("a\nb\r\nc\rd".to_string()), "abcd");
+  }
+
+  #[test]
+  fn test_strip_newlines_noop_when_clean() {
+    let filter = FilterOp::<String>::StripNewlines;
+    let result = filter.apply_ref("no newlines here");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "no newlines here");
+  }
+
+  #[test]
+  fn test_strip_newlines_preserves_tabs_and_spaces() {
+    let filter = FilterOp::<String>::StripNewlines;
+    assert_eq!(filter.apply("a\tb c".to_string()), "a\tb c");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_strip_newlines() {
+    let op = FilterOp::<String>::StripNewlines;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- NormalizeWhitespace ----
+
+  #[test]
+  fn test_normalize_whitespace_collapses_runs() {
+    let filter = FilterOp::<String>::NormalizeWhitespace;
+    assert_eq!(
+      filter.apply("  hello    world\n\tgo  ".to_string()),
+      "hello world go"
+    );
+  }
+
+  #[test]
+  fn test_normalize_whitespace_noop_when_clean() {
+    let filter = FilterOp::<String>::NormalizeWhitespace;
+    let result = filter.apply_ref("hello world go");
+    assert!(matches!(result, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn test_normalize_whitespace_empty_string() {
+    let filter = FilterOp::<String>::NormalizeWhitespace;
+    let result = filter.apply_ref("");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "");
+  }
+
+  #[test]
+  fn test_normalize_whitespace_whitespace_only() {
+    let filter = FilterOp::<String>::NormalizeWhitespace;
+    assert_eq!(filter.apply("   \t\n  ".to_string()), "");
+  }
+
+  #[test]
+  fn test_normalize_whitespace_tab_becomes_space() {
+    // Tabs aren't the ASCII space — normalising should collapse them to spaces.
+    let filter = FilterOp::<String>::NormalizeWhitespace;
+    assert_eq!(filter.apply("a\tb".to_string()), "a b");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_normalize_whitespace() {
+    let op = FilterOp::<String>::NormalizeWhitespace;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- AllowChars ----
+
+  #[test]
+  fn test_allow_chars_keeps_listed() {
+    let filter = FilterOp::<String>::AllowChars {
+      set: "abc".to_string(),
+    };
+    assert_eq!(filter.apply("abracadabra 123".to_string()), "abacaaba");
+  }
+
+  #[test]
+  fn test_allow_chars_clean_input_is_borrowed() {
+    let filter = FilterOp::<String>::AllowChars {
+      set: "abc".to_string(),
+    };
+    let result = filter.apply_ref("cab");
+    assert!(matches!(result, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn test_allow_chars_empty_set_drops_everything() {
+    let filter = FilterOp::<String>::AllowChars { set: String::new() };
+    assert_eq!(filter.apply("anything".to_string()), "");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_allow_chars() {
+    let op = FilterOp::<String>::AllowChars {
+      set: "0123456789".to_string(),
+    };
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- DenyChars ----
+
+  #[test]
+  fn test_deny_chars_removes_listed() {
+    let filter = FilterOp::<String>::DenyChars {
+      set: "aeiou".to_string(),
+    };
+    assert_eq!(filter.apply("Hello World".to_string()), "Hll Wrld");
+  }
+
+  #[test]
+  fn test_deny_chars_empty_set_is_borrowed() {
+    let filter = FilterOp::<String>::DenyChars { set: String::new() };
+    let result = filter.apply_ref("hello");
+    assert!(matches!(result, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn test_deny_chars_no_overlap_is_borrowed() {
+    let filter = FilterOp::<String>::DenyChars {
+      set: "xyz".to_string(),
+    };
+    let result = filter.apply_ref("hello");
+    assert!(matches!(result, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn test_serde_roundtrip_deny_chars() {
+    let op = FilterOp::<String>::DenyChars {
+      set: "<>&".to_string(),
+    };
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- UrlEncode ----
+
+  #[test]
+  fn test_url_encode_basic() {
+    let filter = FilterOp::<String>::UrlEncode;
+    assert_eq!(filter.apply("hello world".to_string()), "hello%20world");
+  }
+
+  #[test]
+  fn test_url_encode_unicode() {
+    let filter = FilterOp::<String>::UrlEncode;
+    assert_eq!(filter.apply("café".to_string()), "caf%C3%A9");
+  }
+
+  #[test]
+  fn test_url_encode_alphanumeric_only_is_borrowed() {
+    let filter = FilterOp::<String>::UrlEncode;
+    let result = filter.apply_ref("HelloWorld123");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "HelloWorld123");
+  }
+
+  #[test]
+  fn test_url_encode_special_chars() {
+    let filter = FilterOp::<String>::UrlEncode;
+    assert_eq!(filter.apply("a&b=c".to_string()), "a%26b%3Dc");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_url_encode() {
+    let op = FilterOp::<String>::UrlEncode;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- Chain composition with new variants ----
+
+  #[test]
+  fn test_chain_trim_then_digits() {
+    let filter: FilterOp<String> = FilterOp::Chain(vec![FilterOp::Trim, FilterOp::Digits]);
+    assert_eq!(filter.apply("  abc123def  ".to_string()), "123");
+  }
+
+  #[test]
+  fn test_chain_normalize_then_allow_chars() {
+    let filter: FilterOp<String> = FilterOp::Chain(vec![
+      FilterOp::NormalizeWhitespace,
+      FilterOp::AllowChars {
+        set: "abcdefghijklmnopqrstuvwxyz ".to_string(),
+      },
+    ]);
+    assert_eq!(filter.apply("  hello  WORLD  ".to_string()), "hello ");
+  }
+
+  // ---- Debug format coverage ----
+
+  #[test]
+  fn test_debug_format_sanitize_variants() {
+    assert_eq!(format!("{:?}", FilterOp::<String>::Digits), "Digits");
+    let alnum = format!(
+      "{:?}",
+      FilterOp::<String>::Alnum {
+        allow_whitespace: true
+      }
+    );
+    assert!(alnum.contains("Alnum"));
+    assert!(alnum.contains("allow_whitespace"));
+    assert_eq!(
+      format!("{:?}", FilterOp::<String>::StripNewlines),
+      "StripNewlines"
+    );
+    assert_eq!(
+      format!("{:?}", FilterOp::<String>::NormalizeWhitespace),
+      "NormalizeWhitespace"
+    );
+    assert_eq!(format!("{:?}", FilterOp::<String>::UrlEncode), "UrlEncode");
+  }
+
+  // ---- FilterOp<Value> sanitize filter tests ----
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_digits_value_str() {
+    let filter = FilterOp::<Value>::Digits;
+    assert_eq!(
+      filter.apply(Value::Str("abc123".to_string())),
+      Value::Str("123".to_string())
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_digits_value_non_str_pass_through() {
+    let filter = FilterOp::<Value>::Digits;
+    assert_eq!(filter.apply(Value::I64(42)), Value::I64(42));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_normalize_whitespace_value_str() {
+    let filter = FilterOp::<Value>::NormalizeWhitespace;
+    assert_eq!(
+      filter.apply(Value::Str("  hi   there  ".to_string())),
+      Value::Str("hi there".to_string())
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_url_encode_value_str() {
+    let filter = FilterOp::<Value>::UrlEncode;
+    assert_eq!(
+      filter.apply(Value::Str("hello world".to_string())),
+      Value::Str("hello%20world".to_string())
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_allow_chars_value_str() {
+    let filter = FilterOp::<Value>::AllowChars {
+      set: "abc".to_string(),
+    };
+    assert_eq!(
+      filter.apply(Value::Str("abracadabra".to_string())),
+      Value::Str("abacaaba".to_string())
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_deny_chars_value_str() {
+    let filter = FilterOp::<Value>::DenyChars {
+      set: "aeiou".to_string(),
+    };
+    assert_eq!(
+      filter.apply(Value::Str("hello".to_string())),
+      Value::Str("hll".to_string())
+    );
   }
 }

--- a/crates/filter/src/filter_op.rs
+++ b/crates/filter/src/filter_op.rs
@@ -4,7 +4,7 @@
 //! filter operations. Most variants delegate to the filter struct
 //! implementations in this crate (e.g., [`SlugFilter`], [`StripTagsFilter`]).
 
-use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
@@ -15,27 +15,44 @@ use crate::{Filter, SlugFilter, StripTagsFilter, XmlEntitiesFilter};
 #[cfg(feature = "validation")]
 use walrs_validation::Value;
 
+/// RFC 3986 §2.3 "unreserved" character set: `ALPHA / DIGIT / "-" / "." / "_" / "~"`.
+///
+/// Derived from [`NON_ALPHANUMERIC`] by re-admitting the four unreserved punctuation
+/// characters. Used by [`FilterOp::UrlEncode`] when `encode_unreserved` is `false`.
+const RFC_3986_UNRESERVED: AsciiSet = NON_ALPHANUMERIC
+  .remove(b'-')
+  .remove(b'.')
+  .remove(b'_')
+  .remove(b'~');
+
 /// Collapse runs of whitespace to a single ASCII space and trim leading/trailing
 /// whitespace. Returns `Cow::Borrowed` when the input is already normalized.
+///
+/// Performs a single early-exit scan to detect whether the input is already
+/// normalized. Only rebuilds when a deviation is found — so the clean-input path
+/// allocates nothing and exits as soon as the first anomaly (leading whitespace,
+/// a non-space whitespace character, or a whitespace run) is spotted.
 fn normalize_whitespace(value: &str) -> Cow<'_, str> {
-  let needs_trim = value.chars().next().is_some_and(char::is_whitespace)
-    || value.chars().next_back().is_some_and(char::is_whitespace);
-  let has_run = {
-    let mut prev_ws = false;
-    let mut found = false;
-    for c in value.chars() {
-      let ws = c.is_whitespace();
-      if ws && prev_ws {
-        found = true;
+  let mut prev_ws = false;
+  let mut seen_any = false;
+  let mut trailing_ws = false;
+  let mut dirty = false;
+  for c in value.chars() {
+    let ws = c.is_whitespace();
+    if !seen_any {
+      if ws {
+        dirty = true;
         break;
       }
-      prev_ws = ws;
+      seen_any = true;
+    } else if ws && (prev_ws || c != ' ') {
+      dirty = true;
+      break;
     }
-    found
-  };
-  let has_non_space_ws = value.chars().any(|c| c.is_whitespace() && c != ' ');
-
-  if !needs_trim && !has_run && !has_non_space_ws {
+    prev_ws = ws;
+    trailing_ws = ws;
+  }
+  if !dirty && !trailing_ws {
     return Cow::Borrowed(value);
   }
 
@@ -175,7 +192,9 @@ pub enum FilterOp<T> {
   /// `char::is_alphanumeric` is used, so non-ASCII letters and digits
   /// (`é`, `Ⅳ`, `日`) are preserved.
   Alnum {
-    /// When `true`, whitespace characters are also kept.
+    /// When `true`, any Unicode whitespace character is also kept — detected via
+    /// [`char::is_whitespace`]. This includes tabs (`\t`), newlines (`\n`, `\r`),
+    /// non-breaking space (U+00A0), and other Unicode whitespace — not just ASCII space.
     allow_whitespace: bool,
   },
 
@@ -183,7 +202,9 @@ pub enum FilterOp<T> {
   ///
   /// `char::is_alphabetic` is used, so non-ASCII letters (`é`, `日`) are preserved.
   Alpha {
-    /// When `true`, whitespace characters are also kept.
+    /// When `true`, any Unicode whitespace character is also kept — detected via
+    /// [`char::is_whitespace`]. This includes tabs (`\t`), newlines (`\n`, `\r`),
+    /// non-breaking space (U+00A0), and other Unicode whitespace — not just ASCII space.
     allow_whitespace: bool,
   },
 
@@ -208,10 +229,23 @@ pub enum FilterOp<T> {
     set: String,
   },
 
-  /// Percent-encode the string using `percent-encoding`'s `NON_ALPHANUMERIC` set.
+  /// Percent-encode the string.
   ///
-  /// Encodes anything that isn't ASCII alphanumeric. Infallible.
-  UrlEncode,
+  /// By default (`encode_unreserved: false`), conforms to RFC 3986 §2.3: ASCII
+  /// alphanumerics and the four "unreserved" punctuation characters (`-`, `.`,
+  /// `_`, `~`) are left as-is; everything else is `%HH`-encoded.
+  ///
+  /// Set `encode_unreserved: true` for the stricter `percent-encoding`
+  /// `NON_ALPHANUMERIC` behaviour, which also encodes `-._~` — useful when
+  /// building opaque tokens where any non-alphanumeric byte must be escaped.
+  ///
+  /// Infallible.
+  UrlEncode {
+    /// When `true`, also percent-encode the RFC 3986 "unreserved" characters
+    /// `-`, `.`, `_`, and `~`. When `false` (default-ish — RFC-compliant),
+    /// these pass through.
+    encode_unreserved: bool,
+  },
 
   // ---- Numeric Filters ----
   /// Clamp value to a range (for numeric types).
@@ -284,7 +318,10 @@ impl<T: Debug> Debug for FilterOp<T> {
       Self::NormalizeWhitespace => write!(f, "NormalizeWhitespace"),
       Self::AllowChars { set } => f.debug_struct("AllowChars").field("set", set).finish(),
       Self::DenyChars { set } => f.debug_struct("DenyChars").field("set", set).finish(),
-      Self::UrlEncode => write!(f, "UrlEncode"),
+      Self::UrlEncode { encode_unreserved } => f
+        .debug_struct("UrlEncode")
+        .field("encode_unreserved", encode_unreserved)
+        .finish(),
       Self::Clamp { min, max } => f
         .debug_struct("Clamp")
         .field("min", min)
@@ -330,7 +367,14 @@ impl<T: PartialEq> PartialEq for FilterOp<T> {
       (Self::NormalizeWhitespace, Self::NormalizeWhitespace) => true,
       (Self::AllowChars { set: a }, Self::AllowChars { set: b }) => a == b,
       (Self::DenyChars { set: a }, Self::DenyChars { set: b }) => a == b,
-      (Self::UrlEncode, Self::UrlEncode) => true,
+      (
+        Self::UrlEncode {
+          encode_unreserved: a,
+        },
+        Self::UrlEncode {
+          encode_unreserved: b,
+        },
+      ) => a == b,
       (Self::Clamp { min: a1, max: a2 }, Self::Clamp { min: b1, max: b2 }) => a1 == b1 && a2 == b2,
       (Self::Chain(a), Self::Chain(b)) => a == b,
       // Custom filters are never equal
@@ -456,12 +500,14 @@ impl FilterOp<String> {
           Cow::Owned(value.chars().filter(|c| !set.contains(*c)).collect())
         }
       }
-      FilterOp::UrlEncode => {
-        // percent_encoding returns an iterator adapter that materialises as Cow<str>.
-        match utf8_percent_encode(value, NON_ALPHANUMERIC).into() {
-          Cow::Borrowed(s) => Cow::Borrowed(s),
-          Cow::Owned(s) => Cow::Owned(s),
-        }
+      FilterOp::UrlEncode { encode_unreserved } => {
+        let set: &AsciiSet = if *encode_unreserved {
+          NON_ALPHANUMERIC
+        } else {
+          &RFC_3986_UNRESERVED
+        };
+        // `PercentEncode` materialises as `Cow<str>` — `Borrowed` when nothing needed encoding.
+        utf8_percent_encode(value, set).into()
       }
       FilterOp::Clamp { .. } => Cow::Borrowed(value), // Clamp doesn't apply to strings
       FilterOp::Chain(filters) => {
@@ -497,6 +543,21 @@ impl FilterOp<String> {
 // ============================================================================
 // Value FilterOp Implementation (requires "validation" feature)
 // ============================================================================
+
+/// Apply a string-typed `FilterOp` to a `Value::Str` variant, preserving the
+/// zero-copy `Borrowed → clone the original Value` shortcut that existing `Trim`
+/// / `Lowercase` arms use. Non-string variants pass through unchanged.
+#[cfg(feature = "validation")]
+fn apply_string_op_to_value(op: FilterOp<String>, value: &Value) -> Value {
+  if let Value::Str(s) = value {
+    match op.apply_ref(s.as_str()) {
+      Cow::Borrowed(_) => value.clone(),
+      Cow::Owned(new_s) => Value::Str(new_s),
+    }
+  } else {
+    value.clone()
+  }
+}
 
 #[cfg(feature = "validation")]
 impl FilterOp<Value> {
@@ -586,35 +647,35 @@ impl FilterOp<Value> {
           value.clone()
         }
       }
-      FilterOp::Digits
-      | FilterOp::Alnum { .. }
-      | FilterOp::Alpha { .. }
-      | FilterOp::StripNewlines
-      | FilterOp::NormalizeWhitespace
-      | FilterOp::AllowChars { .. }
-      | FilterOp::DenyChars { .. }
-      | FilterOp::UrlEncode => {
-        if let Value::Str(s) = value {
-          let string_filter: FilterOp<String> = match self {
-            FilterOp::Digits => FilterOp::Digits,
-            FilterOp::Alnum { allow_whitespace } => FilterOp::Alnum {
-              allow_whitespace: *allow_whitespace,
-            },
-            FilterOp::Alpha { allow_whitespace } => FilterOp::Alpha {
-              allow_whitespace: *allow_whitespace,
-            },
-            FilterOp::StripNewlines => FilterOp::StripNewlines,
-            FilterOp::NormalizeWhitespace => FilterOp::NormalizeWhitespace,
-            FilterOp::AllowChars { set } => FilterOp::AllowChars { set: set.clone() },
-            FilterOp::DenyChars { set } => FilterOp::DenyChars { set: set.clone() },
-            FilterOp::UrlEncode => FilterOp::UrlEncode,
-            _ => unreachable!(),
-          };
-          Value::Str(string_filter.apply_ref(s.as_str()).into_owned())
-        } else {
-          value.clone()
-        }
+      FilterOp::Digits => apply_string_op_to_value(FilterOp::Digits, value),
+      FilterOp::Alnum { allow_whitespace } => apply_string_op_to_value(
+        FilterOp::Alnum {
+          allow_whitespace: *allow_whitespace,
+        },
+        value,
+      ),
+      FilterOp::Alpha { allow_whitespace } => apply_string_op_to_value(
+        FilterOp::Alpha {
+          allow_whitespace: *allow_whitespace,
+        },
+        value,
+      ),
+      FilterOp::StripNewlines => apply_string_op_to_value(FilterOp::StripNewlines, value),
+      FilterOp::NormalizeWhitespace => {
+        apply_string_op_to_value(FilterOp::NormalizeWhitespace, value)
       }
+      FilterOp::AllowChars { set } => {
+        apply_string_op_to_value(FilterOp::AllowChars { set: set.clone() }, value)
+      }
+      FilterOp::DenyChars { set } => {
+        apply_string_op_to_value(FilterOp::DenyChars { set: set.clone() }, value)
+      }
+      FilterOp::UrlEncode { encode_unreserved } => apply_string_op_to_value(
+        FilterOp::UrlEncode {
+          encode_unreserved: *encode_unreserved,
+        },
+        value,
+      ),
       FilterOp::Clamp { min, max } => match (value, min, max) {
         (Value::I64(v), Value::I64(min_v), Value::I64(max_v)) => {
           Value::I64((*v).clamp(*min_v, *max_v))
@@ -1614,6 +1675,15 @@ mod tests {
   }
 
   #[test]
+  fn test_normalize_whitespace_non_ascii_whitespace() {
+    // Non-breaking space (U+00A0) is `char::is_whitespace` — it should collapse
+    // to an ASCII space, not pass through unchanged.
+    let filter = FilterOp::<String>::NormalizeWhitespace;
+    let result = filter.apply("a\u{00A0}b".to_string());
+    assert_eq!(result, "a b");
+  }
+
+  #[test]
   fn test_serde_roundtrip_normalize_whitespace() {
     let op = FilterOp::<String>::NormalizeWhitespace;
     let json = serde_json::to_string(&op).unwrap();
@@ -1644,6 +1714,20 @@ mod tests {
   fn test_allow_chars_empty_set_drops_everything() {
     let filter = FilterOp::<String>::AllowChars { set: String::new() };
     assert_eq!(filter.apply("anything".to_string()), "");
+  }
+
+  #[test]
+  fn test_allow_chars_unicode_set() {
+    // Unicode chars in both set and input — the set uses `str::contains(char)`
+    // so non-ASCII members (`é`, `ñ`) match on code-point equality.
+    let filter = FilterOp::<String>::AllowChars {
+      set: "café".to_string(),
+    };
+    let result = filter.apply_ref("café");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "café");
+
+    assert_eq!(filter.apply("café-!".to_string()), "café");
   }
 
   #[test]
@@ -1695,20 +1779,46 @@ mod tests {
   // ---- UrlEncode ----
 
   #[test]
-  fn test_url_encode_basic() {
-    let filter = FilterOp::<String>::UrlEncode;
+  fn test_url_encode_basic_rfc3986_default() {
+    let filter = FilterOp::<String>::UrlEncode {
+      encode_unreserved: false,
+    };
     assert_eq!(filter.apply("hello world".to_string()), "hello%20world");
   }
 
   #[test]
+  fn test_url_encode_rfc3986_preserves_unreserved_punctuation() {
+    // `-._~` are RFC 3986 unreserved and must pass through when encode_unreserved = false.
+    let filter = FilterOp::<String>::UrlEncode {
+      encode_unreserved: false,
+    };
+    let result = filter.apply_ref("a-b_c.d~e");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "a-b_c.d~e");
+  }
+
+  #[test]
+  fn test_url_encode_aggressive_encodes_unreserved_punctuation() {
+    // With encode_unreserved = true, the stricter NON_ALPHANUMERIC set is used.
+    let filter = FilterOp::<String>::UrlEncode {
+      encode_unreserved: true,
+    };
+    assert_eq!(filter.apply("a-b_c.d~e".to_string()), "a%2Db%5Fc%2Ed%7Ee");
+  }
+
+  #[test]
   fn test_url_encode_unicode() {
-    let filter = FilterOp::<String>::UrlEncode;
+    let filter = FilterOp::<String>::UrlEncode {
+      encode_unreserved: false,
+    };
     assert_eq!(filter.apply("café".to_string()), "caf%C3%A9");
   }
 
   #[test]
   fn test_url_encode_alphanumeric_only_is_borrowed() {
-    let filter = FilterOp::<String>::UrlEncode;
+    let filter = FilterOp::<String>::UrlEncode {
+      encode_unreserved: false,
+    };
     let result = filter.apply_ref("HelloWorld123");
     assert!(matches!(result, Cow::Borrowed(_)));
     assert_eq!(result, "HelloWorld123");
@@ -1716,16 +1826,29 @@ mod tests {
 
   #[test]
   fn test_url_encode_special_chars() {
-    let filter = FilterOp::<String>::UrlEncode;
+    let filter = FilterOp::<String>::UrlEncode {
+      encode_unreserved: false,
+    };
     assert_eq!(filter.apply("a&b=c".to_string()), "a%26b%3Dc");
   }
 
   #[test]
   fn test_serde_roundtrip_url_encode() {
-    let op = FilterOp::<String>::UrlEncode;
+    let op = FilterOp::<String>::UrlEncode {
+      encode_unreserved: false,
+    };
     let json = serde_json::to_string(&op).unwrap();
     let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
     assert_eq!(op, deserialized);
+
+    let op_strict = FilterOp::<String>::UrlEncode {
+      encode_unreserved: true,
+    };
+    let json = serde_json::to_string(&op_strict).unwrap();
+    let deserialized: FilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op_strict, deserialized);
+    // The two modes are distinguishable via PartialEq.
+    assert_ne!(op, op_strict);
   }
 
   // ---- Chain composition with new variants ----
@@ -1768,7 +1891,14 @@ mod tests {
       format!("{:?}", FilterOp::<String>::NormalizeWhitespace),
       "NormalizeWhitespace"
     );
-    assert_eq!(format!("{:?}", FilterOp::<String>::UrlEncode), "UrlEncode");
+    let url = format!(
+      "{:?}",
+      FilterOp::<String>::UrlEncode {
+        encode_unreserved: false
+      }
+    );
+    assert!(url.contains("UrlEncode"));
+    assert!(url.contains("encode_unreserved"));
   }
 
   // ---- FilterOp<Value> sanitize filter tests ----
@@ -1803,7 +1933,9 @@ mod tests {
   #[cfg(feature = "validation")]
   #[test]
   fn test_url_encode_value_str() {
-    let filter = FilterOp::<Value>::UrlEncode;
+    let filter = FilterOp::<Value>::UrlEncode {
+      encode_unreserved: false,
+    };
     assert_eq!(
       filter.apply(Value::Str("hello world".to_string())),
       Value::Str("hello%20world".to_string())

--- a/crates/filter/src/lib.rs
+++ b/crates/filter/src/lib.rs
@@ -15,16 +15,21 @@
 //! ## FilterOp Enum
 //!
 //! The [`FilterOp`] enum provides a composable, serializable way to define
-//! filter operations for config-driven form processing.
+//! filter operations for config-driven form processing. In addition to
+//! string/numeric transforms like `Trim`, `Lowercase`, and `Clamp`, it
+//! exposes a suite of sanitize variants: `Digits`, `Alnum`, `Alpha`,
+//! `StripNewlines`, `NormalizeWhitespace`, `AllowChars`, `DenyChars`, and
+//! `UrlEncode`.
 //!
 //! ## TryFilterOp Enum
 //!
 //! The [`TryFilterOp`] enum provides a composable, serializable way to define
 //! **fallible** filter operations. Use this for filters that can legitimately
-//! fail (e.g., base64 decode, JSON parse, URL decode). Errors are represented
+//! fail (e.g., JSON parse, URL decode, type coercion). Errors are represented
 //! as [`FilterError`], which can be converted to
 //! [`Violation`](walrs_validation::Violation) for integration with the
-//! validation error pipeline.
+//! validation error pipeline. Built-in fallible variants include `ToBool`,
+//! `ToInt`, `ToFloat`, and `UrlDecode`.
 //!
 //! ## Example
 //!

--- a/crates/filter/src/try_filter_op.rs
+++ b/crates/filter/src/try_filter_op.rs
@@ -5,6 +5,7 @@
 //! [`FilterOp<T>`](crate::FilterOp), allowing filters that can fail to
 //! participate in the same processing pipeline.
 
+use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
@@ -14,6 +15,17 @@ use crate::{FilterError, FilterOp};
 
 #[cfg(feature = "validation")]
 use walrs_validation::Value;
+
+/// Parse a permissive boolean literal (case-insensitive).
+///
+/// Accepts `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off` — surrounding whitespace is ignored.
+fn parse_bool_literal(s: &str) -> Result<bool, FilterError> {
+  match s.trim().to_ascii_lowercase().as_str() {
+    "1" | "true" | "yes" | "on" => Ok(true),
+    "0" | "false" | "no" | "off" => Ok(false),
+    _ => Err(FilterError::new(format!("cannot parse {s:?} as bool")).with_name("ToBool")),
+  }
+}
 
 /// Iteratively flatten nested `Chain` variants into a list of non-chain operation references.
 ///
@@ -83,6 +95,35 @@ pub enum TryFilterOp<T> {
   /// Applies fallible filters sequentially, short-circuiting on the first error.
   Chain(Vec<TryFilterOp<T>>),
 
+  /// Parse the value as a boolean using a permissive set of accepted literals.
+  ///
+  /// Accepts (case-insensitive): `"1"`, `"0"`, `"true"`, `"false"`, `"yes"`, `"no"`,
+  /// `"on"`, `"off"`. Errors on anything else.
+  ///
+  /// - On `TryFilterOp<String>`: normalises to the canonical `"true"` / `"false"` string.
+  /// - On `TryFilterOp<Value>` (feature `validation`): converts `Value::Str` → `Value::Bool`;
+  ///   `Value::Bool` passes through; other variants pass through unchanged.
+  ToBool,
+
+  /// Parse the value as a signed 64-bit integer (`i64`), accepting surrounding whitespace.
+  ///
+  /// - On `TryFilterOp<String>`: normalises to the canonical decimal representation.
+  /// - On `TryFilterOp<Value>` (feature `validation`): converts `Value::Str` → `Value::I64`;
+  ///   numeric variants pass through; other variants pass through unchanged.
+  ToInt,
+
+  /// Parse the value as a 64-bit floating-point number (`f64`), accepting surrounding whitespace.
+  ///
+  /// - On `TryFilterOp<String>`: normalises to `Display`-canonical form.
+  /// - On `TryFilterOp<Value>` (feature `validation`): converts `Value::Str` → `Value::F64`;
+  ///   numeric variants pass through; other variants pass through unchanged.
+  ToFloat,
+
+  /// Percent-decode the value, interpreting the result as UTF-8.
+  ///
+  /// Errors when the decoded bytes are not valid UTF-8.
+  UrlDecode,
+
   /// Custom fallible filter function (not serializable).
   ///
   /// # Serde limitation
@@ -103,6 +144,10 @@ impl<T: Debug> Debug for TryFilterOp<T> {
     match self {
       Self::Infallible(op) => f.debug_tuple("Infallible").field(op).finish(),
       Self::Chain(ops) => f.debug_tuple("Chain").field(ops).finish(),
+      Self::ToBool => write!(f, "ToBool"),
+      Self::ToInt => write!(f, "ToInt"),
+      Self::ToFloat => write!(f, "ToFloat"),
+      Self::UrlDecode => write!(f, "UrlDecode"),
       Self::TryCustom(_) => write!(f, "TryCustom(<fn>)"),
     }
   }
@@ -113,6 +158,10 @@ impl<T: PartialEq> PartialEq for TryFilterOp<T> {
     match (self, other) {
       (Self::Infallible(a), Self::Infallible(b)) => a == b,
       (Self::Chain(a), Self::Chain(b)) => a == b,
+      (Self::ToBool, Self::ToBool) => true,
+      (Self::ToInt, Self::ToInt) => true,
+      (Self::ToFloat, Self::ToFloat) => true,
+      (Self::UrlDecode, Self::UrlDecode) => true,
       // TryCustom filters are never equal
       (Self::TryCustom(_), Self::TryCustom(_)) => false,
       _ => false,
@@ -148,6 +197,51 @@ impl TryFilterOp<String> {
         }
         Ok(Cow::Owned(result))
       }
+      TryFilterOp::ToBool => {
+        let b = parse_bool_literal(value)?;
+        let canonical = if b { "true" } else { "false" };
+        if value == canonical {
+          Ok(Cow::Borrowed(value))
+        } else {
+          Ok(Cow::Owned(canonical.to_string()))
+        }
+      }
+      TryFilterOp::ToInt => {
+        let parsed: i64 = value.trim().parse().map_err(|e: std::num::ParseIntError| {
+          FilterError::new(format!("cannot parse {value:?} as i64: {e}")).with_name("ToInt")
+        })?;
+        let canonical = parsed.to_string();
+        if value == canonical {
+          Ok(Cow::Borrowed(value))
+        } else {
+          Ok(Cow::Owned(canonical))
+        }
+      }
+      TryFilterOp::ToFloat => {
+        let parsed: f64 = value
+          .trim()
+          .parse()
+          .map_err(|e: std::num::ParseFloatError| {
+            FilterError::new(format!("cannot parse {value:?} as f64: {e}")).with_name("ToFloat")
+          })?;
+        let canonical = format!("{}", parsed);
+        if value == canonical {
+          Ok(Cow::Borrowed(value))
+        } else {
+          Ok(Cow::Owned(canonical))
+        }
+      }
+      TryFilterOp::UrlDecode => {
+        let decoded = percent_decode_str(value).decode_utf8().map_err(|e| {
+          FilterError::new(format!("invalid utf-8 after percent-decode: {e}"))
+            .with_name("UrlDecode")
+        })?;
+        // `decoded` borrows from `value`, so lifetimes line up.
+        match decoded {
+          Cow::Borrowed(s) => Ok(Cow::Borrowed(s)),
+          Cow::Owned(s) => Ok(Cow::Owned(s)),
+        }
+      }
       TryFilterOp::TryCustom(f) => f(value.to_string()).map(Cow::Owned),
     }
   }
@@ -181,6 +275,39 @@ impl TryFilterOp<Value> {
         }
         Ok(result)
       }
+      TryFilterOp::ToBool => match value {
+        Value::Str(s) => Ok(Value::Bool(parse_bool_literal(s)?)),
+        Value::Bool(_) => Ok(value.clone()),
+        other => Ok(other.clone()),
+      },
+      TryFilterOp::ToInt => match value {
+        Value::Str(s) => {
+          let parsed: i64 = s.trim().parse().map_err(|e: std::num::ParseIntError| {
+            FilterError::new(format!("cannot parse {s:?} as i64: {e}")).with_name("ToInt")
+          })?;
+          Ok(Value::I64(parsed))
+        }
+        other => Ok(other.clone()),
+      },
+      TryFilterOp::ToFloat => match value {
+        Value::Str(s) => {
+          let parsed: f64 = s.trim().parse().map_err(|e: std::num::ParseFloatError| {
+            FilterError::new(format!("cannot parse {s:?} as f64: {e}")).with_name("ToFloat")
+          })?;
+          Ok(Value::F64(parsed))
+        }
+        other => Ok(other.clone()),
+      },
+      TryFilterOp::UrlDecode => match value {
+        Value::Str(s) => {
+          let decoded = percent_decode_str(s).decode_utf8().map_err(|e| {
+            FilterError::new(format!("invalid utf-8 after percent-decode: {e}"))
+              .with_name("UrlDecode")
+          })?;
+          Ok(Value::Str(decoded.into_owned()))
+        }
+        other => Ok(other.clone()),
+      },
       TryFilterOp::TryCustom(f) => f(value.clone()),
     }
   }
@@ -207,6 +334,13 @@ macro_rules! impl_numeric_try_filter_op {
                             let flat = flatten_try_chain(ops);
                             flat.iter().try_fold(value, |v, op| op.try_apply(v))
                         }
+                        // String-oriented conversions have no meaningful effect on numeric
+                        // types: preserve the value unchanged. Chains can still mix numeric
+                        // ops with these variants without spuriously failing.
+                        TryFilterOp::ToBool
+                        | TryFilterOp::ToInt
+                        | TryFilterOp::ToFloat
+                        | TryFilterOp::UrlDecode => Ok(value),
                         TryFilterOp::TryCustom(f) => f(value),
                     }
                 }
@@ -334,7 +468,7 @@ mod tests {
     assert!(debug.contains("Infallible"));
     assert!(debug.contains("Trim"));
 
-    let custom: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(|s| Ok(s)));
+    let custom: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(Ok));
     let debug = format!("{:?}", custom);
     assert!(debug.contains("TryCustom"));
   }
@@ -349,8 +483,8 @@ mod tests {
     assert_ne!(a, c);
 
     // TryCustom is never equal
-    let d: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(|s| Ok(s)));
-    let e: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(|s| Ok(s)));
+    let d: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(Ok));
+    let e: TryFilterOp<String> = TryFilterOp::TryCustom(Arc::new(Ok));
     assert_ne!(d, e);
   }
 
@@ -593,5 +727,308 @@ mod tests {
       chain = TryFilterOp::Chain(vec![chain]);
     }
     assert_eq!(chain.try_apply(150).unwrap(), 100);
+  }
+
+  // ====================================================================
+  // Conversion filter tests — #235
+  // ====================================================================
+
+  // ---- ToBool on String ----
+
+  #[test]
+  fn test_to_bool_string_truthy_variants() {
+    let op = TryFilterOp::<String>::ToBool;
+    for input in ["1", "true", "TRUE", "Yes", "on", "ON"] {
+      assert_eq!(op.try_apply(input.to_string()).unwrap(), "true",);
+    }
+  }
+
+  #[test]
+  fn test_to_bool_string_falsy_variants() {
+    let op = TryFilterOp::<String>::ToBool;
+    for input in ["0", "false", "FALSE", "no", "off", " OFF "] {
+      assert_eq!(op.try_apply(input.to_string()).unwrap(), "false",);
+    }
+  }
+
+  #[test]
+  fn test_to_bool_string_invalid_errors() {
+    let op = TryFilterOp::<String>::ToBool;
+    let err = op.try_apply("maybe".to_string()).unwrap_err();
+    assert_eq!(err.filter_name(), Some("ToBool"));
+  }
+
+  #[test]
+  fn test_to_bool_string_already_canonical_is_borrowed() {
+    let op = TryFilterOp::<String>::ToBool;
+    let result = op.try_apply_ref("true").unwrap();
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "true");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_to_bool() {
+    let op = TryFilterOp::<String>::ToBool;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: TryFilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- ToInt on String ----
+
+  #[test]
+  fn test_to_int_string_canonicalizes() {
+    let op = TryFilterOp::<String>::ToInt;
+    assert_eq!(op.try_apply("042".to_string()).unwrap(), "42");
+    assert_eq!(op.try_apply("  -7 ".to_string()).unwrap(), "-7");
+  }
+
+  #[test]
+  fn test_to_int_string_already_canonical_is_borrowed() {
+    let op = TryFilterOp::<String>::ToInt;
+    let result = op.try_apply_ref("42").unwrap();
+    assert!(matches!(result, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn test_to_int_string_invalid_errors() {
+    let op = TryFilterOp::<String>::ToInt;
+    let err = op.try_apply("abc".to_string()).unwrap_err();
+    assert_eq!(err.filter_name(), Some("ToInt"));
+  }
+
+  #[test]
+  fn test_to_int_string_overflow_errors() {
+    let op = TryFilterOp::<String>::ToInt;
+    // `i64::MAX` is 9223372036854775807 — this exceeds it.
+    assert!(op.try_apply("9223372036854775808".to_string()).is_err());
+  }
+
+  #[test]
+  fn test_serde_roundtrip_to_int() {
+    let op = TryFilterOp::<String>::ToInt;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: TryFilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- ToFloat on String ----
+
+  #[test]
+  fn test_to_float_string_canonicalizes() {
+    let op = TryFilterOp::<String>::ToFloat;
+    assert_eq!(op.try_apply(" 3.0 ".to_string()).unwrap(), "3");
+    assert_eq!(op.try_apply("2.5".to_string()).unwrap(), "2.5");
+    assert_eq!(op.try_apply("-1e2".to_string()).unwrap(), "-100");
+  }
+
+  #[test]
+  fn test_to_float_string_invalid_errors() {
+    let op = TryFilterOp::<String>::ToFloat;
+    let err = op.try_apply("xyz".to_string()).unwrap_err();
+    assert_eq!(err.filter_name(), Some("ToFloat"));
+  }
+
+  #[test]
+  fn test_serde_roundtrip_to_float() {
+    let op = TryFilterOp::<String>::ToFloat;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: TryFilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- UrlDecode on String ----
+
+  #[test]
+  fn test_url_decode_string_basic() {
+    let op = TryFilterOp::<String>::UrlDecode;
+    assert_eq!(
+      op.try_apply("hello%20world".to_string()).unwrap(),
+      "hello world"
+    );
+  }
+
+  #[test]
+  fn test_url_decode_string_unicode() {
+    let op = TryFilterOp::<String>::UrlDecode;
+    assert_eq!(op.try_apply("caf%C3%A9".to_string()).unwrap(), "café");
+  }
+
+  #[test]
+  fn test_url_decode_string_no_escapes_is_borrowed() {
+    let op = TryFilterOp::<String>::UrlDecode;
+    let result = op.try_apply_ref("plaintext").unwrap();
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "plaintext");
+  }
+
+  #[test]
+  fn test_url_decode_string_invalid_utf8_errors() {
+    // `%FF` alone is not a valid UTF-8 byte sequence.
+    let op = TryFilterOp::<String>::UrlDecode;
+    let err = op.try_apply("%FF".to_string()).unwrap_err();
+    assert_eq!(err.filter_name(), Some("UrlDecode"));
+  }
+
+  #[test]
+  fn test_url_decode_lone_percent_passes_through() {
+    // percent-encoding's decoder is lenient: a lone `%` with no hex pair is left as-is.
+    let op = TryFilterOp::<String>::UrlDecode;
+    assert_eq!(op.try_apply("100%".to_string()).unwrap(), "100%");
+  }
+
+  #[test]
+  fn test_serde_roundtrip_url_decode() {
+    let op = TryFilterOp::<String>::UrlDecode;
+    let json = serde_json::to_string(&op).unwrap();
+    let deserialized: TryFilterOp<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(op, deserialized);
+  }
+
+  // ---- Chain composition with conversions ----
+
+  #[test]
+  fn test_chain_trim_then_to_int() {
+    let op: TryFilterOp<String> = TryFilterOp::Chain(vec![
+      TryFilterOp::Infallible(FilterOp::Trim),
+      TryFilterOp::ToInt,
+    ]);
+    assert_eq!(op.try_apply("  042  ".to_string()).unwrap(), "42");
+  }
+
+  // ---- Debug format coverage ----
+
+  #[test]
+  fn test_debug_format_conversions() {
+    assert_eq!(format!("{:?}", TryFilterOp::<String>::ToBool), "ToBool");
+    assert_eq!(format!("{:?}", TryFilterOp::<String>::ToInt), "ToInt");
+    assert_eq!(format!("{:?}", TryFilterOp::<String>::ToFloat), "ToFloat");
+    assert_eq!(
+      format!("{:?}", TryFilterOp::<String>::UrlDecode),
+      "UrlDecode"
+    );
+  }
+
+  #[test]
+  fn test_partial_eq_conversions() {
+    assert_eq!(TryFilterOp::<String>::ToBool, TryFilterOp::<String>::ToBool);
+    assert_ne!(TryFilterOp::<String>::ToBool, TryFilterOp::<String>::ToInt);
+  }
+
+  // ---- TryFilterOp<Value> conversion tests ----
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_bool_value_str_to_bool() {
+    let op = TryFilterOp::<Value>::ToBool;
+    assert_eq!(
+      op.try_apply(Value::Str("yes".to_string())).unwrap(),
+      Value::Bool(true)
+    );
+    assert_eq!(
+      op.try_apply(Value::Str("0".to_string())).unwrap(),
+      Value::Bool(false)
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_bool_value_bool_pass_through() {
+    let op = TryFilterOp::<Value>::ToBool;
+    assert_eq!(op.try_apply(Value::Bool(true)).unwrap(), Value::Bool(true));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_bool_value_other_pass_through() {
+    let op = TryFilterOp::<Value>::ToBool;
+    assert_eq!(op.try_apply(Value::I64(42)).unwrap(), Value::I64(42));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_int_value_str_to_i64() {
+    let op = TryFilterOp::<Value>::ToInt;
+    assert_eq!(
+      op.try_apply(Value::Str("  -7  ".to_string())).unwrap(),
+      Value::I64(-7)
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_int_value_str_invalid_errors() {
+    let op = TryFilterOp::<Value>::ToInt;
+    assert!(op.try_apply(Value::Str("abc".to_string())).is_err());
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_int_value_non_str_pass_through() {
+    let op = TryFilterOp::<Value>::ToInt;
+    assert_eq!(op.try_apply(Value::I64(99)).unwrap(), Value::I64(99));
+    assert_eq!(op.try_apply(Value::F64(1.5)).unwrap(), Value::F64(1.5));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_float_value_str_to_f64() {
+    let op = TryFilterOp::<Value>::ToFloat;
+    assert_eq!(
+      op.try_apply(Value::Str("3.25".to_string())).unwrap(),
+      Value::F64(3.25)
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_float_value_non_str_pass_through() {
+    let op = TryFilterOp::<Value>::ToFloat;
+    assert_eq!(op.try_apply(Value::F64(2.5)).unwrap(), Value::F64(2.5));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_url_decode_value_str() {
+    let op = TryFilterOp::<Value>::UrlDecode;
+    assert_eq!(
+      op.try_apply(Value::Str("hello%20world".to_string()))
+        .unwrap(),
+      Value::Str("hello world".to_string())
+    );
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_url_decode_value_non_str_pass_through() {
+    let op = TryFilterOp::<Value>::UrlDecode;
+    assert_eq!(op.try_apply(Value::I64(7)).unwrap(), Value::I64(7));
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_chain_value_trim_then_to_int() {
+    let op: TryFilterOp<Value> = TryFilterOp::Chain(vec![
+      TryFilterOp::Infallible(FilterOp::Trim),
+      TryFilterOp::ToInt,
+    ]);
+    assert_eq!(
+      op.try_apply(Value::Str("  42  ".to_string())).unwrap(),
+      Value::I64(42)
+    );
+  }
+
+  // ---- Numeric pass-through for conversions ----
+
+  #[test]
+  fn test_numeric_pass_through_to_int() {
+    let op = TryFilterOp::<i32>::ToInt;
+    assert_eq!(op.try_apply(42).unwrap(), 42);
+  }
+
+  #[test]
+  fn test_numeric_pass_through_to_bool() {
+    let op = TryFilterOp::<f64>::ToBool;
+    assert_eq!(op.try_apply(1.0).unwrap(), 1.0);
   }
 }

--- a/crates/filter/src/try_filter_op.rs
+++ b/crates/filter/src/try_filter_op.rs
@@ -108,6 +108,9 @@ pub enum TryFilterOp<T> {
   /// Parse the value as a signed 64-bit integer (`i64`), accepting surrounding whitespace.
   ///
   /// - On `TryFilterOp<String>`: normalises to the canonical decimal representation.
+  ///   **Note:** a leading `+` sign is accepted by the parser but is **not**
+  ///   preserved in the canonical output (`"+42"` → `"42"`). Likewise, leading
+  ///   zeros are stripped (`"042"` → `"42"`).
   /// - On `TryFilterOp<Value>` (feature `validation`): converts `Value::Str` → `Value::I64`;
   ///   numeric variants pass through; other variants pass through unchanged.
   ToInt,
@@ -115,6 +118,10 @@ pub enum TryFilterOp<T> {
   /// Parse the value as a 64-bit floating-point number (`f64`), accepting surrounding whitespace.
   ///
   /// - On `TryFilterOp<String>`: normalises to `Display`-canonical form.
+  ///   **Note:** this canonical form is what Rust's default `f64` `Display` impl
+  ///   produces — which drops the fractional part for whole-valued floats
+  ///   (`"3.0"` → `"3"`), normalises exponents (`"-1e2"` → `"-100"`), and
+  ///   preserves the sign of `-0.0` (`"-0.0"` → `"-0"`).
   /// - On `TryFilterOp<Value>` (feature `validation`): converts `Value::Str` → `Value::F64`;
   ///   numeric variants pass through; other variants pass through unchanged.
   ToFloat,
@@ -805,6 +812,15 @@ mod tests {
   }
 
   #[test]
+  fn test_to_int_string_plus_sign_stripped() {
+    // Rust's `i64::parse` accepts a leading `+`; the canonical form does not
+    // preserve it. Documented behaviour.
+    let op = TryFilterOp::<String>::ToInt;
+    assert_eq!(op.try_apply("+42".to_string()).unwrap(), "42");
+    assert_eq!(op.try_apply("  +42  ".to_string()).unwrap(), "42");
+  }
+
+  #[test]
   fn test_serde_roundtrip_to_int() {
     let op = TryFilterOp::<String>::ToInt;
     let json = serde_json::to_string(&op).unwrap();
@@ -827,6 +843,31 @@ mod tests {
     let op = TryFilterOp::<String>::ToFloat;
     let err = op.try_apply("xyz".to_string()).unwrap_err();
     assert_eq!(err.filter_name(), Some("ToFloat"));
+  }
+
+  #[test]
+  fn test_to_float_string_negative_zero_preserved() {
+    // Rust's `Display` for `f64` renders `-0.0` as `"-0"` — the sign survives
+    // String canonicalisation.
+    let op = TryFilterOp::<String>::ToFloat;
+    assert_eq!(op.try_apply("-0.0".to_string()).unwrap(), "-0");
+  }
+
+  #[cfg(feature = "validation")]
+  #[test]
+  fn test_to_float_value_preserves_negative_zero() {
+    // On `Value`, `-0.0` survives as a `Value::F64` with its sign bit intact.
+    let op = TryFilterOp::<Value>::ToFloat;
+    let result = op.try_apply(Value::Str("-0.0".to_string())).unwrap();
+    if let Value::F64(f) = result {
+      assert!(
+        f.is_sign_negative(),
+        "-0.0 sign should survive Value::F64 path"
+      );
+      assert_eq!(f, 0.0);
+    } else {
+      panic!("expected Value::F64, got {result:?}");
+    }
   }
 
   #[test]

--- a/crates/filter/src/try_filter_op.rs
+++ b/crates/filter/src/try_filter_op.rs
@@ -19,12 +19,22 @@ use walrs_validation::Value;
 /// Parse a permissive boolean literal (case-insensitive).
 ///
 /// Accepts `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off` — surrounding whitespace is ignored.
+///
+/// Uses [`str::eq_ignore_ascii_case`] to avoid allocating a lowercased copy of the input;
+/// the common already-canonical paths (`"true"` / `"false"`) stay allocation-free.
 fn parse_bool_literal(s: &str) -> Result<bool, FilterError> {
-  match s.trim().to_ascii_lowercase().as_str() {
-    "1" | "true" | "yes" | "on" => Ok(true),
-    "0" | "false" | "no" | "off" => Ok(false),
-    _ => Err(FilterError::new(format!("cannot parse {s:?} as bool")).with_name("ToBool")),
+  let t = s.trim();
+  for truthy in ["true", "1", "yes", "on"] {
+    if t.eq_ignore_ascii_case(truthy) {
+      return Ok(true);
+    }
   }
+  for falsy in ["false", "0", "no", "off"] {
+    if t.eq_ignore_ascii_case(falsy) {
+      return Ok(false);
+    }
+  }
+  Err(FilterError::new(format!("cannot parse {s:?} as bool")).with_name("ToBool"))
 }
 
 /// Iteratively flatten nested `Chain` variants into a list of non-chain operation references.
@@ -239,15 +249,13 @@ impl TryFilterOp<String> {
         }
       }
       TryFilterOp::UrlDecode => {
+        // `percent_decode_str(value).decode_utf8()` returns `Cow<'_, str>` borrowing from
+        // `value`, so the lifetimes line up and we can return it directly.
         let decoded = percent_decode_str(value).decode_utf8().map_err(|e| {
           FilterError::new(format!("invalid utf-8 after percent-decode: {e}"))
             .with_name("UrlDecode")
         })?;
-        // `decoded` borrows from `value`, so lifetimes line up.
-        match decoded {
-          Cow::Borrowed(s) => Ok(Cow::Borrowed(s)),
-          Cow::Owned(s) => Ok(Cow::Owned(s)),
-        }
+        Ok(decoded)
       }
       TryFilterOp::TryCustom(f) => f(value.to_string()).map(Cow::Owned),
     }
@@ -341,13 +349,17 @@ macro_rules! impl_numeric_try_filter_op {
                             let flat = flatten_try_chain(ops);
                             flat.iter().try_fold(value, |v, op| op.try_apply(v))
                         }
-                        // String-oriented conversions have no meaningful effect on numeric
-                        // types: preserve the value unchanged. Chains can still mix numeric
-                        // ops with these variants without spuriously failing.
+                        // String-oriented conversions (`ToBool`, `ToInt`, `ToFloat`,
+                        // `UrlDecode`) are only meaningful for `TryFilterOp<String>`.
+                        // Constructing one with a numeric `T` is a programming error —
+                        // panic loudly rather than silently pass the value through.
                         TryFilterOp::ToBool
                         | TryFilterOp::ToInt
                         | TryFilterOp::ToFloat
-                        | TryFilterOp::UrlDecode => Ok(value),
+                        | TryFilterOp::UrlDecode => unreachable!(
+                            "string-oriented TryFilterOp variant applied to numeric TryFilterOp<{}>; these variants are only valid for TryFilterOp<String>",
+                            stringify!($t)
+                        ),
                         TryFilterOp::TryCustom(f) => f(value),
                     }
                 }
@@ -771,6 +783,10 @@ mod tests {
     let result = op.try_apply_ref("true").unwrap();
     assert!(matches!(result, Cow::Borrowed(_)));
     assert_eq!(result, "true");
+
+    let result = op.try_apply_ref("false").unwrap();
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "false");
   }
 
   #[test]
@@ -1059,17 +1075,35 @@ mod tests {
     );
   }
 
-  // ---- Numeric pass-through for conversions ----
+  // ---- Numeric types reject string-oriented conversions ----
 
   #[test]
-  fn test_numeric_pass_through_to_int() {
+  #[should_panic(expected = "string-oriented TryFilterOp variant applied to numeric")]
+  fn test_numeric_to_int_panics() {
+    // `ToInt` on a numeric `TryFilterOp<T>` is a misconfiguration — the variant is
+    // only meaningful for `TryFilterOp<String>` (and `TryFilterOp<Value>`).
     let op = TryFilterOp::<i32>::ToInt;
-    assert_eq!(op.try_apply(42).unwrap(), 42);
+    let _ = op.try_apply(42);
   }
 
   #[test]
-  fn test_numeric_pass_through_to_bool() {
+  #[should_panic(expected = "string-oriented TryFilterOp variant applied to numeric")]
+  fn test_numeric_to_bool_panics() {
     let op = TryFilterOp::<f64>::ToBool;
-    assert_eq!(op.try_apply(1.0).unwrap(), 1.0);
+    let _ = op.try_apply(1.0);
+  }
+
+  #[test]
+  #[should_panic(expected = "string-oriented TryFilterOp variant applied to numeric")]
+  fn test_numeric_to_float_panics() {
+    let op = TryFilterOp::<i64>::ToFloat;
+    let _ = op.try_apply(1);
+  }
+
+  #[test]
+  #[should_panic(expected = "string-oriented TryFilterOp variant applied to numeric")]
+  fn test_numeric_url_decode_panics() {
+    let op = TryFilterOp::<u32>::UrlDecode;
+    let _ = op.try_apply(1);
   }
 }


### PR DESCRIPTION
## Summary

Closes #235. Adds 12 new variants to `FilterOp<T>` / `TryFilterOp<T>` so the ~80% of common input-sanitization patterns (strip-to-digits, normalize whitespace, coerce `"true"` → `bool`, etc.) no longer require a `Custom` / `TryCustom` closure — which would otherwise break serialisable config-driven pipelines.

### `FilterOp<T>` — infallible
- `Digits` — keep ASCII digits only.
- `Alnum { allow_whitespace }` / `Alpha { allow_whitespace }` — Unicode-aware character-class filters.
- `StripNewlines` — remove `\r` / `\n`.
- `NormalizeWhitespace` — collapse runs of whitespace and trim.
- `AllowChars { set }` / `DenyChars { set }` — explicit allow/deny char lists.
- `UrlEncode { encode_unreserved }` — percent-encode. With `encode_unreserved: false` (default-ish), conforms to RFC 3986 §2.3 and leaves `-._~` unencoded; with `encode_unreserved: true`, uses the stricter `NON_ALPHANUMERIC` set (encodes `-._~` as well) for opaque-token use-cases.

### `TryFilterOp<T>` — fallible
- `ToBool` — accepts `"1"/"0"/"true"/"false"/"yes"/"no"/"on"/"off"` (case-insensitive); canonicalises on `String`, converts `Value::Str → Value::Bool` on `Value`. Fast path via `eq_ignore_ascii_case` — already-canonical `"true"`/`"false"` inputs stay allocation-free.
- `ToInt` / `ToFloat` — parse to `i64` / `f64`; canonicalise on `String`, convert on `Value`.
- `UrlDecode` — percent-decode with UTF-8 validation.

### Notes
- All new variants preserve the `Cow`-based zero-copy contract — clean input returns `Cow::Borrowed`.
- All variants serialise through the existing adjacent-tag format; round-trip tests included.
- On numeric `TryFilterOp<T>` (`i32`, `i64`, `f32`, `f64`, `u32`, `u64`, `usize`), the four string-oriented fallible variants (`ToBool`, `ToInt`, `ToFloat`, `UrlDecode`) panic via `unreachable!()` — these variants are only valid for `TryFilterOp<String>` (and `TryFilterOp<Value>`), and silently passing through a misconfigured pipeline was hiding bugs.
- New dep: `percent-encoding = "2"`.
- The `walrs_fieldset_derive` attribute surface is split out into follow-up issue #236.
- `RemoveDiacritics`/`deunicode` spike tracked in follow-up issue #237.
- Benches (`FilterOp_Sanitize`, `TryFilterOp_Conversions`) and examples (`filter_op_usage`, `try_filters`) extended to exercise the new variants.

## Test plan

- [x] `cargo test -p walrs_filter` — 226 unit + 12 doctest pass.
- [x] `cargo test -p walrs_filter --no-default-features` — non-`Value` tests still pass, `Value` tests correctly compile-gated out.
- [x] `cargo clippy -p walrs_filter --all-targets --no-deps -- -D warnings` — clean.
- [x] `cargo fmt -p walrs_filter` — clean.
- [x] `cargo llvm-cov --summary-only -p walrs_filter` — `filter_op.rs` 93.25% lines, `try_filter_op.rs` 98.03% lines (both ≥ 80%).
- [x] Examples (`filter_op_usage`, `try_filters`) run and output verified by hand.
- [x] Benches build (`cargo build -p walrs_filter --benches`).
- [x] Serde round-trip test for every new variant.
- [x] `Cow` zero-copy assertions for every new borrowed-input path.
- [x] `#[should_panic]` coverage for each of the four string-oriented variants on numeric `TryFilterOp<T>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)