### PR TITLE
refactor(fieldfilter): #288 rename clean→sanitize on Field and Fieldset

### DIFF
--- a/crates/fieldfilter/DESIGN.md
+++ b/crates/fieldfilter/DESIGN.md
@@ -33,7 +33,7 @@ walrs_validation → walrs_filter      → walrs_fieldfilter ← walrs_fieldset_
 
 - **`Fieldset`** — Typed multi-field pipeline trait. Implemented by hand or
   via `#[derive(Fieldset)]` (the `derive` feature). Provides `filter()`,
-  `validate()`, and `clean()` over a struct's named fields with
+  `validate()`, and `sanitize()` over a struct's named fields with
   compile-time-checked field names and types.
 
 - **`FieldsetAsync`** — Async variant of `Fieldset` (behind the `async`
@@ -44,7 +44,7 @@ walrs_validation → walrs_filter      → walrs_fieldfilter ← walrs_fieldset_
 
 ### Processing Pipeline
 
-`Fieldset::clean(self)` runs:
+`Fieldset::sanitize(self)` runs:
 
 1. **`filter(self)`** — applies each field's `FilterOp` filters in order.
 2. **`validate(&self)`** — runs each field's `Rule<T>` plus any

--- a/crates/fieldfilter/README.md
+++ b/crates/fieldfilter/README.md
@@ -15,14 +15,14 @@ let required_field: Field<String> = FieldBuilder::default()
     .build()
     .unwrap();
 // Field with rule and filter operations
-let cleaned_field: Field<String> = FieldBuilder::default()
+let sanitized_field: Field<String> = FieldBuilder::default()
     .rule(Rule::Required.and(Rule::MinLength(3)))
     .filters(vec![FilterOp::Trim, FilterOp::Lowercase])
     .build()
     .unwrap();
 // Validate
 assert!(required_field.validate("".to_string()).is_err());
-assert!(cleaned_field.validate("hello".to_string()).is_ok());
+assert!(sanitized_field.validate("hello".to_string()).is_ok());
 ```
 ### FilterOp<T> Enum
 Serializable filter operations for value transformation (defined in `walrs_filter`, re-exported here):
@@ -72,15 +72,15 @@ fn main() {
         name: "  Alice  ".into(),
     };
     
-    match form.clean() {
-        Ok(cleaned) => println!("Cleaned: {:?}", cleaned),
+    match form.sanitize() {
+        Ok(sanitized) => println!("Sanitized: {:?}", sanitized),
         Err(violations) => eprintln!("Errors: {}", violations),
     }
 }
 ```
 
 **Key features:**
-- `clean()` — filter then validate (convenience method)
+- `sanitize()` — filter then validate (convenience method)
 - `validate()` — validate without filtering
 - `filter()` — filter without validation
 - Nested struct support with `#[validate(nested)]` and `#[filter(nested)]`

--- a/crates/fieldfilter/examples/derive_async.rs
+++ b/crates/fieldfilter/examples/derive_async.rs
@@ -36,8 +36,8 @@ async fn main() {
     email: "  USER@EXAMPLE.COM  ".into(),
     username: "alice".into(),
   };
-  match ok.clean_async().await {
-    Ok(_) => println!("ok: clean_async succeeded"),
+  match ok.sanitize_async().await {
+    Ok(_) => println!("ok: sanitize_async succeeded"),
     Err(violations) => {
       eprintln!("unexpected validation failure:");
       for (field, fv) in violations.iter() {

--- a/crates/fieldfilter/examples/derive_nested.rs
+++ b/crates/fieldfilter/examples/derive_nested.rs
@@ -33,12 +33,12 @@ fn main() {
     },
   };
 
-  match form.clean() {
-    Ok(cleaned) => {
+  match form.sanitize() {
+    Ok(sanitized) => {
       println!("✓ Validation passed!");
-      println!("  Name: {}", cleaned.name);
-      println!("  Street: {}", cleaned.address.street);
-      println!("  Zip: {}", cleaned.address.zip);
+      println!("  Name: {}", sanitized.name);
+      println!("  Street: {}", sanitized.address.street);
+      println!("  Zip: {}", sanitized.address.zip);
     }
     Err(violations) => {
       eprintln!("✗ Validation failed:");
@@ -60,7 +60,7 @@ fn main() {
     },
   };
 
-  match invalid_form.clean() {
+  match invalid_form.sanitize() {
     Ok(_) => println!("✓ Unexpected success"),
     Err(violations) => {
       eprintln!("✗ Validation failed (expected):");

--- a/crates/fieldfilter/examples/derive_simple.rs
+++ b/crates/fieldfilter/examples/derive_simple.rs
@@ -19,14 +19,11 @@ fn main() {
     name: "  Alice  ".into(),
   };
 
-  match form.clean() {
-    Ok(cleaned) => {
+  match form.sanitize() {
+    Ok(sanitized) => {
       println!("✓ Validation passed!");
-      println!(
-        "  Email: {} (was: {})",
-        cleaned.email, "  USER@EXAMPLE.COM  "
-      );
-      println!("  Name: {} (was: {})", cleaned.name, "  Alice  ");
+      println!("  Email: {} (was:   USER@EXAMPLE.COM  )", sanitized.email);
+      println!("  Name: {} (was:   Alice  )", sanitized.name);
     }
     Err(violations) => {
       eprintln!("✗ Validation failed:");
@@ -45,7 +42,7 @@ fn main() {
     name: "A".into(),
   };
 
-  match invalid_form.clean() {
+  match invalid_form.sanitize() {
     Ok(_) => println!("✓ Unexpected success"),
     Err(violations) => {
       eprintln!("✗ Validation failed (expected):");

--- a/crates/fieldfilter/examples/field_basics.rs
+++ b/crates/fieldfilter/examples/field_basics.rs
@@ -71,10 +71,10 @@ fn main() {
   println!("   Filtered: '{}'", filtered);
   println!("   Validation: {:?}", email_field.validate_ref(&filtered));
 
-  // Example 4: Clean (filter + validate in one step)
-  println!("\n4. Using clean() for filter + validate:");
+  // Example 4: Sanitize (filter + validate in one step)
+  println!("\n4. Using sanitize() for filter + validate:");
   let input = "  ADMIN@COMPANY.ORG  ".to_string();
-  match email_field.clean(input.clone()) {
+  match email_field.sanitize(input.clone()) {
     Ok(result) => println!("   Input '{}' -> Result: '{}'", input, result),
     Err(violations) => println!("   Input '{}' -> Errors: {:?}", input, violations),
   }

--- a/crates/fieldfilter/fuzz/Cargo.toml
+++ b/crates/fieldfilter/fuzz/Cargo.toml
@@ -22,6 +22,6 @@ members = ["."]
 debug = 1
 
 [[bin]]
-name = "fuzz_field_string_clean"
-path = "fuzz_targets/fuzz_field_string_clean.rs"
+name = "fuzz_field_string_sanitize"
+path = "fuzz_targets/fuzz_field_string_sanitize.rs"
 doc = false

--- a/crates/fieldfilter/fuzz/fuzz_targets/fuzz_field_string_sanitize.rs
+++ b/crates/fieldfilter/fuzz/fuzz_targets/fuzz_field_string_sanitize.rs
@@ -12,8 +12,8 @@ fuzz_target!(|data: &[u8]| {
             .filters(vec![FilterOp::Trim, FilterOp::Lowercase])
             .build()
             .unwrap();
-        let _ = field.clean(s.to_string());
-        let _ = field.clean_ref(s);
+        let _ = field.sanitize(s.to_string());
+        let _ = field.sanitize_ref(s);
 
         // Field with length validation + strip tags
         let field: Field<String> = FieldBuilder::default()
@@ -22,6 +22,6 @@ fuzz_target!(|data: &[u8]| {
             .filters(vec![FilterOp::Trim, FilterOp::StripTags])
             .build()
             .unwrap();
-        let _ = field.clean(s.to_string());
+        let _ = field.sanitize(s.to_string());
     }
 });

--- a/crates/fieldfilter/src/field.rs
+++ b/crates/fieldfilter/src/field.rs
@@ -55,9 +55,9 @@ use walrs_validation::ValidateRefAsync;
 ///     .build()
 ///     .unwrap();
 ///
-/// // clean() applies infallible filters, then fallible filters, then validates
-/// assert!(field.clean("  hello  ".to_string()).is_ok());
-/// assert!(field.clean("  \0bad  ".to_string()).is_err());
+/// // sanitize() applies infallible filters, then fallible filters, then validates
+/// assert!(field.sanitize("  hello  ".to_string()).is_ok());
+/// assert!(field.sanitize("  \0bad  ".to_string()).is_err());
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize, Builder)]
 #[builder(setter(into, strip_option), default)]
@@ -294,7 +294,7 @@ where
   }
 }
 
-fn clean_impl<T: FieldOps>(field: &Field<T>, value: T) -> Result<T, Violations>
+fn sanitize_impl<T: FieldOps>(field: &Field<T>, value: T) -> Result<T, Violations>
 where
   Rule<T>: ValidateRef<T::ValueRef>,
 {
@@ -335,7 +335,7 @@ where
 }
 
 #[cfg(feature = "async")]
-async fn clean_async_impl<T: FieldOps>(field: &Field<T>, value: T) -> Result<T, Violations>
+async fn sanitize_async_impl<T: FieldOps>(field: &Field<T>, value: T) -> Result<T, Violations>
 where
   T::ValueRef: Sync,
   Rule<T>: ValidateRefAsync<T::ValueRef>,
@@ -402,15 +402,15 @@ impl Field<String> {
   ///
   /// Applies infallible filters first, then fallible filters, then validates.
   /// Returns `Ok(filtered_value)` if all steps pass, or `Err(Violations)`.
-  pub fn clean(&self, value: String) -> Result<String, Violations> {
-    clean_impl(self, value)
+  pub fn sanitize(&self, value: String) -> Result<String, Violations> {
+    sanitize_impl(self, value)
   }
 
   /// Filter a `&str` and then validate the result.
   ///
-  /// Like [`clean`](Self::clean) but starts from a `&str` reference,
+  /// Like [`sanitize`](Self::sanitize) but starts from a `&str` reference,
   /// avoiding the need for the caller to allocate a `String` up-front.
-  pub fn clean_ref(&self, value: &str) -> Result<String, Violations> {
+  pub fn sanitize_ref(&self, value: &str) -> Result<String, Violations> {
     let filtered = self.filter_ref(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref(&filtered)?;
@@ -440,12 +440,12 @@ impl Field<String> {
   /// Filter the value synchronously (infallible + fallible), then validate asynchronously.
   ///
   /// Returns `Ok(filtered_value)` if all steps pass, or `Err(Violations)`.
-  pub async fn clean_async(&self, value: String) -> Result<String, Violations> {
-    clean_async_impl(self, value).await
+  pub async fn sanitize_async(&self, value: String) -> Result<String, Violations> {
+    sanitize_async_impl(self, value).await
   }
 
-  /// Like [`clean_async`](Self::clean_async) but starts from a `&str` reference.
-  pub async fn clean_ref_async(&self, value: &str) -> Result<String, Violations> {
+  /// Like [`sanitize_async`](Self::sanitize_async) but starts from a `&str` reference.
+  pub async fn sanitize_ref_async(&self, value: &str) -> Result<String, Violations> {
     let filtered = self.filter_ref(value);
     let filtered = self.try_filter(filtered)?;
     self.validate_ref_async(&filtered).await?;
@@ -538,14 +538,14 @@ mod tests {
   }
 
   #[test]
-  fn test_string_field_clean() {
+  fn test_string_field_sanitize() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .rule(Rule::MinLength(3))
       .build()
       .unwrap();
 
-    let result = field.clean("  hello  ".to_string());
+    let result = field.sanitize("  hello  ".to_string());
     assert_eq!(result.unwrap(), "hello");
   }
 
@@ -660,7 +660,7 @@ mod tests {
   }
 
   #[test]
-  fn test_string_field_clean_with_try_filters() {
+  fn test_string_field_sanitize_with_try_filters() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .try_filters(vec![TryFilterOp::TryCustom(Arc::new(|s: String| {
@@ -675,20 +675,20 @@ mod tests {
       .unwrap();
 
     // Happy path: trim -> try_filter passes -> validation passes
-    assert_eq!(field.clean("  hello  ".to_string()).unwrap(), "hello");
+    assert_eq!(field.sanitize("  hello  ".to_string()).unwrap(), "hello");
 
     // Try filter fails (empty after trim)
-    let err = field.clean("     ".to_string()).unwrap_err();
+    let err = field.sanitize("     ".to_string()).unwrap_err();
     assert_eq!(err.len(), 1);
     assert!(err[0].message().contains("empty after trimming"));
 
     // Try filter passes but validation fails (too short)
-    let err = field.clean("  hi  ".to_string()).unwrap_err();
+    let err = field.sanitize("  hi  ".to_string()).unwrap_err();
     assert_eq!(err.len(), 1);
   }
 
   #[test]
-  fn test_string_field_clean_try_filter_short_circuits() {
+  fn test_string_field_sanitize_try_filter_short_circuits() {
     let field = FieldBuilder::<String>::default()
       .try_filters(vec![
         TryFilterOp::TryCustom(Arc::new(|_| Err(FilterError::new("first fails")))),
@@ -699,7 +699,7 @@ mod tests {
       .build()
       .unwrap();
 
-    let err = field.clean("hello".to_string()).unwrap_err();
+    let err = field.sanitize("hello".to_string()).unwrap_err();
     assert!(err[0].message().contains("first fails"));
   }
 
@@ -725,11 +725,11 @@ mod tests {
   }
 
   // ====================================================================
-  // clean_ref tests — Field<String>
+  // sanitize_ref tests — Field<String>
   // ====================================================================
 
   #[test]
-  fn test_string_field_clean_ref() {
+  fn test_string_field_sanitize_ref() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .rule(Rule::MinLength(3))
@@ -737,14 +737,14 @@ mod tests {
       .unwrap();
 
     // Happy path: starts from &str
-    assert_eq!(field.clean_ref("  hello  ").unwrap(), "hello");
+    assert_eq!(field.sanitize_ref("  hello  ").unwrap(), "hello");
 
     // Validation fails
-    assert!(field.clean_ref("  hi  ").is_err());
+    assert!(field.sanitize_ref("  hi  ").is_err());
   }
 
   #[test]
-  fn test_string_field_clean_ref_with_try_filters() {
+  fn test_string_field_sanitize_ref_with_try_filters() {
     let field = FieldBuilder::<String>::default()
       .filters(vec![FilterOp::Trim])
       .try_filters(vec![TryFilterOp::TryCustom(Arc::new(|s: String| {
@@ -758,15 +758,15 @@ mod tests {
       .build()
       .unwrap();
 
-    assert_eq!(field.clean_ref("  hello  ").unwrap(), "hello");
-    assert!(field.clean_ref("     ").is_err()); // empty after trim
-    assert!(field.clean_ref("  hi  ").is_err()); // too short
+    assert_eq!(field.sanitize_ref("  hello  ").unwrap(), "hello");
+    assert!(field.sanitize_ref("     ").is_err()); // empty after trim
+    assert!(field.sanitize_ref("  hi  ").is_err()); // too short
   }
 
   #[test]
-  fn test_string_field_clean_ref_no_filters_no_rule() {
+  fn test_string_field_sanitize_ref_no_filters_no_rule() {
     let field = FieldBuilder::<String>::default().build().unwrap();
-    assert_eq!(field.clean_ref("hello").unwrap(), "hello");
+    assert_eq!(field.sanitize_ref("hello").unwrap(), "hello");
   }
 
   // ====================================================================

--- a/crates/fieldfilter/src/fieldset.rs
+++ b/crates/fieldfilter/src/fieldset.rs
@@ -47,8 +47,8 @@ use std::future::Future;
 /// }
 ///
 /// let form = LoginForm { email: " Test@Example.com ".to_string(), password: "secret123".to_string() };
-/// let cleaned = form.clean().unwrap();
-/// assert_eq!(cleaned.email, "test@example.com");
+/// let sanitized = form.sanitize().unwrap();
+/// assert_eq!(sanitized.email, "test@example.com");
 /// ```
 pub trait Fieldset: Sized {
   /// If `true`, validation stops after the first field with violations.
@@ -61,7 +61,7 @@ pub trait Fieldset: Sized {
   fn filter(self) -> Result<Self, FieldsetViolations>;
 
   /// Filter and then validate (convenience method).
-  fn clean(self) -> Result<Self, FieldsetViolations> {
+  fn sanitize(self) -> Result<Self, FieldsetViolations> {
     let filtered = self.filter()?;
     filtered.validate()?;
     Ok(filtered)
@@ -81,7 +81,7 @@ pub trait FieldsetAsync: Fieldset + Send {
   fn filter_async(self) -> impl Future<Output = Result<Self, FieldsetViolations>> + Send;
 
   /// Filter and then validate asynchronously (convenience method).
-  fn clean_async(self) -> impl Future<Output = Result<Self, FieldsetViolations>> + Send {
+  fn sanitize_async(self) -> impl Future<Output = Result<Self, FieldsetViolations>> + Send {
     async {
       let filtered = self.filter_async().await?;
       filtered.validate_async().await?;
@@ -182,7 +182,7 @@ mod tests {
     }
   }
 
-  // 1. Test manual Fieldset impl — validate, filter, clean
+  // 1. Test manual Fieldset impl — validate, filter, sanitize
   #[test]
   fn test_validate_pass() {
     let form = ContactForm {
@@ -215,14 +215,14 @@ mod tests {
   }
 
   #[test]
-  fn test_clean_success() {
+  fn test_sanitize_success() {
     let form = ContactForm {
       name: "  Alice  ".into(),
       email: "  ALICE@EXAMPLE.COM  ".into(),
     };
-    let cleaned = form.clean().unwrap();
-    assert_eq!(cleaned.name, "Alice");
-    assert_eq!(cleaned.email, "alice@example.com");
+    let sanitized = form.sanitize().unwrap();
+    assert_eq!(sanitized.name, "Alice");
+    assert_eq!(sanitized.email, "alice@example.com");
   }
 
   // 2. Test BREAK_ON_FAILURE const override
@@ -245,44 +245,44 @@ mod tests {
     assert_eq!(err.len(), 1);
   }
 
-  // 3. Test that clean = filter + validate
+  // 3. Test that sanitize = filter + validate
   #[test]
-  fn test_clean_equals_filter_then_validate() {
+  fn test_sanitize_equals_filter_then_validate() {
     let form1 = ContactForm {
       name: "  Alice  ".into(),
       email: "  ALICE@EXAMPLE.COM  ".into(),
     };
     let form2 = form1.clone();
 
-    let via_clean = form1.clean().unwrap();
+    let via_sanitize = form1.sanitize().unwrap();
 
     let filtered = form2.filter().unwrap();
     filtered.validate().unwrap();
     let via_manual = filtered;
 
-    assert_eq!(via_clean, via_manual);
+    assert_eq!(via_sanitize, via_manual);
   }
 
-  // 4. Test clean with filter error
+  // 4. Test sanitize with filter error
   #[test]
-  fn test_clean_filter_error() {
+  fn test_sanitize_filter_error() {
     let form = ParsedForm {
       age: "not-a-number".into(),
     };
-    let err = form.clean().unwrap_err();
+    let err = form.sanitize().unwrap_err();
     assert!(err.get("age").is_some());
     assert_eq!(err.len(), 1);
   }
 
-  // 5. Test clean with validation error
+  // 5. Test sanitize with validation error
   #[test]
-  fn test_clean_validation_error() {
+  fn test_sanitize_validation_error() {
     let form = ContactForm {
       name: "  ".into(),
       email: "  bad  ".into(),
     };
     // Filter trims, then validate sees empty name and bad email
-    let err = form.clean().unwrap_err();
+    let err = form.sanitize().unwrap_err();
     assert!(err.get("name").is_some() || err.get("email").is_some());
   }
 
@@ -347,20 +347,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_clean_async() {
+    async fn test_sanitize_async() {
       let form = AsyncForm {
         email: "  VALID@EXAMPLE.COM  ".into(),
       };
-      let cleaned = form.clean_async().await.unwrap();
-      assert_eq!(cleaned.email, "valid@example.com");
+      let sanitized = form.sanitize_async().await.unwrap();
+      assert_eq!(sanitized.email, "valid@example.com");
     }
 
     #[tokio::test]
-    async fn test_clean_async_validation_error() {
+    async fn test_sanitize_async_validation_error() {
       let form = AsyncForm {
         email: "   ".into(),
       };
-      let err = form.clean_async().await.unwrap_err();
+      let err = form.sanitize_async().await.unwrap_err();
       assert!(err.get("email").is_some());
     }
   }

--- a/crates/fieldfilter/src/lib.rs
+++ b/crates/fieldfilter/src/lib.rs
@@ -27,8 +27,8 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! // Clean (filter + validate) a value
-//! let result = email_field.clean("  TEST@EXAMPLE.COM  ".to_string());
+//! // Sanitize (filter + validate) a value
+//! let result = email_field.sanitize("  TEST@EXAMPLE.COM  ".to_string());
 //! assert!(result.is_ok());
 //! assert_eq!(result.unwrap(), "test@example.com");
 //!
@@ -47,8 +47,8 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! assert!(encoded_field.clean("hello".to_string()).is_ok());
-//! assert!(encoded_field.clean("bad\0input".to_string()).is_err());
+//! assert!(encoded_field.sanitize("hello".to_string()).is_ok());
+//! assert!(encoded_field.sanitize("bad\0input".to_string()).is_err());
 //! ```
 //!
 //! ## Typed path — [`Fieldset`]
@@ -56,7 +56,7 @@
 //! When fields are known at compile time, define a struct and either implement
 //! [`Fieldset`] manually or use `#[derive(Fieldset)]` (behind the `derive`
 //! feature, re-exported as [`DeriveFieldset`]). You get statically-checked
-//! fields, native Rust types, and per-field `clean()` semantics.
+//! fields, native Rust types, and per-field `sanitize()` semantics.
 
 #[macro_use]
 extern crate derive_builder;

--- a/crates/fieldfilter/tests/async_fieldfilter.rs
+++ b/crates/fieldfilter/tests/async_fieldfilter.rs
@@ -50,7 +50,7 @@ async fn string_field_with_custom_async_rule() {
 }
 
 #[tokio::test]
-async fn string_field_clean_async() {
+async fn string_field_sanitize_async() {
   let rule = Rule::<String>::custom_async(Arc::new(|value: &String| {
     Box::pin(async move {
       if value.contains("bad") {
@@ -66,9 +66,9 @@ async fn string_field_clean_async() {
     .build()
     .unwrap();
 
-  let result = field.clean_async("  good  ".to_string()).await;
+  let result = field.sanitize_async("  good  ".to_string()).await;
   assert_eq!(result.unwrap(), "good");
 
-  let result = field.clean_async("  bad  ".to_string()).await;
+  let result = field.sanitize_async("  bad  ".to_string()).await;
   assert!(result.is_err());
 }

--- a/crates/fieldfilter/tests/derive_fieldset.rs
+++ b/crates/fieldfilter/tests/derive_fieldset.rs
@@ -52,23 +52,23 @@ mod derive_tests {
   }
 
   #[test]
-  fn test_simple_clean() {
+  fn test_simple_sanitize() {
     let addr = UserAddress {
       street: "  123 Main St  ".into(),
       zip: "  90210  ".into(),
     };
-    let cleaned = addr.clean().unwrap();
-    assert_eq!(cleaned.street, "123 Main St");
-    assert_eq!(cleaned.zip, "90210");
+    let sanitized = addr.sanitize().unwrap();
+    assert_eq!(sanitized.street, "123 Main St");
+    assert_eq!(sanitized.zip, "90210");
   }
 
   #[test]
-  fn test_clean_fails_validation_after_filter() {
+  fn test_sanitize_fails_validation_after_filter() {
     let addr = UserAddress {
       street: "  ab  ".into(), // trims to "ab", too short
       zip: "  bad  ".into(),   // trims to "bad", no match
     };
-    let err = addr.clean().unwrap_err();
+    let err = addr.sanitize().unwrap_err();
     assert!(err.get("street").is_some());
     assert!(err.get("zip").is_some());
   }
@@ -428,11 +428,11 @@ mod derive_tests {
   }
 
   #[test]
-  fn test_numeric_clamp_clean() {
+  fn test_numeric_clamp_sanitize() {
     let form = ClampForm { percentage: 150 };
     // After filter (clamp to 100), validation passes
-    let cleaned = form.clean().unwrap();
-    assert_eq!(cleaned.percentage, 100);
+    let sanitized = form.sanitize().unwrap();
+    assert_eq!(sanitized.percentage, 100);
   }
 
   // =========================================================================

--- a/crates/fieldfilter/tests/derive_fieldset_async.rs
+++ b/crates/fieldfilter/tests/derive_fieldset_async.rs
@@ -94,14 +94,14 @@ async fn filter_async_delegates_to_sync_filter() {
 }
 
 #[tokio::test]
-async fn clean_async_runs_filter_then_validate() {
+async fn sanitize_async_runs_filter_then_validate() {
   let r = Registration {
     email: "  USER@EXAMPLE.COM  ".into(),
     username: "alice".into(),
   };
-  let cleaned = r.clean_async().await.unwrap();
-  assert_eq!(cleaned.email, "user@example.com");
-  assert_eq!(cleaned.username, "alice");
+  let sanitized = r.sanitize_async().await.unwrap();
+  assert_eq!(sanitized.email, "user@example.com");
+  assert_eq!(sanitized.username, "alice");
 }
 
 #[tokio::test]

--- a/crates/fieldset_derive/README.md
+++ b/crates/fieldset_derive/README.md
@@ -46,11 +46,11 @@ fn main() {
         name: "  Alice  ".into(),
     };
     
-    match form.clean() {
-        Ok(cleaned) => {
-            // cleaned.email == "user@example.com"
-            // cleaned.name == "Alice"
-            println!("Success: {:?}", cleaned);
+    match form.sanitize() {
+        Ok(sanitized) => {
+            // sanitized.email == "user@example.com"
+            // sanitized.name == "Alice"
+            println!("Success: {:?}", sanitized);
         }
         Err(violations) => {
             eprintln!("Validation failed: {}", violations);


### PR DESCRIPTION
Closes #288.

## Summary

- Renames `clean` (and variants) → `sanitize` on `Field<String>` and `Fieldset` for clearer combined filter+validate semantics.
- Pure rename: signatures, behavior, and filter→validate execution order are unchanged.
- The `fieldset_derive` proc-macro relies on the trait default and emits no literal `clean` identifier, so no macro source changes were needed.

## Renames

| Old | New |
| --- | --- |
| `Field::clean` | `Field::sanitize` |
| `Field::clean_ref` | `Field::sanitize_ref` |
| `Field::clean_async` | `Field::sanitize_async` |
| `Field::clean_ref_async` | `Field::sanitize_ref_async` |
| `Fieldset::clean` (default impl) | `Fieldset::sanitize` |
| `FieldsetAsync::clean_async` (default impl) | `FieldsetAsync::sanitize_async` |
| Private helpers `clean_impl` / `clean_async_impl` | `sanitize_impl` / `sanitize_async_impl` |
| Fuzz target `fuzz_field_string_clean.rs` | `fuzz_field_string_sanitize.rs` |

Plus all in-crate tests, examples, doc comments, `crates/fieldfilter/{README.md,DESIGN.md}`, and `crates/fieldset_derive/README.md`.

## Breaking change

This is a public-API rename for `walrs_fieldfilter`. Per the prepublish stance (all walrs crates pinned to `0.1.0`), there is no SemVer obligation, but downstream users of `clean*` methods will need to update their call-sites.

## Test plan

- [x] `cargo build --workspace --all-features` — clean.
- [x] `cargo test -p walrs_fieldfilter --all-features` — 22 lib + 4 async + 13 derive_fieldset + 4 derive_fieldset_async tests pass.
- [x] `cargo run -p walrs_fieldfilter --example derive_simple --features derive` — runs and produces expected output.
- [x] `cargo doc -p walrs_fieldfilter --all-features --no-deps` — intra-doc links resolve cleanly.
- [x] `cargo build --manifest-path crates/fieldfilter/fuzz/Cargo.toml` — renamed fuzz target builds.
- [x] Workspace-wide `\bclean\b` sweep — no remaining method references; only unrelated hits (e.g. `ammonia::Clean::clean()` in `walrs_filter::strip_tags`, English usage in benches/comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)