### PR TITLE
feat(walrs_acl): #246 async assertion evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,12 +2102,14 @@ name = "walrs_acl"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "async-trait",
  "js-sys",
  "rand 0.9.2",
  "serde",
  "serde-wasm-bindgen",
  "serde_derive",
  "serde_json",
+ "tokio",
  "walrs_digraph",
  "wasm-bindgen",
 ]

--- a/crates/acl/Cargo.toml
+++ b/crates/acl/Cargo.toml
@@ -9,6 +9,11 @@ crate-type = ["cdylib", "rlib"]
 default = ["std"]
 std = ["serde/std", "serde_json/std"]
 wasm = ["wasm-bindgen", "serde-wasm-bindgen", "js-sys"]
+async = ["dep:async-trait"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 walrs_digraph = { path = '../digraph' }
@@ -18,10 +23,12 @@ serde_derive = "1.0.228"
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 js-sys = { version = "0.3", optional = true }
+async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
 rand = "0.9"
 actix-web = "4"
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [[example]]
 name = "acl_builder_example"

--- a/crates/acl/Cargo.toml
+++ b/crates/acl/Cargo.toml
@@ -12,7 +12,7 @@ wasm = ["wasm-bindgen", "serde-wasm-bindgen", "js-sys"]
 async = ["dep:async-trait"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["async"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/acl/README.md
+++ b/crates/acl/README.md
@@ -137,6 +137,38 @@ The same rules can be expressed in JSON via the `allow_if` / `deny_if` top-level
 
 **Conservative defaults.** Plain `is_allowed` (no resolver) treats `AllowIf` as **not-allow** and `DenyIf` as **not-deny**: without a resolver we can't evaluate the predicate, so we stay on the safe side for allows and don't synthesise a deny we aren't sure about. An explicit `Deny` still overrides a conditional `AllowIf` even when the resolver says `true`.
 
+### Sync vs. async resolvers
+
+`AssertionResolver::evaluate` is synchronous — use it when the decision is in-memory (cached flags, request-scoped values, etc.). For assertions that need I/O (database lookups, calls to a policy service, remote feature flags), enable the `async` feature and implement `AsyncAssertionResolver` instead:
+
+```toml
+[dependencies]
+walrs_acl = { version = "0.1.0", features = ["async"] }
+```
+
+```rust,ignore
+use walrs_acl::simple::{AclBuilder, AsyncAssertionResolver};
+use async_trait::async_trait;
+
+struct DbResolver { /* pool, etc. */ }
+
+#[async_trait]
+impl AsyncAssertionResolver for DbResolver {
+  async fn evaluate(&self, key: &str) -> bool {
+    // Await your DB / service call here.
+    key == "is_owner"
+  }
+}
+
+# async fn check(acl: &walrs_acl::simple::Acl, resolver: &DbResolver) {
+let allowed = acl
+  .is_allowed_with_async(Some("editor"), Some("post"), Some("edit"), resolver)
+  .await;
+# }
+```
+
+`Acl::is_allowed_with_async` / `is_allowed_any_with_async` mirror their sync siblings' semantics exactly — the only difference is that the resolver call is awaited. The sync path has zero async overhead; the async path is opt-in.
+
 ## How it works?
 
 The ACL structure is made up of a `roles`, and a `resources`, symbol graph, and a "nested" `rules` structure [which is used to define, and query-for, "allow" and "deny" rules].
@@ -157,6 +189,7 @@ $ sh ./ci-cd-wasm.sh
 
 - **`std`** (default): Full standard library support with file I/O
 - **`wasm`**: WASM-compatible mode with `no_std` + `alloc`
+- **`async`**: Adds `AsyncAssertionResolver` and `Acl::is_allowed_with_async` / `is_allowed_any_with_async` for assertions that need I/O
 
 ### Usage
 

--- a/crates/acl/src/lib.rs
+++ b/crates/acl/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/crates/acl/src/simple/acl.rs
+++ b/crates/acl/src/simple/acl.rs
@@ -886,8 +886,7 @@ mod async_impl {
       for resource in
         self._filter_vec_option_to_options_vec1(&|xs: &str| self.has_resource(xs), resources)
       {
-        for role in self._filter_vec_option_to_options_vec1(&|xs: &str| self.has_role(xs), roles)
-        {
+        for role in self._filter_vec_option_to_options_vec1(&|xs: &str| self.has_role(xs), roles) {
           for privilege in self._filter_vec_option_to_options_vec1(&|_| true, privileges) {
             if self
               ._is_allowed_inner_async(role, resource, privilege, resolver)

--- a/crates/acl/src/simple/acl.rs
+++ b/crates/acl/src/simple/acl.rs
@@ -823,6 +823,259 @@ impl Default for Acl {
   }
 }
 
+#[cfg(feature = "async")]
+mod async_impl {
+  //! Async counterparts to [`Acl::is_allowed_with`] / [`is_allowed_any_with`].
+  //!
+  //! The rule-walking logic mirrors the sync path in the enclosing module; the
+  //! only difference is that assertion resolution awaits an
+  //! [`AsyncAssertionResolver`]. Helpers are duplicated rather than abstracted
+  //! so the sync hot path keeps zero dispatch cost and the async walk can
+  //! `.await` freely without the sync code paying for indirection.
+
+  use super::Acl;
+  use crate::prelude::Vec;
+  use crate::simple::async_assertion_resolver::AsyncAssertionResolver;
+  use crate::simple::rule::Rule;
+  use walrs_digraph::{DigraphDFSShape, DirectedPathsDFS};
+
+  async fn rule_is_deny_async(rule: &Rule, resolver: &dyn AsyncAssertionResolver) -> bool {
+    match rule {
+      Rule::Deny => true,
+      Rule::DenyIf(k) => resolver.evaluate(k).await,
+      Rule::Allow | Rule::AllowIf(_) => false,
+    }
+  }
+
+  async fn rule_is_allow_async(rule: &Rule, resolver: &dyn AsyncAssertionResolver) -> bool {
+    match rule {
+      Rule::Allow => true,
+      Rule::AllowIf(k) => resolver.evaluate(k).await,
+      Rule::Deny | Rule::DenyIf(_) => false,
+    }
+  }
+
+  impl Acl {
+    /// Async variant of [`Acl::is_allowed_with`]. Evaluates conditional
+    /// (`AllowIf` / `DenyIf`) rules via an [`AsyncAssertionResolver`].
+    ///
+    /// Semantics match the sync version exactly — only the resolver call is
+    /// awaited.
+    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+    pub async fn is_allowed_with_async<R: AsyncAssertionResolver>(
+      &self,
+      role: Option<&str>,
+      resource: Option<&str>,
+      privilege: Option<&str>,
+      resolver: &R,
+    ) -> bool {
+      self
+        ._is_allowed_inner_async(role, resource, privilege, resolver)
+        .await
+    }
+
+    /// Async variant of [`Acl::is_allowed_any_with`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+    pub async fn is_allowed_any_with_async<R: AsyncAssertionResolver>(
+      &self,
+      roles: Option<&[&str]>,
+      resources: Option<&[&str]>,
+      privileges: Option<&[&str]>,
+      resolver: &R,
+    ) -> bool {
+      for resource in
+        self._filter_vec_option_to_options_vec1(&|xs: &str| self.has_resource(xs), resources)
+      {
+        for role in self._filter_vec_option_to_options_vec1(&|xs: &str| self.has_role(xs), roles)
+        {
+          for privilege in self._filter_vec_option_to_options_vec1(&|_| true, privileges) {
+            if self
+              ._is_allowed_inner_async(role, resource, privilege, resolver)
+              .await
+            {
+              return true;
+            }
+          }
+        }
+      }
+      false
+    }
+
+    async fn _is_allowed_inner_async(
+      &self,
+      role: Option<&str>,
+      resource: Option<&str>,
+      privilege: Option<&str>,
+      resolver: &dyn AsyncAssertionResolver,
+    ) -> bool {
+      // Collect transitive parent roles (DFS), same as the sync path.
+      let _roles = role.and_then(|_role| {
+        let role_idx = self._roles.index(_role)?;
+        let dfs = DirectedPathsDFS::new(self._roles.graph(), role_idx).ok()?;
+
+        let mut inherited = Vec::new();
+        for i in 0..self._roles.vert_count() {
+          if i != role_idx
+            && dfs.marked(i).unwrap_or(false)
+            && let Some(name) = self._roles.name_as_ref(i)
+          {
+            inherited.push(name);
+          }
+        }
+
+        if inherited.is_empty() {
+          None
+        } else {
+          Some(inherited)
+        }
+      });
+
+      let _resources = resource.and_then(|_resource| {
+        let resource_idx = self._resources.index(_resource)?;
+        let dfs = DirectedPathsDFS::new(self._resources.graph(), resource_idx).ok()?;
+
+        let mut inherited = Vec::new();
+        for i in 0..self._resources.vert_count() {
+          if i != resource_idx
+            && dfs.marked(i).unwrap_or(false)
+            && let Some(name) = self._resources.name_as_ref(i)
+          {
+            inherited.push(name);
+          }
+        }
+
+        if inherited.is_empty() {
+          None
+        } else {
+          Some(inherited)
+        }
+      });
+
+      // Explicit-Deny short-circuit on the direct (role, resource, privilege).
+      let has_explicit_deny = if let Some(priv_id) = privilege {
+        if resource.is_some() {
+          let role_rules = self
+            ._rules
+            .get_role_privilege_rules(resource)
+            .get_privilege_rules(role);
+          if let Some(rule) = role_rules
+            .by_privilege_id
+            .as_ref()
+            .and_then(|map| map.get(priv_id))
+          {
+            rule_is_deny_async(rule, resolver).await
+          } else {
+            false
+          }
+        } else {
+          let role_rules = self._rules.for_all_resources.get_privilege_rules(role);
+          if let Some(rule) = role_rules
+            .by_privilege_id
+            .as_ref()
+            .and_then(|map| map.get(priv_id))
+          {
+            rule_is_deny_async(rule, resolver).await
+          } else {
+            false
+          }
+        }
+      } else {
+        false
+      };
+
+      if has_explicit_deny {
+        return false;
+      }
+
+      // Walk inherited combinations looking for an allowing verdict, then fall
+      // back to the direct (role, resource, privilege).
+      if let (Some(res_list), Some(role_list)) = (_resources.as_ref(), _roles.as_ref()) {
+        for r in res_list.iter().rev() {
+          for ro in role_list.iter().rev() {
+            if self
+              ._matches_allow_no_dfs_async(Some(ro), Some(r), privilege, resolver)
+              .await
+            {
+              return true;
+            }
+          }
+        }
+        self
+          ._matches_allow_no_dfs_async(role, resource, privilege, resolver)
+          .await
+      } else if _resources.is_none() && _roles.is_some() {
+        let rs = _roles.as_ref().unwrap();
+        for ro in rs.iter().rev() {
+          if self
+            ._matches_allow_no_dfs_async(Some(ro), resource, privilege, resolver)
+            .await
+          {
+            return true;
+          }
+        }
+        self
+          ._matches_allow_no_dfs_async(role, resource, privilege, resolver)
+          .await
+      } else if _resources.is_some() && _roles.is_none() {
+        let rs = _resources.as_ref().unwrap();
+        for r in rs.iter().rev() {
+          if self
+            ._matches_allow_no_dfs_async(role, Some(*r), privilege, resolver)
+            .await
+          {
+            return true;
+          }
+        }
+        self
+          ._matches_allow_no_dfs_async(role, resource, privilege, resolver)
+          .await
+      } else {
+        self
+          ._matches_allow_no_dfs_async(role, resource, privilege, resolver)
+          .await
+      }
+    }
+
+    async fn _matches_allow_no_dfs_async(
+      &self,
+      role: Option<&str>,
+      resource: Option<&str>,
+      privilege: Option<&str>,
+      resolver: &dyn AsyncAssertionResolver,
+    ) -> bool {
+      if resource.is_some() {
+        let specific_rule = self
+          ._rules
+          .get_role_privilege_rules(resource)
+          .get_privilege_rules(role)
+          .get_rule(privilege);
+
+        if rule_is_allow_async(specific_rule, resolver).await {
+          return true;
+        }
+
+        let global_rule = self
+          ._rules
+          .for_all_resources
+          .get_privilege_rules(role)
+          .get_rule(privilege);
+
+        return rule_is_allow_async(global_rule, resolver).await;
+      }
+
+      rule_is_allow_async(
+        self
+          ._rules
+          .for_all_resources
+          .get_privilege_rules(role)
+          .get_rule(privilege),
+        resolver,
+      )
+      .await
+    }
+  }
+}
+
 #[cfg(test)]
 mod test_acl {
   use crate::simple::acl::Acl;
@@ -833,8 +1086,8 @@ mod test_acl {
   #[test]
   fn test_default_and_new() {
     let acl = Acl::default();
-    assert_eq!(acl.has_resource("index"), false);
-    assert_eq!(acl.has_role("admin"), false);
+    assert!(!acl.has_resource("index"));
+    assert!(!acl.has_role("admin"));
     assert_eq!(
       acl
         ._rules
@@ -845,8 +1098,8 @@ mod test_acl {
     );
 
     let acl2 = Acl::new();
-    assert_eq!(acl2.has_resource("index"), false);
-    assert_eq!(acl2.has_role("admin"), false);
+    assert!(!acl2.has_resource("index"));
+    assert!(!acl2.has_role("admin"));
     assert_eq!(
       acl2
         ._rules
@@ -878,9 +1131,8 @@ mod test_acl {
       "Should contain {:?} resource",
       users
     );
-    assert_eq!(
-      acl.has_resource(non_existent_resource),
-      false,
+    assert!(
+      !acl.has_resource(non_existent_resource),
       "Should \"not\" contain {:?} resource",
       non_existent_resource
     );
@@ -905,9 +1157,8 @@ mod test_acl {
       "Should contain {:?} role",
       super_admin
     );
-    assert_eq!(
-      acl.has_role(non_existent_role),
-      false,
+    assert!(
+      !acl.has_role(non_existent_role),
       "Should \"not\" contain {:?} role",
       non_existent_role
     );
@@ -929,9 +1180,9 @@ mod test_acl {
       privilege_rules
         .by_privilege_id
         .as_mut()
-        .and_then(|privilege_id_map| {
+        .map(|privilege_id_map| {
           privilege_id_map.insert(privilege.to_string(), expected_rule.clone());
-          Some(())
+          ()
         })
         .expect("Expecting a `privilege_id_map`;  None found");
 
@@ -1210,9 +1461,8 @@ mod test_acl {
 
       // println!("`#Acl._rules`: {:#?}", &acl._rules);
 
-      assert_eq!(
-        acl.is_allowed_any(roles, resources, privileges),
-        false,
+      assert!(
+        !acl.is_allowed_any(roles, resources, privileges),
         "Expected `acl.is_allowed_any({:?}, {:?}, {:?}) == {}`",
         roles,
         resources,

--- a/crates/acl/src/simple/async_assertion_resolver.rs
+++ b/crates/acl/src/simple/async_assertion_resolver.rs
@@ -1,0 +1,39 @@
+//! Async resolver trait for conditional assertions.
+//!
+//! [`AsyncAssertionResolver`] is the async counterpart to
+//! [`AssertionResolver`](crate::simple::AssertionResolver): it maps an
+//! [`AssertionKey`](crate::simple::AssertionKey) to a boolean, but awaits the
+//! result. Use it when evaluating an assertion requires I/O (database lookups,
+//! policy services, remote feature flags, etc.).
+//!
+//! This module is only compiled with the `async` feature.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use walrs_acl::simple::{AclBuilder, AsyncAssertionResolver};
+//! use async_trait::async_trait;
+//!
+//! struct Resolver;
+//!
+//! #[async_trait]
+//! impl AsyncAssertionResolver for Resolver {
+//!   async fn evaluate(&self, key: &str) -> bool {
+//!     key == "is_owner"
+//!   }
+//! }
+//! ```
+
+use async_trait::async_trait;
+
+/// Resolves an assertion key to `true` / `false` at check time, asynchronously.
+///
+/// Unknown keys should return `false` (conservative default), mirroring the
+/// sync [`AssertionResolver`](crate::simple::AssertionResolver) contract.
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+#[async_trait]
+pub trait AsyncAssertionResolver: Send + Sync {
+  /// Return `true` if the assertion identified by `key` holds in the current
+  /// context; `false` otherwise (including for unknown keys).
+  async fn evaluate(&self, key: &str) -> bool;
+}

--- a/crates/acl/src/simple/mod.rs
+++ b/crates/acl/src/simple/mod.rs
@@ -2,6 +2,8 @@ pub mod acl;
 pub mod acl_builder;
 pub mod acl_data;
 pub mod assertion_resolver;
+#[cfg(feature = "async")]
+pub mod async_assertion_resolver;
 pub mod privilege_rules;
 pub mod resource_role_rules;
 pub mod role_privilege_rules;
@@ -15,6 +17,8 @@ pub use acl::*;
 pub use acl_builder::*;
 pub use acl_data::*;
 pub use assertion_resolver::*;
+#[cfg(feature = "async")]
+pub use async_assertion_resolver::*;
 pub use privilege_rules::*;
 pub use resource_role_rules::*;
 pub use role_privilege_rules::*;

--- a/crates/acl/tests/async_conditional_assertions_test.rs
+++ b/crates/acl/tests/async_conditional_assertions_test.rs
@@ -1,0 +1,137 @@
+//! Tests for async conditional assertion evaluation (issue #246).
+//!
+//! Exercises [`Acl::is_allowed_with_async`] / [`is_allowed_any_with_async`]
+//! using an in-memory map resolver — no actual I/O needed to verify the
+//! awaited code path works end-to-end.
+
+#![cfg(feature = "async")]
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use walrs_acl::simple::{AclBuilder, AsyncAssertionResolver};
+
+struct MapResolver {
+  table: HashMap<String, bool>,
+}
+
+#[async_trait]
+impl AsyncAssertionResolver for MapResolver {
+  async fn evaluate(&self, key: &str) -> bool {
+    // A real implementation might hit a database here; the `.await` is what
+    // we care about exercising.
+    self.table.get(key).copied().unwrap_or(false)
+  }
+}
+
+fn owner_resolver(owner: bool) -> MapResolver {
+  let mut table = HashMap::new();
+  table.insert("is_owner".to_string(), owner);
+  MapResolver { table }
+}
+
+#[tokio::test]
+async fn allow_if_true_allows_async() -> Result<(), String> {
+  let acl = AclBuilder::new()
+    .add_role("editor", None)?
+    .add_resource("post", None)?
+    .allow_if(
+      Some(&["editor"]),
+      Some(&["post"]),
+      Some(&["edit"]),
+      "is_owner",
+    )?
+    .build()?;
+
+  let resolver = owner_resolver(true);
+  assert!(
+    acl
+      .is_allowed_with_async(Some("editor"), Some("post"), Some("edit"), &resolver)
+      .await
+  );
+  Ok(())
+}
+
+#[tokio::test]
+async fn allow_if_false_denies_async() -> Result<(), String> {
+  let acl = AclBuilder::new()
+    .add_role("editor", None)?
+    .add_resource("post", None)?
+    .allow_if(
+      Some(&["editor"]),
+      Some(&["post"]),
+      Some(&["edit"]),
+      "is_owner",
+    )?
+    .build()?;
+
+  let resolver = owner_resolver(false);
+  assert!(
+    !acl
+      .is_allowed_with_async(Some("editor"), Some("post"), Some("edit"), &resolver)
+      .await
+  );
+  Ok(())
+}
+
+#[tokio::test]
+async fn deny_if_true_denies_async() -> Result<(), String> {
+  let acl = AclBuilder::new()
+    .add_role("user", None)?
+    .add_resource("admin_panel", None)?
+    .allow(Some(&["user"]), Some(&["admin_panel"]), Some(&["access"]))?
+    .deny_if(
+      Some(&["user"]),
+      Some(&["admin_panel"]),
+      Some(&["access"]),
+      "outside_hours",
+    )?
+    .build()?;
+
+  let mut table = HashMap::new();
+  table.insert("outside_hours".to_string(), true);
+  let resolver = MapResolver { table };
+
+  assert!(
+    !acl
+      .is_allowed_with_async(Some("user"), Some("admin_panel"), Some("access"), &resolver)
+      .await
+  );
+  Ok(())
+}
+
+#[tokio::test]
+async fn is_allowed_any_with_async_works() -> Result<(), String> {
+  let acl = AclBuilder::new()
+    .add_role("editor", None)?
+    .add_resource("post", None)?
+    .allow_if(
+      Some(&["editor"]),
+      Some(&["post"]),
+      Some(&["edit"]),
+      "is_owner",
+    )?
+    .build()?;
+
+  let resolver = owner_resolver(true);
+  assert!(
+    acl
+      .is_allowed_any_with_async(
+        Some(&["editor"]),
+        Some(&["post"]),
+        Some(&["edit", "delete"]),
+        &resolver,
+      )
+      .await
+  );
+  assert!(
+    !acl
+      .is_allowed_any_with_async(
+        Some(&["editor"]),
+        Some(&["post"]),
+        Some(&["delete"]),
+        &resolver,
+      )
+      .await
+  );
+  Ok(())
+}


### PR DESCRIPTION
## Summary

- New `AsyncAssertionResolver` trait behind `async` feature flag
- `Acl::is_allowed_with_async` / `is_allowed_any_with_async` mirror `is_allowed_with` / `is_allowed_any_with` semantics, awaiting the resolver
- Integration test exercising the async walk via an in-memory `MapResolver`
- README section under Assertions covering sync vs. async resolver selection
- `[package.metadata.docs.rs]` with `all-features = true` + `doc_cfg` so async items render on docs.rs

## Related

Closes #246

## Testing

- `cargo test -p walrs_acl` (default features) — passes
- `cargo test -p walrs_acl --features async` — passes, new integration test exercises async path (4 tests: allow_if true/false, deny_if true, is_allowed_any_with_async)