### PR TITLE
chore(walrs_acl): #249 conditional assertion polish follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,6 +2099,7 @@ dependencies = [
  "serde_json",
  "walrs_digraph",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/acl/CHANGELOG.md
+++ b/crates/acl/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `walrs_acl` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed (breaking)
+
+- `Rule` no longer implements `Copy`. The new `Rule::AllowIf(AssertionKey)` and
+  `Rule::DenyIf(AssertionKey)` variants carry a `String`, which is not `Copy`,
+  so the enum as a whole cannot be `Copy` either. Downstream code that copied
+  `Rule` values (e.g. `let r = *existing_rule;`) must now use `.clone()`.
+  Introduced in PR #247 (closes #244).

--- a/crates/acl/Cargo.toml
+++ b/crates/acl/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["std"]
 std = ["serde/std", "serde_json/std"]
-wasm = ["wasm-bindgen", "serde-wasm-bindgen", "js-sys"]
+wasm = ["wasm-bindgen", "serde-wasm-bindgen", "js-sys", "web-sys"]
 
 [dependencies]
 walrs_digraph = { path = '../digraph' }
@@ -18,6 +18,7 @@ serde_derive = "1.0.228"
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 js-sys = { version = "0.3", optional = true }
+web-sys = { version = "0.3", optional = true, features = ["console"] }
 
 [dev-dependencies]
 rand = "0.9"

--- a/crates/acl/README.md
+++ b/crates/acl/README.md
@@ -137,6 +137,8 @@ The same rules can be expressed in JSON via the `allow_if` / `deny_if` top-level
 
 **Conservative defaults.** Plain `is_allowed` (no resolver) treats `AllowIf` as **not-allow** and `DenyIf` as **not-deny**: without a resolver we can't evaluate the predicate, so we stay on the safe side for allows and don't synthesise a deny we aren't sure about. An explicit `Deny` still overrides a conditional `AllowIf` even when the resolver says `true`.
 
+**Opposing-family clearing across conditional and unconditional rules.** When a rule is added on the exact same `(role, resource, privilege)` triple as an existing rule in the opposing family, the existing rule is cleared. "Family" groups `Allow` with `AllowIf` and `Deny` with `DenyIf`, so this clearing is symmetric: adding `DenyIf(k)` on a triple that already carries an unconditional `Allow` will *remove* that `Allow`, and vice versa. This is a deliberate divergence from Laminas' ACL semantics (which would keep both rules side-by-side) — the rationale is that the builder models each triple as holding a single authoritative rule, and mixing opposing rules on one triple is usually a mistake. If you need both a conditional and an unconditional grant to coexist, place them on different roles (e.g. unconditional `Allow` on the parent role, `DenyIf` on the child) and rely on inheritance — the `deny_if_false_does_not_deny` test in `tests/conditional_assertions_test.rs` shows this pattern.
+
 ## How it works?
 
 The ACL structure is made up of a `roles`, and a `resources`, symbol graph, and a "nested" `rules` structure [which is used to define, and query-for, "allow" and "deny" rules].

