### PR TITLE
feat(walrs_fieldset_derive): #260 structured cross-field rule variants

### DIFF
--- a/crates/fieldfilter/Cargo.toml
+++ b/crates/fieldfilter/Cargo.toml
@@ -34,3 +34,7 @@ required-features = ["derive"]
 [[example]]
 name = "derive_nested"
 required-features = ["derive"]
+
+[[example]]
+name = "derive_cross_validate"
+required-features = ["derive"]

--- a/crates/fieldfilter/examples/derive_cross_validate.rs
+++ b/crates/fieldfilter/examples/derive_cross_validate.rs
@@ -1,0 +1,72 @@
+//! Demonstrates structured `#[cross_validate(...)]` variants on
+//! `#[derive(Fieldset)]`.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example derive_cross_validate -p walrs_fieldfilter --features derive
+//! ```
+
+use walrs_fieldfilter::{DeriveFieldset, Fieldset};
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(fields_equal(password, confirm))]
+#[cross_validate(required_if(shipping_street, country = "us"))]
+struct Checkout {
+  #[validate(required, min_length = 8)]
+  password: String,
+  #[validate(required)]
+  confirm: String,
+  #[validate(required)]
+  country: String,
+  shipping_street: Option<String>,
+}
+
+fn report(label: &str, form: &Checkout) {
+  match form.validate() {
+    Ok(()) => println!("[{label}] OK"),
+    Err(v) => {
+      println!("[{label}] {} violation(s):", v.len());
+      for (field, vs) in v.iter() {
+        let key = if field.is_empty() { "<form>" } else { field };
+        for violation in vs.iter() {
+          println!("  - {key}: {}", violation.message());
+        }
+      }
+    }
+  }
+}
+
+fn main() {
+  // Happy path: passwords match; country is non-US, so shipping not required.
+  report(
+    "happy",
+    &Checkout {
+      password: "supersecret".into(),
+      confirm: "supersecret".into(),
+      country: "ca".into(),
+      shipping_street: None,
+    },
+  );
+
+  // fields_equal violation.
+  report(
+    "mismatch",
+    &Checkout {
+      password: "supersecret".into(),
+      confirm: "different!".into(),
+      country: "ca".into(),
+      shipping_street: None,
+    },
+  );
+
+  // required_if violation: country = "us" but shipping_street missing.
+  report(
+    "missing-shipping",
+    &Checkout {
+      password: "supersecret".into(),
+      confirm: "supersecret".into(),
+      country: "us".into(),
+      shipping_street: None,
+    },
+  );
+}

--- a/crates/fieldfilter/tests/derive_cross_validate_structured.rs
+++ b/crates/fieldfilter/tests/derive_cross_validate_structured.rs
@@ -267,3 +267,69 @@ fn required_if_int_condition_mismatch() {
   };
   assert!(form.validate().is_ok());
 }
+
+// =========================================================================
+// presence checks treat whitespace-only strings as empty
+// =========================================================================
+//
+// `walrs_validation::IsEmpty for String` and `ValueExt::is_empty_value()`
+// both treat `"   "` as empty, so the typed-derive cross-field rules must
+// agree. These tests pin that contract: a whitespace-only String /
+// Option<String> behaves the same as an empty / `None` value.
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(one_of_required(email, phone))]
+struct ContactWs {
+  email: Option<String>,
+  phone: Option<String>,
+}
+
+#[test]
+fn one_of_required_treats_whitespace_only_as_empty() {
+  let form = ContactWs {
+    email: Some("   ".into()),
+    phone: Some("\t\n".into()),
+  };
+  let err = form
+    .validate()
+    .expect_err("whitespace-only fields should not satisfy one_of_required");
+  assert!(err.form_violations().is_some());
+}
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(required_if(addr, country = "us"))]
+struct CheckoutWs {
+  country: String,
+  addr: Option<String>,
+}
+
+#[test]
+fn required_if_treats_whitespace_only_addr_as_missing() {
+  let form = CheckoutWs {
+    country: "us".into(),
+    addr: Some("   ".into()),
+  };
+  let err = form
+    .validate()
+    .expect_err("whitespace-only addr should be treated as missing");
+  assert!(err.form_violations().is_some());
+}
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(dependent_required(trigger = ship, dependents(street, zip)))]
+struct ShipFormWs {
+  ship: String,
+  street: Option<String>,
+  zip: Option<String>,
+}
+
+#[test]
+fn dependent_required_whitespace_only_trigger_does_not_fire() {
+  // A whitespace-only trigger is "empty", so the dependents check must skip.
+  let form = ShipFormWs {
+    ship: "   ".into(),
+    street: None,
+    zip: None,
+  };
+  assert!(form.validate().is_ok());
+}

