### PR TITLE
chore(walrs_acl): #266 silence unnecessary_unwrap in async _matches_allow

### DIFF
--- a/crates/acl/src/simple/acl.rs
+++ b/crates/acl/src/simple/acl.rs
@@ -1002,8 +1002,7 @@ mod async_impl {
         self
           ._matches_allow_no_dfs_async(role, resource, privilege, resolver)
           .await
-      } else if _resources.is_none() && _roles.is_some() {
-        let rs = _roles.as_ref().unwrap();
+      } else if let Some(rs) = _roles.as_ref().filter(|_| _resources.is_none()) {
         for ro in rs.iter().rev() {
           if self
             ._matches_allow_no_dfs_async(Some(ro), resource, privilege, resolver)
@@ -1015,8 +1014,7 @@ mod async_impl {
         self
           ._matches_allow_no_dfs_async(role, resource, privilege, resolver)
           .await
-      } else if _resources.is_some() && _roles.is_none() {
-        let rs = _resources.as_ref().unwrap();
+      } else if let Some(rs) = _resources.as_ref().filter(|_| _roles.is_none()) {
         for r in rs.iter().rev() {
           if self
             ._matches_allow_no_dfs_async(role, Some(*r), privilege, resolver)


### PR DESCRIPTION
## Summary

Replaces two `is_some()` + `as_ref().unwrap()` patterns in the async branch of `_matches_allow*` with `if let Some(...) = ...`, matching the idiom the sync sibling already uses.

## Related Issue

Part of #266 (item 4 — surfaced by the unified acceptance command, not in the original report).

## Changes

- `crates/acl/src/simple/acl.rs`: rewrote two branches around lines 1005-1027 to use `if let`.

## Testing

- `cargo clippy -p walrs_acl -- -D warnings` — clean
- `cargo build -p walrs_acl`
- `cargo test -p walrs_acl`