--- a/crates/acl/benchmarks/benchmark_extensive_acl.rs
+++ b/crates/acl/benchmarks/benchmark_extensive_acl.rs
@@ -119,6 +119,13 @@ fn main() -> Result<(), String> {
   println!("=== Conditional assertion path ===");
   run_conditional_benchmark(&acl, &roles, &resources, &privileges, 100_000);
 
+  // Conditional assertion path — mixed allow / allow_if / deny_if rules with a
+  // table-backed resolver that actually looks keys up (follow-up #249). This
+  // surfaces the real cost of resolver dispatch, unlike the always-true
+  // benchmark above which never branches.
+  println!("=== Conditional assertion path (mixed rules + lookup resolver) ===");
+  run_mixed_conditional_benchmark(100_000)?;
+
   println!();
   println!("=== Benchmark Complete ===");
 
@@ -130,6 +137,99 @@ impl walrs_acl::simple::AssertionResolver for AlwaysTrue {
   fn evaluate(&self, _: &str) -> bool {
     true
   }
+}
+
+/// Resolver that looks keys up in a `HashMap`, returning `false` for unknown
+/// keys. Simulates a realistic "facts table" populated per-request.
+struct TableResolver(std::collections::HashMap<String, bool>);
+impl walrs_acl::simple::AssertionResolver for TableResolver {
+  fn evaluate(&self, key: &str) -> bool {
+    self.0.get(key).copied().unwrap_or(false)
+  }
+}
+
+fn run_mixed_conditional_benchmark(iterations: usize) -> Result<(), String> {
+  // Small ACL mixing every rule variant. The `post` resource carries an
+  // unconditional Allow (read), an AllowIf gated on `is_owner` (edit), and a
+  // DenyIf gated on `locked` (publish). The resolver populates both keys so
+  // every check actually branches through the conditional code path.
+  let acl = AclBuilder::new()
+    .add_role("guest", None)?
+    .add_role("user", Some(&["guest"]))?
+    .add_role("editor", Some(&["user"]))?
+    .add_resource("post", None)?
+    .add_resource("admin_panel", None)?
+    .allow(Some(&["editor"]), Some(&["post"]), Some(&["read"]))?
+    .allow_if(
+      Some(&["editor"]),
+      Some(&["post"]),
+      Some(&["edit"]),
+      "is_owner",
+    )?
+    .deny_if(
+      Some(&["editor"]),
+      Some(&["post"]),
+      Some(&["publish"]),
+      "locked",
+    )?
+    .allow(Some(&["guest"]), Some(&["admin_panel"]), Some(&["access"]))?
+    .deny_if(
+      Some(&["user"]),
+      Some(&["admin_panel"]),
+      Some(&["access"]),
+      "outside_hours",
+    )?
+    .build()?;
+
+  let resolver = {
+    let mut m = std::collections::HashMap::new();
+    m.insert("is_owner".to_string(), true);
+    m.insert("locked".to_string(), false);
+    m.insert("outside_hours".to_string(), false);
+    TableResolver(m)
+  };
+
+  // Pre-built query set cycling through the rule variants so each iteration
+  // hits a different path in the engine.
+  let queries: Vec<(&str, &str, &str)> = vec![
+    ("editor", "post", "read"),       // unconditional Allow
+    ("editor", "post", "edit"),       // AllowIf → true
+    ("editor", "post", "publish"),    // DenyIf → false (allowed via fallthrough? no — no Allow)
+    ("user", "admin_panel", "access"), // Allow on parent, DenyIf on child (false)
+    ("guest", "admin_panel", "access"), // Allow direct
+  ];
+
+  let mut rng = rand::rng();
+  let start = Instant::now();
+  let mut allowed_count = 0;
+  let mut denied_count = 0;
+
+  for _ in 0..iterations {
+    let (role, resource, privilege) = *queries.choose(&mut rng).unwrap();
+    if acl.is_allowed_with(Some(role), Some(resource), Some(privilege), &resolver) {
+      allowed_count += 1;
+    } else {
+      denied_count += 1;
+    }
+  }
+
+  let duration = start.elapsed();
+  let avg_time = duration / iterations as u32;
+  let checks_per_sec = iterations as f64 / duration.as_secs_f64();
+
+  println!(
+    "{} is_allowed_with checks (mixed rules, lookup resolver)",
+    iterations
+  );
+  println!("  Total time: {:?}", duration);
+  println!("  Average per check: {:?}", avg_time);
+  println!("  Checks per second: {:.0}", checks_per_sec);
+  println!(
+    "  Results: {} allowed, {} denied",
+    allowed_count, denied_count
+  );
+  println!();
+  Ok(())
 }
 
 fn run_conditional_benchmark(

--- a/crates/acl/src/simple/acl_builder.rs
+++ b/crates/acl/src/simple/acl_builder.rs
@@ -230,6 +230,13 @@ impl AclBuilder {
   /// treated conservatively — `AllowIf` does NOT allow. Pair with explicit
   /// `Allow` if you need an "always-on" fallback.
   ///
+  /// # Errors
+  ///
+  /// Returns `Err` when `privileges` is `None` or an empty slice. Conditional
+  /// rules must target explicit privileges; an "all privileges" conditional
+  /// rule is not representable in [`AclData`](crate::simple::AclData) and would
+  /// fail at serialization time.
+  ///
   /// # Example
   ///
   /// ```rust
@@ -252,6 +259,12 @@ impl AclBuilder {
     privileges: Option<&[&str]>,
     assertion_key: &str,
   ) -> Result<&mut Self, String> {
+    if _is_empty(&privileges) {
+      return Err(
+        "allow_if requires an explicit, non-empty privilege list; \"all privileges\" conditional rules are not representable in AclData"
+          .to_string(),
+      );
+    }
     self._add_rule(
       Rule::AllowIf(assertion_key.to_string()),
       roles,
@@ -271,6 +284,12 @@ impl AclBuilder {
     privileges: Option<&[&str]>,
     assertion_key: &str,
   ) -> Result<&mut Self, String> {
+    if _is_empty(&privileges) {
+      return Err(
+        "deny_if requires an explicit, non-empty privilege list; \"all privileges\" conditional rules are not representable in AclData"
+          .to_string(),
+      );
+    }
     self._add_rule(
       Rule::DenyIf(assertion_key.to_string()),
       roles,
@@ -695,10 +714,14 @@ impl<'a> TryFrom<&'a AclData> for AclBuilder {
     // list is `(privilege_name, assertion_key)` tuples instead of privilege
     // strings; we have to split by assertion_key because one call to
     // `allow_if` / `deny_if` on the builder can only accept one assertion key.
+    //
+    // Use BTreeMap unconditionally so the builder visits assertion keys in a
+    // stable order — this keeps the resulting `AclData` (and therefore the
+    // serialized JSON bytes) deterministic across runs.
     #[cfg(not(feature = "std"))]
     use alloc::collections::BTreeMap as KeyMap;
     #[cfg(feature = "std")]
-    use std::collections::HashMap as KeyMap;
+    use std::collections::BTreeMap as KeyMap;
     let process_conditional_rules = |builder: &mut AclBuilder,
                                      rules: &Vec<(
       String,
@@ -815,10 +838,15 @@ impl TryFrom<&AclBuilder> for AclData {
   type Error = String;
 
   fn try_from(builder: &AclBuilder) -> Result<Self, Self::Error> {
+    // Use BTreeMap unconditionally so that the extracted `AclData` (and any
+    // JSON emitted from it) has a deterministic key order across runs. The
+    // per-resource and per-role maps below are small; the sort cost is
+    // negligible compared to the stability benefit for fixtures, snapshot
+    // tests, and cache keys.
     #[cfg(not(feature = "std"))]
-    use alloc::collections::BTreeMap as HashMap;
+    use alloc::collections::BTreeMap;
     #[cfg(feature = "std")]
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use walrs_digraph::DisymGraphData;
 
@@ -846,7 +874,7 @@ impl TryFrom<&AclBuilder> for AclData {
     let extract_rules = |role_priv_rules: &crate::simple::RolePrivilegeRules,
                          match_rule: &crate::simple::Rule|
      -> Option<Vec<(String, Option<Vec<String>>)>> {
-      let mut role_rules = HashMap::new();
+      let mut role_rules: BTreeMap<String, Option<Vec<String>>> = BTreeMap::new();
 
       // Check "for all roles" rules
       let by_priv_is_empty = role_priv_rules
@@ -915,7 +943,7 @@ impl TryFrom<&AclBuilder> for AclData {
       Option<Vec<(String, Option<Vec<(String, String)>>)>>,
       String,
     > {
-      let mut role_rules: HashMap<String, Option<Vec<(String, String)>>> = HashMap::new();
+      let mut role_rules: BTreeMap<String, Option<Vec<(String, String)>>> = BTreeMap::new();
       let rule_name = if want_allow_if { "allow_if" } else { "deny_if" };
 
       let variant_matches = |rule: &crate::simple::Rule| -> Option<String> {
@@ -972,7 +1000,8 @@ impl TryFrom<&AclBuilder> for AclData {
     };
 
     // Extract allow rules
-    let mut allow_map: HashMap<String, Option<Vec<(String, Option<Vec<String>>)>>> = HashMap::new();
+    let mut allow_map: BTreeMap<String, Option<Vec<(String, Option<Vec<String>>)>>> =
+      BTreeMap::new();
 
     let for_all_allow = extract_rules(
       &builder._rules.for_all_resources,
@@ -996,7 +1025,8 @@ impl TryFrom<&AclBuilder> for AclData {
     };
 
     // Extract deny rules
-    let mut deny_map: HashMap<String, Option<Vec<(String, Option<Vec<String>>)>>> = HashMap::new();
+    let mut deny_map: BTreeMap<String, Option<Vec<(String, Option<Vec<String>>)>>> =
+      BTreeMap::new();
 
     let for_all_deny = extract_rules(
       &builder._rules.for_all_resources,
@@ -1020,8 +1050,8 @@ impl TryFrom<&AclBuilder> for AclData {
     };
 
     // Extract allow_if rules
-    let mut allow_if_map: HashMap<String, Option<Vec<(String, Option<Vec<(String, String)>>)>>> =
-      HashMap::new();
+    let mut allow_if_map: BTreeMap<String, Option<Vec<(String, Option<Vec<(String, String)>>)>>> =
+      BTreeMap::new();
 
     let for_all_allow_if = extract_conditional_rules("*", &builder._rules.for_all_resources, true)?;
     if for_all_allow_if.is_some() {
@@ -1042,8 +1072,8 @@ impl TryFrom<&AclBuilder> for AclData {
     };
 
     // Extract deny_if rules
-    let mut deny_if_map: HashMap<String, Option<Vec<(String, Option<Vec<(String, String)>>)>>> =
-      HashMap::new();
+    let mut deny_if_map: BTreeMap<String, Option<Vec<(String, Option<Vec<(String, String)>>)>>> =
+      BTreeMap::new();
 
     let for_all_deny_if = extract_conditional_rules("*", &builder._rules.for_all_resources, false)?;
     if for_all_deny_if.is_some() {

--- a/crates/acl/src/simple/acl_builder.rs
+++ b/crates/acl/src/simple/acl_builder.rs
@@ -956,10 +956,11 @@ impl TryFrom<&AclBuilder> for AclData {
 
       // Check "for all roles" per-privilege rules
       if let Some(ref by_priv) = role_priv_rules.for_all_roles.by_privilege_id {
-        let matches: Vec<(String, String)> = by_priv
+        let mut matches: Vec<(String, String)> = by_priv
           .iter()
           .filter_map(|(pname, rule)| variant_matches(rule).map(|k| (pname.to_string(), k)))
           .collect();
+        matches.sort();
         if !matches.is_empty() {
           role_rules.insert("*".to_string(), Some(matches));
         }
@@ -975,10 +976,11 @@ impl TryFrom<&AclBuilder> for AclData {
       if let Some(ref by_role) = role_priv_rules.by_role_id {
         for (role, priv_rules) in by_role.iter() {
           if let Some(ref by_priv) = priv_rules.by_privilege_id {
-            let matches: Vec<(String, String)> = by_priv
+            let mut matches: Vec<(String, String)> = by_priv
               .iter()
               .filter_map(|(pname, rule)| variant_matches(rule).map(|k| (pname.to_string(), k)))
               .collect();
+            matches.sort();
             if !matches.is_empty() {
               role_rules.insert(role.clone(), Some(matches));
             }

--- a/crates/acl/src/simple/acl_builder.rs
+++ b/crates/acl/src/simple/acl_builder.rs
@@ -885,11 +885,12 @@ impl TryFrom<&AclBuilder> for AclData {
 
       if !by_priv_is_empty {
         if let Some(ref by_priv) = role_priv_rules.for_all_roles.by_privilege_id {
-          let matching_privileges: Vec<String> = by_priv
+          let mut matching_privileges: Vec<String> = by_priv
             .iter()
             .filter(|(_, rule)| *rule == match_rule)
             .map(|(k, _)| k.to_string())
             .collect();
+          matching_privileges.sort();
           if !matching_privileges.is_empty() {
             role_rules.insert("*".to_string(), Some(matching_privileges));
           }
@@ -911,11 +912,12 @@ impl TryFrom<&AclBuilder> for AclData {
 
           if !role_by_priv_is_empty {
             if let Some(ref by_priv) = priv_rules.by_privilege_id {
-              let matching_privileges: Vec<String> = by_priv
+              let mut matching_privileges: Vec<String> = by_priv
                 .iter()
                 .filter(|(_, rule)| *rule == match_rule)
                 .map(|(k, _)| k.to_string())
                 .collect();
+              matching_privileges.sort();
               if !matching_privileges.is_empty() {
                 role_rules.insert(role.clone(), Some(matching_privileges));
               }

--- a/crates/acl/src/wasm.rs
+++ b/crates/acl/src/wasm.rs
@@ -13,7 +13,9 @@ use wasm_bindgen::prelude::*;
 /// The JS callback receives the assertion key (a string) and should return a
 /// JavaScript boolean value: `true` grants the conditional rule, while `false`
 /// denies it. Unknown keys, exceptions, and non-boolean returns are all
-/// treated conservatively as `false`.
+/// treated conservatively as `false`; exceptions and non-boolean returns are
+/// additionally surfaced via `console.warn` so misbehaving resolvers aren't
+/// silent.
 struct JsResolver {
   f: Function,
 }
@@ -22,12 +24,33 @@ impl AssertionResolver for JsResolver {
   fn evaluate(&self, key: &str) -> bool {
     let this = JsValue::NULL;
     let arg = JsValue::from_str(key);
-    self
-      .f
-      .call1(&this, &arg)
-      .ok()
-      .and_then(|v| v.as_bool())
-      .unwrap_or(false)
+    match self.f.call1(&this, &arg) {
+      Ok(v) => match v.as_bool() {
+        Some(b) => b,
+        None => {
+          // Non-boolean return: warn once per call so surprising resolver
+          // behavior (e.g. forgetting to `return`) is visible in the JS
+          // console. Falls back to the conservative `false` verdict.
+          web_sys::console::warn_1(&JsValue::from_str(&format!(
+            "walrs_acl: assertion resolver for key '{}' returned a non-boolean value; treating as false",
+            key
+          )));
+          false
+        }
+      },
+      Err(e) => {
+        // JS exception: surface it via console.warn so callers can see the
+        // error message instead of silently denying.
+        web_sys::console::warn_2(
+          &JsValue::from_str(&format!(
+            "walrs_acl: assertion resolver for key '{}' threw; treating as false",
+            key
+          )),
+          &e,
+        );
+        false
+      }
+    }
   }
 }
 

--- a/crates/acl/tests/acl_builder_test.rs
+++ b/crates/acl/tests/acl_builder_test.rs
@@ -2061,15 +2061,19 @@ fn test_acl_data_conditional_rule_without_role_entries_returns_error() {
 
 #[test]
 fn test_acl_builder_to_acl_data_conditional_all_privileges_returns_error() -> Result<(), String> {
+  // Conditional rules with `privileges = None` are rejected at the builder
+  // call site (see the `allow_if` / `deny_if` guard in
+  // `crates/acl/src/simple/acl_builder.rs`). This test pins that early
+  // rejection so the invalid state can never reach serialization.
   let mut builder = AclBuilder::new();
   builder.add_role("editor", None)?;
   builder.add_resource("post", None)?;
-  builder.allow_if(Some(&["editor"]), Some(&["post"]), None, "is_owner")?;
 
-  let err = AclData::try_from(&builder)
-    .expect_err("all-privileges conditional rules are not representable");
-  assert!(err.contains("cannot serialize allow_if rule"));
-  assert!(err.contains("applies to all privileges"));
+  let err = builder
+    .allow_if(Some(&["editor"]), Some(&["post"]), None, "is_owner")
+    .expect_err("all-privileges conditional rules must be rejected at the builder");
+  assert!(err.contains("allow_if"));
+  assert!(err.contains("privilege"));
 
   Ok(())
 }

--- a/crates/acl/tests/conditional_assertions_test.rs
+++ b/crates/acl/tests/conditional_assertions_test.rs
@@ -423,12 +423,17 @@ fn deny_if_without_privileges_errors() {
 fn acl_data_round_trip_bytes_are_deterministic() -> Result<(), Box<dyn std::error::Error>> {
   // Build an ACL with enough conditional rules across multiple resources and
   // privileges that any non-deterministic map iteration would surface as a
-  // byte-difference between two consecutive serializations.
-  let acl_data = AclData::try_from(&mut File::open("./test-fixtures/example-acl-conditional.json")?)?;
-  let builder = AclBuilder::try_from(&acl_data)?;
+  // byte-difference between two fresh parses/builds.
+  let first_acl_data =
+    AclData::try_from(&mut File::open("./test-fixtures/example-acl-conditional.json")?)?;
+  let first_builder = AclBuilder::try_from(&first_acl_data)?;
 
-  let first = serde_json::to_string(&AclData::try_from(&builder)?)?;
-  let second = serde_json::to_string(&AclData::try_from(&builder)?)?;
+  let second_acl_data =
+    AclData::try_from(&mut File::open("./test-fixtures/example-acl-conditional.json")?)?;
+  let second_builder = AclBuilder::try_from(&second_acl_data)?;
+
+  let first = serde_json::to_string(&AclData::try_from(&first_builder)?)?;
+  let second = serde_json::to_string(&AclData::try_from(&second_builder)?)?;
 
   assert_eq!(
     first, second,

--- a/crates/acl/tests/conditional_assertions_test.rs
+++ b/crates/acl/tests/conditional_assertions_test.rs
@@ -370,3 +370,101 @@ fn is_allowed_any_with_works() -> Result<(), String> {
   assert!(!acl.is_allowed_any_with(Some(&["editor"]), Some(&["post"]), Some(&["delete"]), &r,));
   Ok(())
 }
+
+#[test]
+fn allow_if_without_privileges_errors() {
+  // AclData cannot represent a conditional rule that applies to "all
+  // privileges", so the builder should reject it up-front with a clear
+  // error rather than failing later at serialization time.
+  let mut builder = AclBuilder::new();
+  let err = builder
+    .add_role("editor", None)
+    .and_then(|b| b.add_resource("post", None))
+    .and_then(|b| b.allow_if(Some(&["editor"]), Some(&["post"]), None, "is_owner"))
+    .expect_err("allow_if with privileges=None must fail");
+  assert!(
+    err.contains("allow_if"),
+    "error should name the builder method: {err}"
+  );
+  assert!(
+    err.contains("privilege"),
+    "error should mention the missing privilege list: {err}"
+  );
+
+  // Empty slice is treated the same as `None` for this guard.
+  let mut builder = AclBuilder::new();
+  let err = builder
+    .add_role("editor", None)
+    .and_then(|b| b.add_resource("post", None))
+    .and_then(|b| b.allow_if(Some(&["editor"]), Some(&["post"]), Some(&[]), "is_owner"))
+    .expect_err("allow_if with empty privileges must fail");
+  assert!(err.contains("allow_if"));
+}
+
+#[test]
+fn deny_if_without_privileges_errors() {
+  let mut builder = AclBuilder::new();
+  let err = builder
+    .add_role("user", None)
+    .and_then(|b| b.add_resource("admin_panel", None))
+    .and_then(|b| b.deny_if(Some(&["user"]), Some(&["admin_panel"]), None, "closed"))
+    .expect_err("deny_if with privileges=None must fail");
+  assert!(
+    err.contains("deny_if"),
+    "error should name the builder method: {err}"
+  );
+  assert!(
+    err.contains("privilege"),
+    "error should mention the missing privilege list: {err}"
+  );
+}
+
+#[test]
+fn acl_data_round_trip_bytes_are_deterministic() -> Result<(), Box<dyn std::error::Error>> {
+  // Build an ACL with enough conditional rules across multiple resources and
+  // privileges that any non-deterministic map iteration would surface as a
+  // byte-difference between two consecutive serializations.
+  let acl_data = AclData::try_from(&mut File::open("./test-fixtures/example-acl-conditional.json")?)?;
+  let builder = AclBuilder::try_from(&acl_data)?;
+
+  let first = serde_json::to_string(&AclData::try_from(&builder)?)?;
+  let second = serde_json::to_string(&AclData::try_from(&builder)?)?;
+
+  assert_eq!(
+    first, second,
+    "AclData -> JSON must be byte-identical across runs"
+  );
+  Ok(())
+}
+
+#[test]
+fn deny_if_on_parent_role_does_not_block_child_allow() -> Result<(), String> {
+  // The engine's `has_explicit_deny` short-circuit only looks at rules
+  // attached directly to the queried role/resource — it does NOT walk the
+  // role-inheritance graph. So a `DenyIf` placed on a parent role must not
+  // override an explicit `Allow` placed directly on the child role, even when
+  // the resolver would fire the parent's DenyIf.
+  let acl = AclBuilder::new()
+    .add_role("user", None)?
+    .add_role("editor", Some(&["user"]))?
+    .add_resource("post", None)?
+    // Conditional deny on the parent role.
+    .deny_if(
+      Some(&["user"]),
+      Some(&["post"]),
+      Some(&["edit"]),
+      "locked",
+    )?
+    // Explicit allow directly on the child role.
+    .allow(Some(&["editor"]), Some(&["post"]), Some(&["edit"]))?
+    .build()?;
+
+  // Resolver says the parent's DenyIf would fire, but the child has a direct
+  // Allow, so the check must return true.
+  let resolver = StaticResolver(&[("locked", true)]);
+  assert!(
+    acl.is_allowed_with(Some("editor"), Some("post"), Some("edit"), &resolver),
+    "direct Allow on child role must not be blocked by inherited DenyIf on parent"
+  );
+  Ok(())
+}


### PR DESCRIPTION
## Summary

Follow-up polish on the conditional assertions landed in PR #247. Addresses all seven items from issue #249 in a single commit.

## Items addressed

1. **"DenyIf clears unconditional Allow" semantic.** Went with option (b): kept current behavior (opposing-family clearing affects both conditional and unconditional rules on the same triple) and documented the divergence from Laminas' ACL in the `Assertions` section of `crates/acl/README.md`. Points readers at the `deny_if_false_does_not_deny` test for the "put them on different roles" pattern when coexistence is required.
2. **Reject `allow_if` / `deny_if` with no privileges.** Guard added at the top of `allow_if` / `deny_if` in `crates/acl/src/simple/acl_builder.rs`; error names the method and mentions the missing privilege list. Two new tests (`allow_if_without_privileges_errors`, `deny_if_without_privileges_errors`) pin the new early-fail path. Updated the existing `test_acl_builder_to_acl_data_conditional_all_privileges_returns_error` in `acl_builder_test.rs` to assert against the builder call (previously asserted against `AclData::try_from(&AclBuilder)` — still a valid defensive check if someone hand-constructs rules via `from_parts`, but no longer reachable through the normal fluent API).
3. **Deterministic JSON output.** Replaced `HashMap` with `BTreeMap` in both the `process_conditional_rules` helper (`KeyMap`) in `AclBuilder::try_from(&AclData)` and every extraction map in `AclData::try_from(&AclBuilder)` (including `allow_map` / `deny_map` / `allow_if_map` / `deny_if_map` and the inner `role_rules` inside both `extract_rules` and `extract_conditional_rules`). Added `acl_data_round_trip_bytes_are_deterministic` in `conditional_assertions_test.rs` which serializes twice and asserts byte-for-byte equality.
4. **`Rule` lost `Copy` — documented.** Added `crates/acl/CHANGELOG.md` with an `[Unreleased]` entry noting the semver-breaking change and the reason (`AllowIf(String)` / `DenyIf(String)`).
5. **WASM resolver error visibility.** `JsResolver::evaluate` now surfaces both JS exceptions and non-boolean returns via `web_sys::console::warn_1` / `warn_2`. Added `web-sys = { optional, features = ["console"] }` to `Cargo.toml` and pulled it into the existing `wasm` feature. Falls back to the conservative `false` verdict either way. Verified with `cargo build --target wasm32-unknown-unknown --features wasm`.
6. **Missing test for parent `DenyIf` + child `Allow`.** Added `deny_if_on_parent_role_does_not_block_child_allow` in `conditional_assertions_test.rs` — pins that `has_explicit_deny` only short-circuits on the direct role/resource, so an inherited `DenyIf` doesn't override an explicit `Allow` on the child.
7. **Conditional benchmark that actually fires.** Kept the existing `run_conditional_benchmark` (always-true resolver, no conditional rules) as-is and added `run_mixed_conditional_benchmark` alongside it in `benchmarks/benchmark_extensive_acl.rs`. New scenario builds an ACL mixing `Allow` / `AllowIf` / `DenyIf`, populates a `HashMap<String, bool>`-backed `TableResolver`, and cycles through queries that hit each rule variant.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --fix --allow-dirty --manifest-path Cargo.toml -- -D warnings` — clean
- `cargo build --workspace --manifest-path Cargo.toml` — clean
- `cargo test --workspace --manifest-path Cargo.toml` — all green
- `walrs_acl` specifically: **245 tests passing** (up from 235 in PR #247: +4 new tests here, plus +6 from the separate PR #251 merged into main).
- `cargo build --target wasm32-unknown-unknown --no-default-features --features wasm` — clean (web-sys + console warnings compile).

## Test plan

- [x] New unit tests for `allow_if` / `deny_if` early-failure
- [x] Byte-equality round-trip test for determinism
- [x] Parent-DenyIf-doesn't-block-child-Allow test
- [x] Updated existing pinned test to reflect new early-fail semantics
- [x] New mixed-rules benchmark compiles and runs under `cargo run --release --example benchmark_extensive_acl`

Closes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)