### PR TITLE
chore(walrs_validation): #266 silence type_complexity in async Rule fn pointer

### DIFF
--- a/crates/validation/src/rule.rs
+++ b/crates/validation/src/rule.rs
@@ -126,6 +126,11 @@ impl<'de> Deserialize<'de> for CompiledPattern {
 /// Result of applying a rule to a value.
 pub type RuleResult = Result<(), Violation>;
 
+/// Type alias for the async custom validation function pointer used by `Rule::CustomAsync`.
+#[cfg(feature = "async")]
+pub type CustomAsyncFn<T> =
+  Arc<dyn Fn(&T) -> Pin<Box<dyn std::future::Future<Output = RuleResult> + Send + '_>> + Send + Sync>;
+
 // ============================================================================
 // Condition Enum
 // ============================================================================
@@ -351,13 +356,7 @@ pub enum Rule<T> {
   /// Use `Rule::custom_async()` to construct this variant.
   #[cfg(feature = "async")]
   #[serde(skip)]
-  CustomAsync(
-    Arc<
-      dyn Fn(&T) -> Pin<Box<dyn std::future::Future<Output = RuleResult> + Send + '_>>
-        + Send
-        + Sync,
-    >,
-  ),
+  CustomAsync(CustomAsyncFn<T>),
 
   /// Reference to a named rule (left to userland code)
   #[serde(skip)]
@@ -655,13 +654,7 @@ impl<T> Rule<T> {
   /// }));
   /// ```
   #[cfg(feature = "async")]
-  pub fn custom_async(
-    f: Arc<
-      dyn Fn(&T) -> Pin<Box<dyn std::future::Future<Output = RuleResult> + Send + '_>>
-        + Send
-        + Sync,
-    >,
-  ) -> Rule<T> {
+  pub fn custom_async(f: CustomAsyncFn<T>) -> Rule<T> {
     Rule::CustomAsync(f)
   }
 


### PR DESCRIPTION
## Summary

Extracts a single `type` alias for the complex async function-pointer type used by `Rule<T>::CustomAsync` and `Rule::custom_async`, silencing two `clippy::type_complexity` errors that surface under `--features async`.

## Related Issue

Part of #266.

## Changes

- `crates/validation/src/rule.rs`: introduced `type` alias (cfg-gated on `async`); used it in the enum variant and constructor signature.

## Testing

- `cargo clippy --features async -p walrs_validation -- -D warnings` — clean
- `cargo build -p walrs_validation --features async`
- `cargo test -p walrs_validation --features async`