### PR TITLE
ci/docs: #243 phase 3 - WASM CI workflow + README updates

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: latest
+          version: '0.14.0'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install JS test dependencies
         working-directory: crates/${{ matrix.crate }}/tests-js
-        run: npm install
+        run: npm ci
 
       - name: Run JS tests
         working-directory: crates/${{ matrix.crate }}/tests-js

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,55 @@
+name: WASM
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    name: ${{ matrix.crate }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [acl-wasm, rbac-wasm]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (stable + wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/${{ matrix.crate }}
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build WASM package
+        working-directory: crates/${{ matrix.crate }}
+        run: wasm-pack build --target nodejs
+
+      - name: Install JS test dependencies
+        working-directory: crates/${{ matrix.crate }}/tests-js
+        run: npm install
+
+      - name: Run JS tests
+        working-directory: crates/${{ matrix.crate }}/tests-js
+        run: npm test

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: '0.14.0'
+          version: 'v0.14.0'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can also depend on individual sub-crates directly (e.g., `walrs_fieldfilter 
 | Crate | Description |
 |---|---|
 | `walrs_acl` | Access control list structure |
+| `walrs_acl_wasm` | WebAssembly bindings for `walrs_acl` (sibling crate, opt-in) |
 | `walrs_digraph` | Directed graph structures |
 | `walrs_filter` | Input value transformation/sanitization filters |
 | `walrs_graph` | Undirected graph structures |
@@ -55,6 +56,7 @@ You can also depend on individual sub-crates directly (e.g., `walrs_fieldfilter 
 | `walrs_fieldset_derive` | Proc-macro crate providing `#[derive(Fieldset)]`; consumed via `walrs_fieldfilter`'s `derive` feature |
 | `walrs_navigation` | Web page link graph / navigation structures |
 | `walrs_rbac` | Role-Based Access Control |
+| `walrs_rbac_wasm` | WebAssembly bindings for `walrs_rbac` (sibling crate, opt-in) |
 | `walrs_validation` | Composable validation rules |
 
 ### The typed path (`Fieldset`)


### PR DESCRIPTION
## Summary

Phase 3 of #243. Closes the longstanding gap where WASM regressions could only be caught locally via `ci-cd-wasm.sh`.

## Changes

- **New** `.github/workflows/wasm.yml` — matrix job over `acl-wasm` + `rbac-wasm`. Installs Rust stable + `wasm32-unknown-unknown`, installs `wasm-pack` and Node 20, runs `wasm-pack build --target nodejs` then `cd tests-js && npm install && npm test` for each crate. Triggers on PR + push to main. Uses `Swatinem/rust-cache@v2` for cargo build cache.
- **Updated** `README.md` sub-crates table to include `walrs_acl_wasm` and `walrs_rbac_wasm` (alphabetical order: `acl_wasm` after `acl`, `rbac_wasm` after `rbac`).

## Notable choices

- **Toolchain**: `stable` (with `wasm32-unknown-unknown` target). Existing `build-and-test.yml` uses nightly; for WASM builds stable is sufficient and more reproducible. Easy to swap to nightly if a future need arises.
- **wasm-pack action**: `jetli/wasm-pack-action@v0.4.0` (well-maintained community action) instead of the curl-installer for speed and pinning.
- **wasm-opt**: Intentionally **not** invoked in CI. The local `ci-cd-wasm.sh` runs `wasm-opt -Oz` for size optimization of published artifacts; in CI we only need correctness, and `wasm-pack` produces a valid module the JS tests can exercise without it. Keeps the job lean and avoids needing a binaryen install step.
- **Cache**: `Swatinem/rust-cache@v2` scoped per-matrix-crate workspace.
- **Checkout/Node versions**: bumped to `actions/checkout@v4` and `actions/setup-node@v4` (LTS Node 20).

## Verification

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] `grep walrs_acl_wasm README.md` finds the new row; `grep walrs_rbac_wasm README.md` finds the new row.
- [ ] Actual CI run — verifiable once the PR is opened. Will iterate if the workflow needs tuning.

## Out of scope

Version bumps + CHANGELOG entries → Phase 4 (#281, parallel).

## Related

- Closes #280
- Part of #243
- Phase 1: #283 (merged)
- Phase 2: #282 (merged)
- Phase 4 (parallel): #281