### PR TITLE
chore(walrs_filter): #239 post-#235 minor cleanups

### DIFF
--- a/crates/filter/benches/filter_benchmarks.rs
+++ b/crates/filter/benches/filter_benchmarks.rs
@@ -237,7 +237,11 @@ fn bench_filter_op_sanitize(c: &mut Criterion) {
     b.iter(|| normalize.apply_ref(black_box("hello world go")))
   });
   group.bench_function("normalize_whitespace_mutation", |b| {
-    b.iter(|| normalize.apply_ref(black_box("  hello    world\n\tgo  ")))
+    b.iter(|| {
+      normalize.apply_ref(black_box(
+        "  Lorem   ipsum\tdolor\n\nsit amet,     consectetur\t adipiscing elit.  \n  Sed\t\tdo  eiusmod   tempor\n\n\tincididunt ut labore    et dolore\nmagna\t aliqua.   Ut\n\n enim\t ad minim\tveniam,   quis\n nostrud\nexercitation    ullamco\t laboris\tnisi   ut aliquip\n\n   ex\t ea commodo\nconsequat.  ",
+      ))
+    })
   });
 
   // AllowChars / DenyChars

--- a/crates/filter/benches/filter_benchmarks.rs
+++ b/crates/filter/benches/filter_benchmarks.rs
@@ -7,6 +7,21 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use walrs_filter::{Filter, FilterOp, SlugFilter, StripTagsFilter, TryFilterOp, XmlEntitiesFilter};
 
+const NORMALIZE_WHITESPACE_DIRTY_INPUT: &str = r#"  Lorem   ipsum	dolor
+
+sit amet,     consectetur	 adipiscing elit.  
+  Sed		do  eiusmod   tempor
+
+	incididunt ut labore    et dolore
+magna	 aliqua.   Ut
+
+ enim	 ad minim	veniam,   quis
+ nostrud
+exercitation    ullamco	 laboris	nisi   ut aliquip
+
+   ex	 ea commodo
+consequat.  "#;
+
 fn bench_slug_filter(c: &mut Criterion) {
   let mut group = c.benchmark_group("SlugFilter");
 
@@ -237,11 +252,7 @@ fn bench_filter_op_sanitize(c: &mut Criterion) {
     b.iter(|| normalize.apply_ref(black_box("hello world go")))
   });
   group.bench_function("normalize_whitespace_mutation", |b| {
-    b.iter(|| {
-      normalize.apply_ref(black_box(
-        "  Lorem   ipsum\tdolor\n\nsit amet,     consectetur\t adipiscing elit.  \n  Sed\t\tdo  eiusmod   tempor\n\n\tincididunt ut labore    et dolore\nmagna\t aliqua.   Ut\n\n enim\t ad minim\tveniam,   quis\n nostrud\nexercitation    ullamco\t laboris\tnisi   ut aliquip\n\n   ex\t ea commodo\nconsequat.  ",
-      ))
-    })
+    b.iter(|| normalize.apply_ref(black_box(NORMALIZE_WHITESPACE_DIRTY_INPUT)))
   });
 
   // AllowChars / DenyChars

--- a/crates/filter/src/try_filter_op.rs
+++ b/crates/filter/src/try_filter_op.rs
@@ -27,14 +27,12 @@ fn parse_bool_literal(s: &str) -> Result<bool, FilterError> {
   let t = s.trim();
   if ["true", "1", "yes", "on"]
     .iter()
-    .any(|truthy| t.eq_ignore_ascii_case(truthy))
-  {
+    .any(|truthy| t.eq_ignore_ascii_case(truthy)) {
     return Ok(true);
   }
   if ["false", "0", "no", "off"]
     .iter()
-    .any(|falsy| t.eq_ignore_ascii_case(falsy))
-  {
+    .any(|falsy| t.eq_ignore_ascii_case(falsy)) {
     return Ok(false);
   }
   Err(FilterError::new(format!("cannot parse {s:?} as bool")).with_name("ToBool"))

--- a/crates/filter/src/try_filter_op.rs
+++ b/crates/filter/src/try_filter_op.rs
@@ -20,19 +20,22 @@ use walrs_validation::Value;
 ///
 /// Accepts `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off` — surrounding whitespace is ignored.
 ///
-/// Uses [`str::eq_ignore_ascii_case`] to avoid allocating a lowercased copy of the input;
-/// the common already-canonical paths (`"true"` / `"false"`) stay allocation-free.
+/// Uses [`str::eq_ignore_ascii_case`] to avoid allocating a lowercased copy of the input.
+/// The success path no longer allocates — `eq_ignore_ascii_case` compares in place without
+/// lowering the input; only the `Err` branch still allocates via `format!`.
 fn parse_bool_literal(s: &str) -> Result<bool, FilterError> {
   let t = s.trim();
-  for truthy in ["true", "1", "yes", "on"] {
-    if t.eq_ignore_ascii_case(truthy) {
-      return Ok(true);
-    }
+  if ["true", "1", "yes", "on"]
+    .iter()
+    .any(|truthy| t.eq_ignore_ascii_case(truthy))
+  {
+    return Ok(true);
   }
-  for falsy in ["false", "0", "no", "off"] {
-    if t.eq_ignore_ascii_case(falsy) {
-      return Ok(false);
-    }
+  if ["false", "0", "no", "off"]
+    .iter()
+    .any(|falsy| t.eq_ignore_ascii_case(falsy))
+  {
+    return Ok(false);
   }
   Err(FilterError::new(format!("cannot parse {s:?} as bool")).with_name("ToBool"))
 }
@@ -357,7 +360,7 @@ macro_rules! impl_numeric_try_filter_op {
                         | TryFilterOp::ToInt
                         | TryFilterOp::ToFloat
                         | TryFilterOp::UrlDecode => unreachable!(
-                            "string-oriented TryFilterOp variant applied to numeric TryFilterOp<{}>; these variants are only valid for TryFilterOp<String>",
+                            "string-oriented TryFilterOp variant applied to numeric TryFilterOp<{}>; these variants are only valid for TryFilterOp<String> (and TryFilterOp<Value> while the validation feature is enabled)",
                             stringify!($t)
                         ),
                         TryFilterOp::TryCustom(f) => f(value),


### PR DESCRIPTION
## Summary

- Fix `parse_bool_literal` docstring to reflect all success paths are allocation-free
- Fix `unreachable!()` msg in numeric macro to mention `TryFilterOp<Value>`
- Replace short `NormalizeWhitespace` bench input with 200+ char realistic one
- Tighten loop style in `parse_bool_literal`

## Related

Closes #239