### PR TITLE
chore: #286 revert all crate versions to 0.1.0 (prepublish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "walrs"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "walrs_acl",
  "walrs_digraph",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_acl"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -2125,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "walrs_digraph"
-version = "0.2.0"
+version = "0.1.0"
 
 [[package]]
 name = "walrs_fieldfilter"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "derive_builder",
  "indexmap",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_fieldset_derive"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_filter"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "ammonia",
  "criterion",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_graph"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "walrs_digraph",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_navigation"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_rbac"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "serde",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "walrs_validation"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Elastic-2.0"

--- a/crates/acl-wasm/CHANGELOG.md
+++ b/crates/acl-wasm/CHANGELOG.md
@@ -8,7 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Initial release. Extracted from `walrs_acl` v0.2.0 — see
+- Initial release. Extracted from `walrs_acl` — see
   [issue #243](https://github.com/elycruz/walrs/issues/243) and PR #283
   (which landed phase 1 of the extraction).
 - `wasm-bindgen` bindings: `JsAcl`, `JsAclBuilder`, plus convenience fns

--- a/crates/acl/CHANGELOG.md
+++ b/crates/acl/CHANGELOG.md
@@ -4,38 +4,19 @@ All notable changes to `walrs_acl` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-04-26
+## [Unreleased]
 
-Coordinated pre-1.0 bump completing the WASM extraction cycle. See
-[issue #243](https://github.com/elycruz/walrs/issues/243) for context. The
-WebAssembly bindings have moved to a sibling crate; JavaScript consumers
-should depend on `walrs_acl_wasm` instead.
+The crate is still pre-publish; nothing has shipped to crates.io yet. The
+notes below describe breaking changes that have landed on `main` since the
+crate was created and will be folded into the eventual `0.1.0` release.
 
 ### Removed (breaking)
 
 - `wasm` cargo feature.
 - `cdylib` from `[lib] crate-type` (now defaults to `rlib` only).
 - Optional WASM dependencies (`wasm-bindgen`, `serde-wasm-bindgen`, `js-sys`,
-  `web-sys`).
-
-### Migration
-
-```toml
-# Before
-walrs_acl = { version = "0.2", features = ["wasm"] }
-
-# After (Rust consumers — no change needed beyond version bump)
-walrs_acl = "0.3"
-
-# After (WASM consumers — depend on the sibling crate)
-walrs_acl_wasm = "0.1"
-```
-
-## [0.2.0] - 2026-04-26
-
-Coordinated pre-1.0 bump alongside the rest of the workspace. No `walrs_acl`
-API changes were driven by [issue #267](https://github.com/elycruz/walrs/issues/267);
-the entry below predates this release and is included here for completeness.
+  `web-sys`). The WebAssembly bindings have moved to the sibling crate
+  `walrs_acl_wasm`. See [issue #243](https://github.com/elycruz/walrs/issues/243).
 
 ### Changed (breaking)
 

--- a/crates/acl/Cargo.toml
+++ b/crates/acl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_acl"
-version = "0.3.0"
+version = "0.1.0"
 edition = "2024"
 license = "Elastic-2.0"
 

--- a/crates/digraph/Cargo.toml
+++ b/crates/digraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_digraph"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 license = "Elastic-2.0"
 

--- a/crates/fieldfilter/CHANGELOG.md
+++ b/crates/fieldfilter/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to `walrs_fieldfilter` are documented here. The format follo
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-26
+## [Unreleased]
 
-Coordinated pre-1.0 bump removing the dynamic `FieldFilter` / `Value` path. See
+The crate is still pre-publish; nothing has shipped to crates.io yet. The
+notes below describe breaking changes that have landed on `main` since the
+crate was created and will be folded into the eventual `0.1.0` release.
+
+Removes the dynamic `FieldFilter` / `Value` path. See
 [`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
 and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
 

--- a/crates/fieldfilter/Cargo.toml
+++ b/crates/fieldfilter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_fieldfilter"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 edition = "2024"
 license = "Elastic-2.0"

--- a/crates/fieldset_derive/CHANGELOG.md
+++ b/crates/fieldset_derive/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to `walrs_fieldset_derive` are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-26
+## [Unreleased]
 
-Coordinated pre-1.0 bump removing the dynamic `FormData` bridge. See
+The crate is still pre-publish; nothing has shipped to crates.io yet. The
+notes below describe breaking changes that have landed on `main` since the
+crate was created and will be folded into the eventual `0.1.0` release.
+
+Removes the dynamic `FormData` bridge. See
 [`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
 and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
 

--- a/crates/fieldset_derive/Cargo.toml
+++ b/crates/fieldset_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_fieldset_derive"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2024"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 description = "Derive macro for walrs_fieldfilter Fieldset trait"

--- a/crates/filter/CHANGELOG.md
+++ b/crates/filter/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to `walrs_filter` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-26
+## [Unreleased]
 
-Coordinated pre-1.0 bump removing the dynamic `Value` path. See
+The crate is still pre-publish; nothing has shipped to crates.io yet. The
+notes below describe breaking changes that have landed on `main` since the
+crate was created and will be folded into the eventual `0.1.0` release.
+
+Removes the dynamic `Value` path. See
 [`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
 and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
 

--- a/crates/filter/Cargo.toml
+++ b/crates/filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_filter"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 edition = "2024"
 description = "Filter/transformation structs for input filtering"

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_graph"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2024"
 license = "Elastic-2.0"
 

--- a/crates/navigation/Cargo.toml
+++ b/crates/navigation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_navigation"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2024"
 description = "A navigation component for managing trees of pointers to web pages"
 license = "Elastic-2.0"

--- a/crates/rbac-wasm/CHANGELOG.md
+++ b/crates/rbac-wasm/CHANGELOG.md
@@ -8,7 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Initial release. Extracted from `walrs_rbac` v0.2.0 — see
+- Initial release. Extracted from `walrs_rbac` — see
   [issue #243](https://github.com/elycruz/walrs/issues/243) and PR #282
   (which landed phase 2 of the extraction).
 - `wasm-bindgen` bindings: `JsRbac`, `JsRbacBuilder`, plus convenience fns

--- a/crates/rbac/CHANGELOG.md
+++ b/crates/rbac/CHANGELOG.md
@@ -4,34 +4,16 @@ All notable changes to `walrs_rbac` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-04-26
+## [Unreleased]
 
-Coordinated pre-1.0 bump completing the WASM extraction cycle. See
-[issue #243](https://github.com/elycruz/walrs/issues/243) for context. The
-WebAssembly bindings have moved to a sibling crate; JavaScript consumers
-should depend on `walrs_rbac_wasm` instead.
+The crate is still pre-publish; nothing has shipped to crates.io yet. The
+notes below describe breaking changes that have landed on `main` since the
+crate was created and will be folded into the eventual `0.1.0` release.
 
 ### Removed (breaking)
 
 - `wasm` cargo feature.
 - `cdylib` from `[lib] crate-type` (now defaults to `rlib` only).
 - Optional WASM dependencies (`wasm-bindgen`, `serde-wasm-bindgen`, `js-sys`).
-
-### Migration
-
-```toml
-# Before
-walrs_rbac = { version = "0.2", features = ["wasm"] }
-
-# After (Rust consumers — no change needed beyond version bump)
-walrs_rbac = "0.3"
-
-# After (WASM consumers — depend on the sibling crate)
-walrs_rbac_wasm = "0.1"
-```
-
-## [0.2.0] - 2026-04-26
-
-Coordinated pre-1.0 bump alongside the rest of the workspace as part of
-[issue #267](https://github.com/elycruz/walrs/issues/267) (Phase 4, b66ea99).
-No `walrs_rbac` API changes — this entry is included for changelog completeness.
+  The WebAssembly bindings have moved to the sibling crate `walrs_rbac_wasm`.
+  See [issue #243](https://github.com/elycruz/walrs/issues/243).

--- a/crates/rbac/Cargo.toml
+++ b/crates/rbac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_rbac"
-version = "0.3.0"
+version = "0.1.0"
 edition = "2024"
 description = "Role-Based Access Control (RBAC) permissions management"
 license = "Elastic-2.0"

--- a/crates/validation/CHANGELOG.md
+++ b/crates/validation/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to `walrs_validation` are documented here. The format follow
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-26
+## [Unreleased]
 
-Coordinated pre-1.0 bump removing the dynamic `Value` path. See
+The crate is still pre-publish; nothing has shipped to crates.io yet. The
+notes below describe breaking changes that have landed on `main` since the
+crate was created and will be folded into the eventual `0.1.0` release.
+
+Removes the dynamic `Value` path. See
 [`md/plans/2026-04-25-dynamic-path-removal.md`](../../md/plans/2026-04-25-dynamic-path-removal.md)
 and [issue #267](https://github.com/elycruz/walrs/issues/267) for context.
 

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walrs_validation"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Ely De La Cruz <elycruz@elycruz.com>"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
## Summary

Reverts every workspace crate version back to `0.1.0`. The project is still pre-publish (nothing on crates.io), so the recent bumps to `0.2.0` / `0.3.0` were premature.

## Changes

**Cargo.toml versions (back to 0.1.0):**

- `walrs` (root) — was 0.2.0
- `walrs_acl`, `walrs_rbac` — were 0.3.0
- `walrs_digraph`, `walrs_filter`, `walrs_graph`, `walrs_fieldfilter`, `walrs_navigation`, `walrs_validation`, `walrs_fieldset_derive` — were 0.2.0

`walrs_acl_wasm` and `walrs_rbac_wasm` were already at 0.1.0 and stay there.

**CHANGELOGs:**

The 0.2.0 / 0.3.0 entries described real breaking changes that landed on `main` (WASM extraction from #243; dynamic-`Value` removal from #267; `Rule` no-longer-`Copy` from #244). To preserve that information without claiming a release that didn't happen, each affected crate's `CHANGELOG.md` now folds those entries under `## [Unreleased]`. The two wasm crate CHANGELOGs drop their dangling `walrs_acl v0.2.0` / `walrs_rbac v0.2.0` source-crate references since those source-crate versions no longer exist after this revert.

**Cargo.lock** is updated to mirror the version reverts (no dep graph changes).

## Going forward

Crate versions remain at `0.1.0` until publishing is explicitly green-lit.

## Related Issue

Closes #286

## Test plan

- [x] `cargo fmt --all` — no diff
- [x] `cargo clippy --workspace --fix -- -D warnings` — clean
- [x] `cargo build --workspace` — green
- [x] `cargo test --workspace` — all tests pass (no code changes; only metadata + markdown)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)