### PR TITLE
chore: #267 coordinated 0.1.0 → 0.2.0 bump and CHANGELOGs (Phase 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "walrs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "walrs_acl",
  "walrs_digraph",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_acl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -2116,11 +2116,11 @@ dependencies = [
 
 [[package]]
 name = "walrs_digraph"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "walrs_fieldfilter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "derive_builder",
  "indexmap",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_fieldset_derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_filter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ammonia",
  "criterion",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_graph"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "walrs_digraph",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_navigation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_rbac"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "js-sys",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_validation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Elastic-2.0"

--- a/crates/acl/CHANGELOG.md
+++ b/crates/acl/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to `walrs_acl` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-04-26
+
+Coordinated pre-1.0 bump alongside the rest of the workspace. No `walrs_acl`
+API changes were driven by [issue #267](https://github.com/elycruz/walrs/issues/267);
+the entry below predates this release and is included here for completeness.
 
 ### Changed (breaking)
 

--- a/crates/acl/Cargo.toml
+++ b/crates/acl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_acl"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Elastic-2.0"
 crate-type = ["cdylib", "rlib"]

--- a/crates/digraph/Cargo.toml
+++ b/crates/digraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_digraph"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Elastic-2.0"
 

--- a/crates/fieldfilter/CHANGELOG.md
+++ b/crates/fieldfilter/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to `walrs_fieldfilter` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-26
+
+Coordinated pre-1.0 bump removing the dynamic `FieldFilter` / `Value` path. See
+[`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
+and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
+
+### Removed (breaking)
+
+- `FieldFilter` type and the `field_filter` module.
+- `CrossFieldRule` and `CrossFieldRuleType` types.
+- `Field<Value>` impls (sync and async).
+- Re-exports of `Value` and `ValueExt` from `walrs_validation`.
+- `field_filter` example.
+- `fuzz_fieldfilter_validate` fuzz target.
+
+### Migration
+
+Define a typed struct describing your fields and use `#[derive(Fieldset)]`
+from `walrs_fieldset_derive`. Cross-field rules are expressed via the
+`#[cross_validate(...)]` derive attribute.

--- a/crates/fieldfilter/Cargo.toml
+++ b/crates/fieldfilter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_fieldfilter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 edition = "2024"
 license = "Elastic-2.0"

--- a/crates/fieldset_derive/CHANGELOG.md
+++ b/crates/fieldset_derive/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `walrs_fieldset_derive` are documented here. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-26
+
+Coordinated pre-1.0 bump removing the dynamic `FormData` bridge. See
+[`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
+and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
+
+### Removed (breaking)
+
+- `#[fieldset(into_form_data)]` and `#[fieldset(try_from_form_data)]` struct
+  attributes.
+- `gen_form_data` codegen module (the `From<&T> for FormData` and
+  `TryFrom<FormData> for T` impl emitters).
+
+### Migration
+
+The bridge attributes existed only to interoperate with the now-removed
+`walrs_form::FormData`. Typed struct fields no longer need a dynamic
+counterpart — derive `Fieldset` directly on the struct.

--- a/crates/fieldset_derive/Cargo.toml
+++ b/crates/fieldset_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_fieldset_derive"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 description = "Derive macro for walrs_fieldfilter Fieldset trait"

--- a/crates/filter/CHANGELOG.md
+++ b/crates/filter/CHANGELOG.md
@@ -1,15 +1,24 @@
 # Changelog
 
-## Unreleased
+All notable changes to `walrs_filter` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
+## [0.2.0] - 2026-04-26
 
-- New `value` feature flag (default-on) gating `FilterOp<Value>` and
-  `TryFilterOp<Value>`. The feature forwards to `walrs_validation/value`,
-  so typed-only consumers can disable it via `default-features = false` to
-  build with just `FilterOp<String>` and scalar numeric types.
+Coordinated pre-1.0 bump removing the dynamic `Value` path. See
+[`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
+and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
 
-### Changed
+### Removed (breaking)
 
-- Default-build behavior is unchanged: `default = ["validation", "value"]`
-  still enables the dynamic path out of the box.
+- `FilterOp<Value>` and `TryFilterOp<Value>` impls, including the
+  `apply_string_op_to_value` helper.
+- `Filter<Value>` and `TryFilter<Value>` impl blocks for those types.
+- The `value` feature flag.
+- `bench_filter_op_value` benchmark group.
+
+### Migration
+
+Use `FilterOp<String>` (or numeric `FilterOp<T>`) on typed struct fields.
+The recommended path is `#[derive(Fieldset)]` from `walrs_fieldset_derive`.

--- a/crates/filter/Cargo.toml
+++ b/crates/filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_filter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 edition = "2024"
 description = "Filter/transformation structs for input filtering"

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_graph"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Elastic-2.0"
 

--- a/crates/navigation/Cargo.toml
+++ b/crates/navigation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_navigation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "A navigation component for managing trees of pointers to web pages"
 license = "Elastic-2.0"

--- a/crates/rbac/Cargo.toml
+++ b/crates/rbac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_rbac"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Role-Based Access Control (RBAC) permissions management"
 license = "Elastic-2.0"

--- a/crates/validation/CHANGELOG.md
+++ b/crates/validation/CHANGELOG.md
@@ -1,18 +1,33 @@
 # Changelog
 
-## Unreleased
+All notable changes to `walrs_validation` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
+## [0.2.0] - 2026-04-26
 
-- New `value` feature flag (default-on) gating the dynamic `Value` enum, its
-  `Rule<Value>` / `Condition<Value>` dispatch, the `value!` macro, and the
-  `IsEmpty` implementation for `Value`. Typed-only consumers can now opt out
-  via `default-features = false` to avoid compiling the dynamic path.
-- `serde_json_bridge` now implies `value` (the bridge converts `serde_json::Value`
-  to/from `walrs_validation::Value`, so it cannot function without it).
+Coordinated pre-1.0 bump removing the dynamic `Value` path. See
+[`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
+and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
 
-### Changed
+### Removed (breaking)
 
-- Default-build behavior is unchanged: `default = ["value", "serde_json_bridge"]`
-  still enables the dynamic path out of the box. Existing code that relies on
-  default features continues to compile with no action required.
+- `Value` enum and all variants (`I64`, `U64`, `F64`, `Str`, `Bool`, `Array`,
+  `Object`, `Null`).
+- `ValueExt` trait and the `value!` macro.
+- `Rule<Value>` and `Condition<Value>` dispatch (`crates/validation/src/rule_impls/value.rs`).
+- `IsEmpty for Value` impl.
+- The `value` feature flag.
+- `value_validation` example.
+
+### Changed (breaking)
+
+- `serde_json_bridge` no longer implies the removed `value` feature. The
+  bridge uses `serde_json::Value` directly and never required the now-removed
+  `walrs_validation::Value`.
+- `serde_json` is now an optional dependency, gated on `serde_json_bridge`.
+
+### Migration
+
+Replace `Field<Value>` / `Rule<Value>` / `FilterOp<Value>` with typed
+struct definitions and `#[derive(Fieldset)]` from `walrs_fieldset_derive`.

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_validation"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
## Summary

Phase 4 of the dynamic-path removal tracked in #267. Coordinated **pre-1.0 churn** bump (`0.1.0 → 0.2.0`) across the workspace following the code-removal phases. Per the user's direction, this is a minor bump — not a `1.0.0` cut.

## Changes

**Version bumps**
- Root `Cargo.toml` and all 9 crate `Cargo.toml`s bumped from `0.1.0` to `0.2.0` (`acl`, `digraph`, `fieldfilter`, `fieldset_derive`, `filter`, `graph`, `navigation`, `rbac`, `validation`).
- `Cargo.lock` refreshed via a workspace build.

**CHANGELOG entries** (Keep-a-Changelog format, dated `2026-04-26`)
- `crates/validation/CHANGELOG.md` — replaces the misleading `## Unreleased` entry (which described the mid-cycle internal addition of the `value` feature in PR #256, never publicly released) with a `## [0.2.0]` block documenting the actual `0.1.0 → 0.2.0` net delta: removal of `Value`, `ValueExt`, `value!`, `Rule<Value>`, `Condition<Value>`, `IsEmpty for Value`, the `value` feature, the `value_validation` example, and the `serde_json` dep becoming optional / `serde_json_bridge` becoming standalone.
- `crates/filter/CHANGELOG.md` — same treatment, documenting removal of `FilterOp<Value>`, `TryFilterOp<Value>`, `Filter<Value>` / `TryFilter<Value>` impls, the `value` feature, and the `bench_filter_op_value` group.
- `crates/acl/CHANGELOG.md` — promotes the pre-existing `## Unreleased` entry (the `Rule` `Copy` removal from PR #247) to a `## [0.2.0]` block. No `walrs_acl` API change was driven by #267, but this entry pre-dates #267 and ships with this release.
- `crates/fieldfilter/CHANGELOG.md` — **new**. Documents removal of `FieldFilter`, `CrossFieldRule` / `CrossFieldRuleType`, `Field<Value>` (sync + async), the `Value` / `ValueExt` re-exports, the `field_filter` example, and the `fuzz_fieldfilter_validate` fuzz target.
- `crates/fieldset_derive/CHANGELOG.md` — **new**. Documents removal of `#[fieldset(into_form_data, try_from_form_data)]` and the `gen_form_data` codegen module.

**Untouched crates**
- `digraph`, `graph`, `navigation`, `rbac` get only the version bump. No API surface changes from #267 → no CHANGELOG entries.

## Related Issue

Closes #267. Also closes #258 as superseded per `md/plans/2026-04-25-dynamic-path-removal.md` §10.

## Out of scope

Publishing to crates.io is a manual release-management step the maintainer runs after this PR merges (no CI-driven publish workflow yet). This PR only lands the version bumps and CHANGELOG entries.

## Testing

- `cargo build --workspace` — succeeds. `Cargo.lock` shows all walrs crates at `0.2.0`.
- `cargo test --workspace` — every suite passes.
- `cargo fmt --check` — clean for the touched files (pre-existing fmt drift in `crates/validation/src/rule.rs:128` is unrelated and present on `main`).
- `grep -rE "^version = " Cargo.toml crates/*/Cargo.toml` confirms all 10 manifests at `0.2.0`.
- Pre-PR review verified each CHANGELOG bullet against the prior phase PRs (#273, #274, #275, #276) and confirmed coverage matches the actual removals.

## Stats

16 files changed, 132 insertions, 54 deletions (10 `Cargo.toml`s, `Cargo.lock`, 3 modified CHANGELOGs, 2 new CHANGELOGs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>