### PR TITLE
chore(walrs_fieldfilter): #271 silence type_complexity on CrossFieldRuleType::CustomAsync

### DIFF
--- a/crates/fieldfilter/src/field_filter.rs
+++ b/crates/fieldfilter/src/field_filter.rs
@@ -297,6 +297,7 @@ pub enum CrossFieldRuleType {
   /// Async custom validation (not serializable).
   #[cfg(feature = "async")]
   #[serde(skip)]
+  #[allow(clippy::type_complexity)]
   CustomAsync(
     Arc<
       dyn Fn(


### PR DESCRIPTION
## Summary

Adds `#[allow(clippy::type_complexity)]` to `CrossFieldRuleType::CustomAsync`, matching the suppression already present on the sync sibling `Custom` variant directly above it. The lint surfaced once PR #270 cleared the upstream `walrs_validation` blocker.

## Related Issue

Closes #271. Unblocks the unified acceptance criterion of #266.

## Changes

- `crates/fieldfilter/src/field_filter.rs`: 1-line attribute add.

## Testing

- `cargo clippy --workspace --features async -- -D warnings` — clean
- `cargo build --workspace --features async`
- `cargo test -p walrs_fieldfilter --features async`