### PR TITLE
chore: #243 phase 4 - coordinated 0.2.0 → 0.3.0 bump + CHANGELOGs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_acl"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_rbac"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "serde",

--- a/crates/acl-wasm/CHANGELOG.md
+++ b/crates/acl-wasm/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to `walrs_acl_wasm` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-26
+
+### Added
+
+- Initial release. Extracted from `walrs_acl` v0.2.0 — see
+  [issue #243](https://github.com/elycruz/walrs/issues/243) and PR #283
+  (which landed phase 1 of the extraction).
+- `wasm-bindgen` bindings: `JsAcl`, `JsAclBuilder`, plus convenience fns
+  `createAclFromJson` and `checkPermission`.
+- JavaScript test suite in `tests-js/` (Node built-in test runner).

--- a/crates/acl/CHANGELOG.md
+++ b/crates/acl/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `walrs_acl` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-26
+
+Coordinated pre-1.0 bump completing the WASM extraction cycle. See
+[issue #243](https://github.com/elycruz/walrs/issues/243) for context. The
+WebAssembly bindings have moved to a sibling crate; JavaScript consumers
+should depend on `walrs_acl_wasm` instead.
+
+### Removed (breaking)
+
+- `wasm` cargo feature.
+- `cdylib` from `[lib] crate-type` (now defaults to `rlib` only).
+- Optional WASM dependencies (`wasm-bindgen`, `serde-wasm-bindgen`, `js-sys`,
+  `web-sys`).
+
+### Migration
+
+```toml
+# Before
+walrs_acl = { version = "0.2", features = ["wasm"] }
+
+# After (Rust consumers — no change needed beyond version bump)
+walrs_acl = "0.3"
+
+# After (WASM consumers — depend on the sibling crate)
+walrs_acl_wasm = "0.1"
+```
+
 ## [0.2.0] - 2026-04-26
 
 Coordinated pre-1.0 bump alongside the rest of the workspace. No `walrs_acl`

--- a/crates/acl/Cargo.toml
+++ b/crates/acl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_acl"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Elastic-2.0"
 

--- a/crates/rbac-wasm/CHANGELOG.md
+++ b/crates/rbac-wasm/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to `walrs_rbac_wasm` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-26
+
+### Added
+
+- Initial release. Extracted from `walrs_rbac` v0.2.0 — see
+  [issue #243](https://github.com/elycruz/walrs/issues/243) and PR #282
+  (which landed phase 2 of the extraction).
+- `wasm-bindgen` bindings: `JsRbac`, `JsRbacBuilder`, plus convenience fns
+  `createRbacFromJson` and `checkPermission`.
+- JavaScript test suite in `tests-js/` (Node built-in test runner).

--- a/crates/rbac/CHANGELOG.md
+++ b/crates/rbac/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to `walrs_rbac` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-04-26
+
+Coordinated pre-1.0 bump completing the WASM extraction cycle. See
+[issue #243](https://github.com/elycruz/walrs/issues/243) for context. The
+WebAssembly bindings have moved to a sibling crate; JavaScript consumers
+should depend on `walrs_rbac_wasm` instead.
+
+### Removed (breaking)
+
+- `wasm` cargo feature.
+- `cdylib` from `[lib] crate-type` (now defaults to `rlib` only).
+- Optional WASM dependencies (`wasm-bindgen`, `serde-wasm-bindgen`, `js-sys`).
+
+### Migration
+
+```toml
+# Before
+walrs_rbac = { version = "0.2", features = ["wasm"] }
+
+# After (Rust consumers — no change needed beyond version bump)
+walrs_rbac = "0.3"
+
+# After (WASM consumers — depend on the sibling crate)
+walrs_rbac_wasm = "0.1"
+```

--- a/crates/rbac/CHANGELOG.md
+++ b/crates/rbac/CHANGELOG.md
@@ -29,3 +29,9 @@ walrs_rbac = "0.3"
 # After (WASM consumers — depend on the sibling crate)
 walrs_rbac_wasm = "0.1"
 ```
+
+## [0.2.0] - 2026-04-26
+
+Coordinated pre-1.0 bump alongside the rest of the workspace as part of
+[issue #267](https://github.com/elycruz/walrs/issues/267) (Phase 4, b66ea99).
+No `walrs_rbac` API changes — this entry is included for changelog completeness.

--- a/crates/rbac/Cargo.toml
+++ b/crates/rbac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_rbac"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Role-Based Access Control (RBAC) permissions management"
 license = "Elastic-2.0"


### PR DESCRIPTION
## Summary

Phase 4 of #243 — closes the WASM extraction cycle by bumping `walrs_acl` and `walrs_rbac` to `0.3.0` (SemVer-breaking due to clean-break removal of `wasm` feature in #283 / #282) and adding CHANGELOG entries across the four affected crates.

Mirrors the closing-phase pattern from #267 (b66ea99).

## Changes

### Version bumps
- `walrs_acl` 0.2.0 → 0.3.0
- `walrs_rbac` 0.2.0 → 0.3.0
- `walrs_acl_wasm` stays at 0.1.0 (initial)
- `walrs_rbac_wasm` stays at 0.1.0 (initial)
- Other crates bumped: none

### CHANGELOGs
- `crates/acl/CHANGELOG.md` — new `0.3.0` BREAKING entry documenting WASM extraction (sibling crate is now `walrs_acl_wasm`).
- `crates/rbac/CHANGELOG.md` — new file with `0.3.0` BREAKING entry (no prior changelog existed for rbac).
- `crates/acl-wasm/CHANGELOG.md` — initial `0.1.0` entry.
- `crates/rbac-wasm/CHANGELOG.md` — initial `0.1.0` entry.

### Audit
Walked every other workspace member's `Cargo.toml` (`crates/digraph`, `crates/filter`, `crates/graph`, `crates/fieldfilter`, `crates/fieldset_derive`, `crates/navigation`, `crates/validation`, plus root umbrella `walrs`).

None of them declared a `wasm` feature pass-through to `walrs_acl` / `walrs_rbac`, and none depend on the now-removed feature. The umbrella `walrs/Cargo.toml` has feature flags `acl`, `digraph`, `filter`, `graph`, `fieldfilter`, `fieldfilter-derive`, `navigation`, `rbac`, `validation` — no `wasm` entry. Therefore no downstream breaks, and no other version bumps required.

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo build --workspace` succeeds (acl@0.3.0, rbac@0.3.0)
- [x] `cargo test --workspace` passes
- [x] Per-crate clippy clean for changed crate libs (`cargo clippy -p walrs_acl -p walrs_rbac -p walrs_acl_wasm -p walrs_rbac_wasm -- -D warnings`). Workspace-wide `--all-targets` clippy fails on pre-existing test-target lints in `walrs_acl` (known, out of scope per #283 / #282).

## Related

- Closes #281
- Part of #243
- Phases 1–2: #283, #282 (merged)
- Phase 3 (parallel): #280