--- a/crates/fieldfilter/tests/derive_cross_validate_structured.rs
+++ b/crates/fieldfilter/tests/derive_cross_validate_structured.rs
@@ -1,0 +1,269 @@
+//! Integration tests for structured `#[cross_validate(...)]` variants on
+//! `#[derive(Fieldset)]`.
+
+#![cfg(feature = "derive")]
+
+use walrs_fieldfilter::{DeriveFieldset, Fieldset};
+
+// =========================================================================
+// fields_equal
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(fields_equal(password, confirm))]
+struct PwForm {
+  password: String,
+  confirm: String,
+}
+
+#[test]
+fn fields_equal_pass() {
+  let form = PwForm {
+    password: "hunter2".into(),
+    confirm: "hunter2".into(),
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn fields_equal_fail() {
+  let form = PwForm {
+    password: "hunter2".into(),
+    confirm: "different".into(),
+  };
+  let err = form.validate().unwrap_err();
+  let form_v = err.form_violations().expect("form violations expected");
+  assert!(form_v[0].message().contains("password"));
+  assert!(form_v[0].message().contains("confirm"));
+}
+
+// =========================================================================
+// required_if (string condition)
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(required_if(shipping_street, country = "us"))]
+struct CheckoutStr {
+  country: String,
+  shipping_street: Option<String>,
+}
+
+#[test]
+fn required_if_str_condition_met_field_present() {
+  let form = CheckoutStr {
+    country: "us".into(),
+    shipping_street: Some("123 Main".into()),
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn required_if_str_condition_met_field_missing() {
+  let form = CheckoutStr {
+    country: "us".into(),
+    shipping_street: None,
+  };
+  let err = form.validate().unwrap_err();
+  assert!(err.form_violations().is_some());
+}
+
+#[test]
+fn required_if_str_condition_not_met() {
+  let form = CheckoutStr {
+    country: "ca".into(),
+    shipping_street: None,
+  };
+  assert!(form.validate().is_ok());
+}
+
+// =========================================================================
+// required_unless (bool condition)
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(required_unless(billing, same_as_shipping = true))]
+struct CheckoutBool {
+  same_as_shipping: bool,
+  billing: Option<String>,
+}
+
+#[test]
+fn required_unless_bool_condition_met_skips_check() {
+  let form = CheckoutBool {
+    same_as_shipping: true,
+    billing: None,
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn required_unless_bool_condition_not_met_field_missing() {
+  let form = CheckoutBool {
+    same_as_shipping: false,
+    billing: None,
+  };
+  let err = form.validate().unwrap_err();
+  assert!(err.form_violations().is_some());
+}
+
+#[test]
+fn required_unless_bool_condition_not_met_field_present() {
+  let form = CheckoutBool {
+    same_as_shipping: false,
+    billing: Some("123 Main".into()),
+  };
+  assert!(form.validate().is_ok());
+}
+
+// =========================================================================
+// one_of_required
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(one_of_required(email, phone))]
+struct Contact {
+  email: Option<String>,
+  phone: Option<String>,
+}
+
+#[test]
+fn one_of_required_pass_email() {
+  let form = Contact {
+    email: Some("a@b.c".into()),
+    phone: None,
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn one_of_required_pass_phone() {
+  let form = Contact {
+    email: None,
+    phone: Some("555".into()),
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn one_of_required_fail_neither() {
+  let form = Contact {
+    email: None,
+    phone: None,
+  };
+  let err = form.validate().unwrap_err();
+  assert!(err.form_violations().is_some());
+}
+
+// =========================================================================
+// mutually_exclusive
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(mutually_exclusive(credit_card, paypal))]
+struct Payment {
+  credit_card: Option<String>,
+  paypal: Option<String>,
+}
+
+#[test]
+fn mutually_exclusive_pass_neither() {
+  let form = Payment {
+    credit_card: None,
+    paypal: None,
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn mutually_exclusive_pass_one() {
+  let form = Payment {
+    credit_card: Some("1234".into()),
+    paypal: None,
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn mutually_exclusive_fail_both() {
+  let form = Payment {
+    credit_card: Some("1234".into()),
+    paypal: Some("a@b.c".into()),
+  };
+  let err = form.validate().unwrap_err();
+  assert!(err.form_violations().is_some());
+}
+
+// =========================================================================
+// dependent_required
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(dependent_required(trigger = ship, dependents(street, zip)))]
+struct ShipForm {
+  ship: Option<String>,
+  street: Option<String>,
+  zip: Option<String>,
+}
+
+#[test]
+fn dependent_required_pass_no_trigger() {
+  let form = ShipForm {
+    ship: None,
+    street: None,
+    zip: None,
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn dependent_required_pass_trigger_with_deps() {
+  let form = ShipForm {
+    ship: Some("yes".into()),
+    street: Some("123 Main".into()),
+    zip: Some("90210".into()),
+  };
+  assert!(form.validate().is_ok());
+}
+
+#[test]
+fn dependent_required_fail_trigger_missing_deps() {
+  let form = ShipForm {
+    ship: Some("yes".into()),
+    street: None,
+    zip: None,
+  };
+  let err = form.validate().unwrap_err();
+  let form_v = err.form_violations().expect("expected dependents missing");
+  // both `street` and `zip` should be reported
+  assert_eq!(form_v.len(), 2);
+}
+
+// =========================================================================
+// integer condition
+// =========================================================================
+
+#[derive(Debug, DeriveFieldset)]
+#[cross_validate(required_if(license, age = 18))]
+struct AgeForm {
+  age: i32,
+  license: Option<String>,
+}
+
+#[test]
+fn required_if_int_condition_match() {
+  let form = AgeForm {
+    age: 18,
+    license: None,
+  };
+  let err = form.validate().unwrap_err();
+  assert!(err.form_violations().is_some());
+}
+
+#[test]
+fn required_if_int_condition_mismatch() {
+  let form = AgeForm {
+    age: 21,
+    license: None,
+  };
+  assert!(form.validate().is_ok());
+}

--- a/crates/fieldset_derive/src/gen_validate.rs
+++ b/crates/fieldset_derive/src/gen_validate.rs
@@ -1,37 +1,238 @@
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::Ident;
 
-use crate::parse::{FieldInfo, FieldType, NumericLit, OneOfItem, ValidateAttr};
+use crate::parse::{
+  ConditionLiteral, CrossValidateRule, FieldInfo, FieldType, NumericLit, OneOfItem, ValidateAttr,
+};
 
 /// Generate the body of `fn validate(&self) -> Result<(), FieldsetViolations>`.
 pub fn gen_validate(
   fields: &[FieldInfo],
-  cross_fns: &[syn::Path],
+  cross_rules: &[CrossValidateRule],
   struct_break_on_failure: bool,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
   let field_checks: Vec<TokenStream> = fields
     .iter()
     .filter(|f| !f.validations.is_empty() || f.is_nested_validate)
     .map(|f| gen_field_validate(f, struct_break_on_failure))
     .collect();
 
-  let cross_checks: Vec<TokenStream> = cross_fns
+  let cross_checks: Vec<TokenStream> = cross_rules
     .iter()
-    .map(|path| {
-      quote! {
-        if let Err(violation) = #path(&self) {
-          violations.add_form_violation(violation);
-        }
-      }
-    })
-    .collect();
+    .map(|rule| gen_cross_validate(rule, fields))
+    .collect::<syn::Result<Vec<_>>>()?;
 
-  quote! {
+  Ok(quote! {
     fn validate(&self) -> ::core::result::Result<(), walrs_validation::FieldsetViolations> {
       let mut violations = walrs_validation::FieldsetViolations::new();
       #(#field_checks)*
       #(#cross_checks)*
       violations.into()
+    }
+  })
+}
+
+/// Find a field by ident; error if missing. Returns its type for codegen decisions.
+fn lookup_field<'a>(fields: &'a [FieldInfo], name: &Ident) -> syn::Result<&'a FieldInfo> {
+  fields.iter().find(|f| &f.ident == name).ok_or_else(|| {
+    syn::Error::new(
+      name.span(),
+      format!("cross_validate references unknown field `{name}`"),
+    )
+  })
+}
+
+/// Emit an expression of type `bool` that is `true` when `self.<field>` carries a value.
+///
+/// - `Option<T>` → `self.field.is_some()` (and for Option<String>, also non-empty)
+/// - `String` → `!self.field.is_empty()`
+/// - other scalars (numeric/bool/char) → always `true`
+fn emit_has_value(field: &FieldInfo) -> TokenStream {
+  let name = &field.ident;
+  match &field.ty {
+    FieldType::String => quote! { !self.#name.is_empty() },
+    FieldType::OptionString => {
+      quote! { self.#name.as_ref().map(|s| !s.is_empty()).unwrap_or(false) }
+    }
+    FieldType::OptionBool
+    | FieldType::OptionChar
+    | FieldType::OptionNumeric(_)
+    | FieldType::OptionOther(_) => quote! { self.#name.is_some() },
+    _ => quote! { true },
+  }
+}
+
+/// Emit an expression of type `bool` that compares `self.<field>` against `lit`.
+fn emit_eq_literal(field: &FieldInfo, lit: &ConditionLiteral) -> TokenStream {
+  let name = &field.ident;
+  match (&field.ty, lit) {
+    (FieldType::String, ConditionLiteral::Str(s)) => quote! { self.#name == #s },
+    (FieldType::OptionString, ConditionLiteral::Str(s)) => {
+      quote! { self.#name.as_deref() == ::core::option::Option::Some(#s) }
+    }
+    (FieldType::Bool, ConditionLiteral::Bool(b)) => quote! { self.#name == #b },
+    (FieldType::OptionBool, ConditionLiteral::Bool(b)) => {
+      quote! { self.#name == ::core::option::Option::Some(#b) }
+    }
+    (FieldType::Numeric(_), ConditionLiteral::Int(v)) => {
+      let lit = proc_macro2::Literal::i128_unsuffixed(*v);
+      quote! { self.#name == #lit }
+    }
+    (FieldType::OptionNumeric(_), ConditionLiteral::Int(v)) => {
+      let lit = proc_macro2::Literal::i128_unsuffixed(*v);
+      quote! { self.#name == ::core::option::Option::Some(#lit) }
+    }
+    // Fallback: fall through to direct equality and let rustc surface a type
+    // mismatch at the call site rather than silently codegen the wrong thing.
+    (_, ConditionLiteral::Str(s)) => quote! { self.#name == #s },
+    (_, ConditionLiteral::Bool(b)) => quote! { self.#name == #b },
+    (_, ConditionLiteral::Int(v)) => {
+      let lit = proc_macro2::Literal::i128_unsuffixed(*v);
+      quote! { self.#name == #lit }
+    }
+  }
+}
+
+fn gen_cross_validate(rule: &CrossValidateRule, fields: &[FieldInfo]) -> syn::Result<TokenStream> {
+  match rule {
+    CrossValidateRule::Custom(path) => Ok(quote! {
+      if let Err(violation) = #path(&self) {
+        violations.add_form_violation(violation);
+      }
+    }),
+    CrossValidateRule::FieldsEqual { field_a, field_b } => {
+      let _ = lookup_field(fields, field_a)?;
+      let _ = lookup_field(fields, field_b)?;
+      let a_str = field_a.to_string();
+      let b_str = field_b.to_string();
+      Ok(quote! {
+        if self.#field_a != self.#field_b {
+          violations.add_form_violation(walrs_validation::Violation::new(
+            walrs_validation::ViolationType::NotEqual,
+            ::std::format!("FieldsEqual: {} and {} must be equal", #a_str, #b_str),
+          ));
+        }
+      })
+    }
+    CrossValidateRule::RequiredIf {
+      field,
+      condition_field,
+      condition,
+    } => {
+      let field_info = lookup_field(fields, field)?;
+      let cond_info = lookup_field(fields, condition_field)?;
+      let has_value = emit_has_value(field_info);
+      let cond_check = emit_eq_literal(cond_info, condition);
+      let f_str = field.to_string();
+      let c_str = condition_field.to_string();
+      Ok(quote! {
+        if (#cond_check) && !(#has_value) {
+          violations.add_form_violation(walrs_validation::Violation::new(
+            walrs_validation::ViolationType::ValueMissing,
+            ::std::format!(
+              "RequiredIf: {} is required when condition is met on {}",
+              #f_str, #c_str
+            ),
+          ));
+        }
+      })
+    }
+    CrossValidateRule::RequiredUnless {
+      field,
+      condition_field,
+      condition,
+    } => {
+      let field_info = lookup_field(fields, field)?;
+      let cond_info = lookup_field(fields, condition_field)?;
+      let has_value = emit_has_value(field_info);
+      let cond_check = emit_eq_literal(cond_info, condition);
+      let f_str = field.to_string();
+      let c_str = condition_field.to_string();
+      Ok(quote! {
+        if !(#cond_check) && !(#has_value) {
+          violations.add_form_violation(walrs_validation::Violation::new(
+            walrs_validation::ViolationType::ValueMissing,
+            ::std::format!(
+              "RequiredUnless: {} is required unless condition is met on {}",
+              #f_str, #c_str
+            ),
+          ));
+        }
+      })
+    }
+    CrossValidateRule::OneOfRequired { fields: names } => {
+      let checks: Vec<TokenStream> = names
+        .iter()
+        .map(|n| lookup_field(fields, n).map(emit_has_value))
+        .collect::<syn::Result<_>>()?;
+      let names_csv = names
+        .iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+      Ok(quote! {
+        if !((#(#checks)||*)) {
+          violations.add_form_violation(walrs_validation::Violation::new(
+            walrs_validation::ViolationType::ValueMissing,
+            ::std::format!("OneOfRequired: At least one of {} is required", #names_csv),
+          ));
+        }
+      })
+    }
+    CrossValidateRule::MutuallyExclusive { fields: names } => {
+      let checks: Vec<TokenStream> = names
+        .iter()
+        .map(|n| lookup_field(fields, n).map(emit_has_value))
+        .collect::<syn::Result<_>>()?;
+      let names_csv = names
+        .iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+      Ok(quote! {
+        {
+          let __filled: usize = 0 #(+ if #checks { 1 } else { 0 })*;
+          if __filled > 1 {
+            violations.add_form_violation(walrs_validation::Violation::new(
+              walrs_validation::ViolationType::CustomError,
+              ::std::format!("MutuallyExclusive: Only one of {} can have a value", #names_csv),
+            ));
+          }
+        }
+      })
+    }
+    CrossValidateRule::DependentRequired {
+      trigger,
+      dependents,
+    } => {
+      let trigger_info = lookup_field(fields, trigger)?;
+      let trigger_check = emit_has_value(trigger_info);
+      let dep_arms: Vec<TokenStream> = dependents
+        .iter()
+        .map(|n| {
+          let info = lookup_field(fields, n)?;
+          let has = emit_has_value(info);
+          let n_str = n.to_string();
+          let t_str = trigger.to_string();
+          Ok(quote! {
+            if !(#has) {
+              violations.add_form_violation(walrs_validation::Violation::new(
+                walrs_validation::ViolationType::ValueMissing,
+                ::std::format!(
+                  "DependentRequired: {} is required when {} is provided",
+                  #n_str, #t_str
+                ),
+              ));
+            }
+          })
+        })
+        .collect::<syn::Result<_>>()?;
+      Ok(quote! {
+        if #trigger_check {
+          #(#dep_arms)*
+        }
+      })
     }
   }
 }

--- a/crates/fieldset_derive/src/gen_validate.rs
+++ b/crates/fieldset_derive/src/gen_validate.rs
@@ -45,15 +45,20 @@ fn lookup_field<'a>(fields: &'a [FieldInfo], name: &Ident) -> syn::Result<&'a Fi
 
 /// Emit an expression of type `bool` that is `true` when `self.<field>` carries a value.
 ///
-/// - `Option<T>` → `self.field.is_some()` (and for Option<String>, also non-empty)
-/// - `String` → `!self.field.is_empty()`
+/// String presence checks use `trim().is_empty()` to match `walrs_validation`'s
+/// `IsEmpty for String` and `ValueExt::is_empty_value()` semantics — a
+/// whitespace-only string is treated as empty here, just like field-level
+/// `required` validation and the dynamic cross-field rules.
+///
+/// - `Option<T>` → `self.field.is_some()` (and for Option<String>, also non-blank)
+/// - `String` → `!self.field.trim().is_empty()`
 /// - other scalars (numeric/bool/char) → always `true`
 fn emit_has_value(field: &FieldInfo) -> TokenStream {
   let name = &field.ident;
   match &field.ty {
-    FieldType::String => quote! { !self.#name.is_empty() },
+    FieldType::String => quote! { !self.#name.trim().is_empty() },
     FieldType::OptionString => {
-      quote! { self.#name.as_ref().map(|s| !s.is_empty()).unwrap_or(false) }
+      quote! { self.#name.as_ref().map(|s| !s.trim().is_empty()).unwrap_or(false) }
     }
     FieldType::OptionBool
     | FieldType::OptionChar

--- a/crates/fieldset_derive/src/lib.rs
+++ b/crates/fieldset_derive/src/lib.rs
@@ -22,6 +22,12 @@ use parse::{parse_cross_validate_attrs, parse_field_info, parse_fieldset_struct_
 /// - `#[fieldset(into_form_data)]` — generate `impl From<&T> for walrs_form::FormData`
 /// - `#[fieldset(try_from_form_data)]` — generate `impl TryFrom<walrs_form::FormData> for T`
 /// - `#[cross_validate(fn_name)]` — call `fn_name(&self) -> RuleResult` after per-field validation
+/// - `#[cross_validate(fields_equal(a, b))]` — both fields must be equal
+/// - `#[cross_validate(required_if(field, condition_field = <literal>))]`
+/// - `#[cross_validate(required_unless(field, condition_field = <literal>))]`
+/// - `#[cross_validate(one_of_required(a, b, ...))]`
+/// - `#[cross_validate(mutually_exclusive(a, b, ...))]`
+/// - `#[cross_validate(dependent_required(trigger = t, dependents(a, b, ...)))]`
 ///
 /// ## Field-level validation (`#[validate(...)]`)
 ///
@@ -94,7 +100,7 @@ fn derive_fieldset_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStr
 
   // Parse struct-level attributes
   let struct_attrs = parse_fieldset_struct_attrs(&input.attrs);
-  let cross_validate = parse_cross_validate_attrs(&input.attrs);
+  let cross_validate = parse_cross_validate_attrs(&input.attrs)?;
 
   // Parse all fields
   let field_infos: Vec<_> = fields
@@ -108,9 +114,9 @@ fn derive_fieldset_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStr
   // Generate validate and filter methods
   let validate_fn = gen_validate(
     &field_infos,
-    &cross_validate.fns,
+    &cross_validate.rules,
     struct_attrs.break_on_failure,
-  );
+  )?;
   let filter_fn = gen_filter(&field_infos);
 
   // Generate FormData bridge impls if requested

--- a/crates/fieldset_derive/src/parse.rs
+++ b/crates/fieldset_derive/src/parse.rs
@@ -393,6 +393,7 @@ fn parse_required_conditional(
     let _: Token![=] = input.parse()?;
     let lit: Lit = input.parse()?;
     let condition = lit_to_condition(&lit)?;
+    let _: Option<Token![,]> = input.parse()?;
     Ok((field, condition_field, condition))
   };
   syn::parse::Parser::parse2(parser, body).map_err(|e| {
@@ -450,6 +451,7 @@ fn parse_dependent_required(
         "dependents() requires at least one field ident",
       ));
     }
+    let _: Option<Token![,]> = input.parse()?;
     Ok((trigger, dependents))
   };
   syn::parse::Parser::parse2(parser, body).map_err(|e| {
@@ -1084,5 +1086,41 @@ mod tests {
     })
     .unwrap_err();
     assert!(err.to_string().contains("Unknown cross_validate rule"));
+  }
+
+  #[test]
+  fn parse_cross_validate_required_if_accepts_trailing_comma() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(required_if(addr, country = "us",))]
+      struct S { country: String, addr: Option<String> }
+    })
+    .expect("trailing comma after literal should be accepted");
+    assert!(matches!(attrs.rules[0], CrossValidateRule::RequiredIf { .. }));
+  }
+
+  #[test]
+  fn parse_cross_validate_required_unless_accepts_trailing_comma() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(required_unless(addr, same = true,))]
+      struct S { same: bool, addr: Option<String> }
+    })
+    .expect("trailing comma after literal should be accepted");
+    assert!(matches!(
+      attrs.rules[0],
+      CrossValidateRule::RequiredUnless { .. }
+    ));
+  }
+
+  #[test]
+  fn parse_cross_validate_dependent_required_accepts_trailing_comma() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(dependent_required(trigger = ship, dependents(street, zip),))]
+      struct S { ship: bool, street: Option<String>, zip: Option<String> }
+    })
+    .expect("trailing comma after dependents() should be accepted");
+    assert!(matches!(
+      attrs.rules[0],
+      CrossValidateRule::DependentRequired { .. }
+    ));
   }
 }

--- a/crates/fieldset_derive/src/parse.rs
+++ b/crates/fieldset_derive/src/parse.rs
@@ -17,10 +17,48 @@ pub struct FieldsetStructAttrs {
   pub try_from_form_data: bool,
 }
 
-/// Parsed `#[cross_validate(fn_name)]` on the struct.
+/// Parsed `#[cross_validate(...)]` attributes on the struct.
 #[derive(Debug, Default)]
 pub struct CrossValidateAttrs {
-  pub fns: Vec<Path>,
+  pub rules: Vec<CrossValidateRule>,
+}
+
+/// One parsed `#[cross_validate(...)]` rule.
+#[derive(Debug)]
+pub enum CrossValidateRule {
+  /// Free-form `#[cross_validate(fn_path)]`.
+  Custom(Path),
+  /// `#[cross_validate(fields_equal(a, b))]`
+  FieldsEqual { field_a: Ident, field_b: Ident },
+  /// `#[cross_validate(required_if(field, condition_field = literal))]`
+  RequiredIf {
+    field: Ident,
+    condition_field: Ident,
+    condition: ConditionLiteral,
+  },
+  /// `#[cross_validate(required_unless(field, condition_field = literal))]`
+  RequiredUnless {
+    field: Ident,
+    condition_field: Ident,
+    condition: ConditionLiteral,
+  },
+  /// `#[cross_validate(one_of_required(a, b, ...))]`
+  OneOfRequired { fields: Vec<Ident> },
+  /// `#[cross_validate(mutually_exclusive(a, b, ...))]`
+  MutuallyExclusive { fields: Vec<Ident> },
+  /// `#[cross_validate(dependent_required(trigger = t, dependents(a, b, ...)))]`
+  DependentRequired {
+    trigger: Ident,
+    dependents: Vec<Ident>,
+  },
+}
+
+/// Literal value used in `required_if` / `required_unless` conditions.
+#[derive(Debug, Clone)]
+pub enum ConditionLiteral {
+  Str(String),
+  Bool(bool),
+  Int(i128),
 }
 
 // ---------------------------------------------------------------------------
@@ -216,16 +254,210 @@ pub fn parse_fieldset_struct_attrs(attrs: &[Attribute]) -> FieldsetStructAttrs {
 // Parse struct-level `#[cross_validate(fn_name)]`
 // ---------------------------------------------------------------------------
 
-pub fn parse_cross_validate_attrs(attrs: &[Attribute]) -> CrossValidateAttrs {
+pub fn parse_cross_validate_attrs(attrs: &[Attribute]) -> syn::Result<CrossValidateAttrs> {
   let mut result = CrossValidateAttrs::default();
   for attr in attrs {
-    if attr.path().is_ident("cross_validate")
-      && let Ok(path) = attr.parse_args::<Path>()
-    {
-      result.fns.push(path);
+    if attr.path().is_ident("cross_validate") {
+      result.rules.push(parse_one_cross_validate(attr)?);
     }
   }
-  result
+  Ok(result)
+}
+
+fn parse_one_cross_validate(attr: &Attribute) -> syn::Result<CrossValidateRule> {
+  // Look at the inner tokens. The two top-level shapes we accept:
+  //   #[cross_validate(fn_path)]                     → Custom(Path)
+  //   #[cross_validate(kind(args, ...))]             → structured variant
+  //
+  // syn's `parse_args::<Path>` matches when the inner is a single path with
+  // no parens (e.g. `passwords_match` or `my::module::fn`). When the inner
+  // is `kind(...)` syn parses it as an `ExprCall`.
+  let parsed: CrossValidateInner = attr.parse_args()?;
+  match parsed {
+    CrossValidateInner::Path(p) => Ok(CrossValidateRule::Custom(p)),
+    CrossValidateInner::Structured { kind, body } => parse_structured_rule(&kind, body),
+  }
+}
+
+enum CrossValidateInner {
+  Path(Path),
+  Structured {
+    kind: Ident,
+    body: proc_macro2::TokenStream,
+  },
+}
+
+impl Parse for CrossValidateInner {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    // Try to parse as a structured form first: an Ident followed by a paren group.
+    let fork = input.fork();
+    if fork.parse::<Ident>().is_ok() && fork.peek(token::Paren) {
+      let kind: Ident = input.parse()?;
+      let content;
+      parenthesized!(content in input);
+      let body: proc_macro2::TokenStream = content.parse()?;
+      return Ok(CrossValidateInner::Structured { kind, body });
+    }
+    // Otherwise treat as a free-form fn path.
+    let path: Path = input.parse()?;
+    Ok(CrossValidateInner::Path(path))
+  }
+}
+
+fn parse_structured_rule(
+  kind: &Ident,
+  body: proc_macro2::TokenStream,
+) -> syn::Result<CrossValidateRule> {
+  let kind_name = kind.to_string();
+  match kind_name.as_str() {
+    "fields_equal" => {
+      let idents = parse_ident_list(body)?;
+      if idents.len() != 2 {
+        return Err(syn::Error::new(
+          kind.span(),
+          "fields_equal requires exactly two field idents",
+        ));
+      }
+      let mut iter = idents.into_iter();
+      Ok(CrossValidateRule::FieldsEqual {
+        field_a: iter.next().unwrap(),
+        field_b: iter.next().unwrap(),
+      })
+    }
+    "required_if" => {
+      let (field, condition_field, condition) = parse_required_conditional(kind, body)?;
+      Ok(CrossValidateRule::RequiredIf {
+        field,
+        condition_field,
+        condition,
+      })
+    }
+    "required_unless" => {
+      let (field, condition_field, condition) = parse_required_conditional(kind, body)?;
+      Ok(CrossValidateRule::RequiredUnless {
+        field,
+        condition_field,
+        condition,
+      })
+    }
+    "one_of_required" => {
+      let idents = parse_ident_list(body)?;
+      if idents.is_empty() {
+        return Err(syn::Error::new(
+          kind.span(),
+          "one_of_required requires at least one field ident",
+        ));
+      }
+      Ok(CrossValidateRule::OneOfRequired { fields: idents })
+    }
+    "mutually_exclusive" => {
+      let idents = parse_ident_list(body)?;
+      if idents.is_empty() {
+        return Err(syn::Error::new(
+          kind.span(),
+          "mutually_exclusive requires at least one field ident",
+        ));
+      }
+      Ok(CrossValidateRule::MutuallyExclusive { fields: idents })
+    }
+    "dependent_required" => {
+      let (trigger, dependents) = parse_dependent_required(kind, body)?;
+      Ok(CrossValidateRule::DependentRequired {
+        trigger,
+        dependents,
+      })
+    }
+    _ => Err(syn::Error::new(
+      kind.span(),
+      format!("Unknown cross_validate rule: {kind_name}"),
+    )),
+  }
+}
+
+fn parse_ident_list(body: proc_macro2::TokenStream) -> syn::Result<Vec<Ident>> {
+  let parser = Punctuated::<Ident, Token![,]>::parse_terminated;
+  let punct = syn::parse::Parser::parse2(parser, body)?;
+  Ok(punct.into_iter().collect())
+}
+
+/// Parse the body of `required_if(field, condition_field = literal)`:
+/// a leading bare ident, then a single `name = lit` pair.
+fn parse_required_conditional(
+  kind: &Ident,
+  body: proc_macro2::TokenStream,
+) -> syn::Result<(Ident, Ident, ConditionLiteral)> {
+  let parser = |input: ParseStream<'_>| -> syn::Result<(Ident, Ident, ConditionLiteral)> {
+    let field: Ident = input.parse()?;
+    let _: Token![,] = input.parse()?;
+    let condition_field: Ident = input.parse()?;
+    let _: Token![=] = input.parse()?;
+    let lit: Lit = input.parse()?;
+    let condition = lit_to_condition(&lit)?;
+    Ok((field, condition_field, condition))
+  };
+  syn::parse::Parser::parse2(parser, body).map_err(|e| {
+    syn::Error::new(
+      kind.span(),
+      format!("{kind} requires `field, condition_field = <literal>`: {e}"),
+    )
+  })
+}
+
+fn lit_to_condition(lit: &Lit) -> syn::Result<ConditionLiteral> {
+  match lit {
+    Lit::Str(s) => Ok(ConditionLiteral::Str(s.value())),
+    Lit::Bool(b) => Ok(ConditionLiteral::Bool(b.value)),
+    Lit::Int(i) => Ok(ConditionLiteral::Int(i.base10_parse()?)),
+    _ => Err(syn::Error::new_spanned(
+      lit,
+      "condition literal must be a string, bool, or integer",
+    )),
+  }
+}
+
+/// Parse the body of `dependent_required(trigger = t, dependents(a, b, ...))`.
+fn parse_dependent_required(
+  kind: &Ident,
+  body: proc_macro2::TokenStream,
+) -> syn::Result<(Ident, Vec<Ident>)> {
+  let parser = |input: ParseStream<'_>| -> syn::Result<(Ident, Vec<Ident>)> {
+    // trigger = <ident>
+    let trigger_kw: Ident = input.parse()?;
+    if trigger_kw != "trigger" {
+      return Err(syn::Error::new(
+        trigger_kw.span(),
+        "expected `trigger = <field>`",
+      ));
+    }
+    let _: Token![=] = input.parse()?;
+    let trigger: Ident = input.parse()?;
+    let _: Token![,] = input.parse()?;
+    // dependents(a, b, ...)
+    let dependents_kw: Ident = input.parse()?;
+    if dependents_kw != "dependents" {
+      return Err(syn::Error::new(
+        dependents_kw.span(),
+        "expected `dependents(a, b, ...)`",
+      ));
+    }
+    let content;
+    parenthesized!(content in input);
+    let punct: Punctuated<Ident, Token![,]> = content.parse_terminated(Ident::parse, Token![,])?;
+    let dependents: Vec<Ident> = punct.into_iter().collect();
+    if dependents.is_empty() {
+      return Err(syn::Error::new(
+        dependents_kw.span(),
+        "dependents() requires at least one field ident",
+      ));
+    }
+    Ok((trigger, dependents))
+  };
+  syn::parse::Parser::parse2(parser, body).map_err(|e| {
+    syn::Error::new(
+      kind.span(),
+      format!("{kind} requires `trigger = <field>, dependents(a, b, ...)`: {e}"),
+    )
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -748,5 +980,109 @@ mod tests {
         .to_string()
         .contains("expected `whitespace` inside parentheses")
     );
+  }
+
+  // -------------------------------------------------------------------------
+  // cross_validate: structured variants
+  // -------------------------------------------------------------------------
+
+  fn parse_struct_cross_validate(
+    tokens: proc_macro2::TokenStream,
+  ) -> syn::Result<CrossValidateAttrs> {
+    let item: ItemStruct = syn::parse2(tokens).expect("struct should parse");
+    parse_cross_validate_attrs(&item.attrs)
+  }
+
+  #[test]
+  fn parse_cross_validate_custom_fn() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(my_fn)]
+      struct S { x: String }
+    })
+    .unwrap();
+    assert_eq!(attrs.rules.len(), 1);
+    assert!(matches!(attrs.rules[0], CrossValidateRule::Custom(_)));
+  }
+
+  #[test]
+  fn parse_cross_validate_fields_equal() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(fields_equal(a, b))]
+      struct S { a: String, b: String }
+    })
+    .unwrap();
+    assert!(matches!(
+      attrs.rules[0],
+      CrossValidateRule::FieldsEqual { .. }
+    ));
+  }
+
+  #[test]
+  fn parse_cross_validate_fields_equal_wrong_arity() {
+    let err = parse_struct_cross_validate(quote! {
+      #[cross_validate(fields_equal(a, b, c))]
+      struct S { a: String, b: String, c: String }
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("exactly two"));
+  }
+
+  #[test]
+  fn parse_cross_validate_required_if_str() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(required_if(addr, country = "us"))]
+      struct S { country: String, addr: Option<String> }
+    })
+    .unwrap();
+    match &attrs.rules[0] {
+      CrossValidateRule::RequiredIf { condition, .. } => {
+        assert!(matches!(condition, ConditionLiteral::Str(s) if s == "us"));
+      }
+      _ => panic!("expected RequiredIf"),
+    }
+  }
+
+  #[test]
+  fn parse_cross_validate_required_unless_bool() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(required_unless(addr, same = true))]
+      struct S { same: bool, addr: Option<String> }
+    })
+    .unwrap();
+    match &attrs.rules[0] {
+      CrossValidateRule::RequiredUnless { condition, .. } => {
+        assert!(matches!(condition, ConditionLiteral::Bool(true)));
+      }
+      _ => panic!("expected RequiredUnless"),
+    }
+  }
+
+  #[test]
+  fn parse_cross_validate_dependent_required() {
+    let attrs = parse_struct_cross_validate(quote! {
+      #[cross_validate(dependent_required(trigger = ship, dependents(street, zip)))]
+      struct S { ship: bool, street: Option<String>, zip: Option<String> }
+    })
+    .unwrap();
+    match &attrs.rules[0] {
+      CrossValidateRule::DependentRequired {
+        trigger,
+        dependents,
+      } => {
+        assert_eq!(trigger.to_string(), "ship");
+        assert_eq!(dependents.len(), 2);
+      }
+      _ => panic!("expected DependentRequired"),
+    }
+  }
+
+  #[test]
+  fn parse_cross_validate_unknown_kind_errors() {
+    let err = parse_struct_cross_validate(quote! {
+      #[cross_validate(no_such_kind(a, b))]
+      struct S { a: String, b: String }
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("Unknown cross_validate rule"));
   }
 }


### PR DESCRIPTION
## Summary

Extends `#[cross_validate(...)]` on `#[derive(Fieldset)]` with six structured variants matching the dynamic `CrossFieldRuleType`:

- `fields_equal(a, b)`
- `required_if(field, condition_field = literal)`
- `required_unless(field, condition_field = literal)`
- `one_of_required(a, b, ...)`
- `mutually_exclusive(a, b, ...)`
- `dependent_required(trigger = t, dependents(a, b, ...))`

Free-form `#[cross_validate(fn_name)]` is preserved.

Generated code emits checks directly (no `walrs_fieldfilter::CrossFieldRule` dependency), keeping the typed path decoupled from the dynamic runtime.

## Related

- Closes #260
- Part of #259 (typed-path parity with `FieldFilter<Value>`)

## Testing

- New tests cover pass+fail for each variant.
- Existing `cross_validate(fn)` tests still pass.
- New runnable example: `cargo run --example derive_cross_validate -p walrs_fieldfilter --features derive`.