### PR TITLE
docs: #241 document walrs_fieldset_derive and enforce README/crate-roster sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 Ensure all:
 
 - Call-sites, benches, examples, READMEs, and tests, where required, are updated to reflect any changes made, where required.
+- When a crate is added, renamed, or removed (in `crates/` and/or the workspace `Cargo.toml`), update the main repository `README.md` — sub-crates table, feature flags list, and any umbrella `walrs` crate re-exports / features — so it stays in sync with the current crate roster.
 - Code is covered above 80% coverage. 
 
 ## File/Code Scanning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@
 Ensure all:
 
 - Call-sites, benches, examples, READMEs, and tests, where required, are updated to reflect any changes made, where required.
+- When a crate is added, renamed, or removed (in `crates/` and/or the workspace `Cargo.toml`), update the main repository `README.md` — sub-crates table, feature flags list, and any umbrella `walrs` crate re-exports / features — so it stays in sync with the current crate roster.
 - Code is covered above 80% coverage.
 
 ## File/Code Scanning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Elastic-2.0"
 
 [features]
 default = ["acl", "digraph", "filter", "form", "graph", "fieldfilter", "navigation", "rbac", "validation"]
-full = ["acl", "digraph", "filter", "form", "graph", "fieldfilter", "navigation", "rbac", "validation"]
+full = ["acl", "digraph", "filter", "form", "graph", "fieldfilter", "fieldfilter-derive", "navigation", "rbac", "validation"]
 
 acl = ["dep:walrs_acl"]
 digraph = ["dep:walrs_digraph"]
@@ -17,6 +17,7 @@ filter = ["dep:walrs_filter"]
 form = ["dep:walrs_form"]
 graph = ["dep:walrs_graph"]
 fieldfilter = ["dep:walrs_fieldfilter"]
+fieldfilter-derive = ["fieldfilter", "walrs_fieldfilter/derive"]
 navigation = ["dep:walrs_navigation"]
 rbac = ["dep:walrs_rbac"]
 validation = ["dep:walrs_validation"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ All sub-crates are enabled by default. Disable features you don't need to reduce
 walrs = { version = "0.1", default-features = false, features = ["fieldfilter", "validation", "filter"] }
 ```
 
-Available features: `acl`, `digraph`, `filter`, `form`, `graph`, `fieldfilter`, `navigation`, `rbac`, `validation`.
+Available features: `acl`, `digraph`, `filter`, `form`, `graph`, `fieldfilter`, `fieldfilter-derive`, `navigation`, `rbac`, `validation`.
+
+`fieldfilter-derive` opts into the `#[derive(Fieldset)]` proc-macro — it implies `fieldfilter` and enables `walrs_fieldfilter`'s `derive` feature:
+
+```toml
+[dependencies]
+walrs = { version = "0.1", default-features = false, features = ["fieldfilter-derive", "validation"] }
+```
+
+```rust
+use walrs::fieldfilter::{DeriveFieldset, Fieldset};
+```
 
 You can also depend on individual sub-crates directly (e.g., `walrs_fieldfilter = "0.1"`).
 
@@ -42,6 +53,7 @@ You can also depend on individual sub-crates directly (e.g., `walrs_fieldfilter 
 | `walrs_form` | Form elements and structure for web frameworks |
 | `walrs_graph` | Undirected graph structures |
 | `walrs_fieldfilter` | Field-level validation and filtering for form processing |
+| `walrs_fieldset_derive` | Proc-macro crate providing `#[derive(Fieldset)]`; consumed via `walrs_fieldfilter`'s `derive` feature |
 | `walrs_navigation` | Web page link graph / navigation structures |
 | `walrs_rbac` | Role-Based Access Control |
 | `walrs_validation` | Composable validation rules |


### PR DESCRIPTION
Closes #241.

## Summary
- Add `walrs_fieldset_derive` to the main README sub-crates table with a note that it's consumed via `walrs_fieldfilter`'s `derive` feature.
- Add a `fieldfilter-derive` passthrough feature to the umbrella `walrs` crate (`fieldfilter-derive = ["fieldfilter", "walrs_fieldfilter/derive"]`), update the feature-flags documentation, and add a short usage snippet.
- Codify the convention in `CLAUDE.md` / `AGENTS.md`: whenever a crate is added, renamed, or removed, the main repo README (sub-crates table, feature flag list, umbrella re-exports) must be updated to match. This closes the feedback loop that caused #241 in the first place.

## Test plan
- [x] `cargo check --features fieldfilter-derive` compiles (umbrella crate picks up the derive via `walrs_fieldfilter/derive`).
- [ ] Reviewer sanity-check: README sub-crates table matches `crates/` directory listing.
- [ ] Reviewer sanity-check: umbrella `Cargo.toml` `[features]` matches the README's `Available features` list.

_Note: this PR is docs + `Cargo.toml` metadata only; no Rust source changes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)