### PR TITLE
docs(walrs_rbac,walrs_rbac_wasm): #292-rbac-pair refresh READMEs — features, public API, examples

### DIFF
--- a/crates/rbac-wasm/README.md
+++ b/crates/rbac-wasm/README.md
@@ -1,6 +1,8 @@
-# walrs_rbac (js)
+# walrs_rbac_wasm
 
-WebAssembly version of [walrs_rbac](../../README.md).
+WebAssembly / JavaScript bindings for [`walrs_rbac`](../rbac/README.md).
+
+This crate re-exposes `walrs_rbac`'s `Rbac` and `RbacBuilder` to JS through `wasm-bindgen` as `JsRbac` and `JsRbacBuilder`. For Rust-side semantics (role hierarchy, inheritance rules, JSON representation), see the [`walrs_rbac` README](../rbac/README.md).
 
 ## Prerequisites
 
@@ -11,6 +13,13 @@ Any environment that supports WebAssembly:
 - Chrome/Edge 57+
 - Firefox 52+
 - Safari 11+
+
+## Public API surface (JS)
+
+Exported from `pkg/walrs_rbac_wasm.js` after a `wasm-pack` build (see `src/lib.rs` for the `#[wasm_bindgen]` definitions):
+
+- **Classes**: `JsRbacBuilder`, `JsRbac`
+- **Functions**: `createRbacFromJson(json)`, `checkPermission(rbacJson, role, permission)`
 
 ## JavaScript API
 
@@ -65,9 +74,9 @@ console.log(rbac.roleCount());  // 4
 
 #### Methods
 
-- **`new JsRbac()`** - Create empty RBAC
-- **`fromJson(json: string): JsRbac`** - Load from JSON configuration
-- **`isGranted(role: string, permission: string): boolean`** - Check permission
+- **`new JsRbac()`** - Create empty RBAC (rarely used directly; prefer the builder or `JsRbac.fromJson(...)`)
+- **`JsRbac.fromJson(json: string): JsRbac`** _(static)_ - Load from a JSON configuration string
+- **`isGranted(role: string, permission: string): boolean`** - Check permission (direct or inherited)
 - **`hasRole(role: string): boolean`** - Check if role exists
 - **`roleCount(): number`** - Get number of roles
 
@@ -140,6 +149,22 @@ wasm-pack build --target web
 wasm-pack build --target bundler
 ```
 
+**Build + run JS tests in one shot** (matches the [`WASM` CI workflow](../../.github/workflows/wasm.yml)):
+
+```bash
+sh ./ci-cd-wasm.sh
+```
+
+This runs `wasm-pack build --target nodejs`, optimizes the resulting `.wasm` with `wasm-opt -Oz`, then runs the Node test suite under `tests-js/`.
+
+### Rust-side sanity check
+
+For a quick compile check without producing a `.wasm` artifact:
+
+```bash
+cargo check -p walrs_rbac_wasm
+```
+
 ### Publishing to NPM
 
 ```bash
@@ -153,4 +178,4 @@ This crate is inspired by the [laminas-permissions-rbac](https://github.com/lami
 
 ## License
 
-Same as the main crate: Apache-2.0 AND GPL-3.0-only.
+Elastic-2.0 (matches the parent [`walrs_rbac`](../rbac/README.md) crate).

--- a/crates/rbac/README.md
+++ b/crates/rbac/README.md
@@ -53,8 +53,7 @@ The RBAC can be constructed:
 
 - using the `RbacBuilder` structure (fluent interface).
 - from a \*.json representation, using `RbacBuilder::try_from(&mut File)?.build()`.
-- from a \*.json representation, using `RbacBuilder::try_from(RbacData)?.build()` (`RbacData` can also be constructed from a \*.json file).
-- from a \*.yaml representation (behind the `yaml` feature flag), using `RbacData::from_yaml()`.
+- from a deserialized `RbacData`, using `RbacBuilder::try_from(&RbacData)?.build()` (`RbacData` can be parsed from JSON via `RbacData::from_json` or, with the `yaml` feature, from YAML via `RbacData::from_yaml`).
 
 ### JSON Representation
 
@@ -115,19 +114,33 @@ The `is_granted(role, permission)` method checks if a role has a permission eith
 | `rbac.has_role(role)` | Check if a role exists |
 | `rbac.get_role(role)` | Get a reference to a `Role` |
 | `rbac.role_count()` | Get the number of roles |
+| `rbac.role_names()` | Iterator over role names |
 
 See tests, [benchmarks](benchmarks), and/or [examples](examples) for more details.
 
+## Public API surface
+
+Top-level re-exports from `walrs_rbac` (see `src/lib.rs`):
+
+- **Core**: `Rbac`, `RbacBuilder`, `Role`
+- **Data**: `RbacData` (serde-serializable representation; supports JSON and, with `yaml`, YAML)
+- **Errors**: `RbacError`, `Result` (alias for `core::result::Result<T, RbacError>`)
+
+`RbacError` variants: `RoleNotFound`, `CycleDetected`, `InvalidConfiguration`, `DeserializationError`, `SerializationError`.
+
 ## Features
 
-- **`std`** (default): Full standard library support with file I/O and JSON
-- **`yaml`**: YAML serialization/deserialization support
-- **`wasm`**: WASM-compatible mode with `no_std` + `alloc`
+| Feature | Default | Enables |
+|---|---|---|
+| `std` | yes | Standard-library support: file I/O (`TryFrom<&mut File>` for `RbacData`/`RbacBuilder`), `std::error::Error` impl on `RbacError`, `HashMap` storage. |
+| `yaml` | no | YAML serialization/deserialization on `RbacData` (`from_yaml` / `to_yaml`) via `serde_yaml`. |
 
-### Usage
+Disabling default features (`default-features = false`) drops `std` and switches the crate to `no_std + alloc` mode (uses `BTreeMap` instead of `HashMap`); this is the configuration used by `walrs_rbac_wasm`.
+
+### Installation
 
 ```toml
-# Default (JSON support)
+# Default (JSON support, std)
 [dependencies]
 walrs_rbac = "0.1.0"
 
@@ -135,20 +148,25 @@ walrs_rbac = "0.1.0"
 [dependencies]
 walrs_rbac = { version = "0.1.0", features = ["yaml"] }
 
-# For WASM targets
+# no_std / WASM-compatible (alloc only)
 [dependencies]
-walrs_rbac = { version = "0.1.0", default-features = false, features = ["wasm"] }
+walrs_rbac = { version = "0.1.0", default-features = false }
 ```
+
+## Examples
+
+Runnable examples live in [`examples/`](./examples/). Run any of them with `cargo run -p walrs_rbac --example <name>`.
+
+| Example | Demonstrates | Run command |
+|---|---|---|
+| `rbac_builder_example` | Fluent `RbacBuilder` usage and `is_granted` checks | `cargo run -p walrs_rbac --example rbac_builder_example` |
+| `rbac_try_from_json` | Loading an RBAC from a JSON file via `TryFrom<&mut File>` | `cargo run -p walrs_rbac --example rbac_try_from_json` (run from `crates/rbac/` so the fixture path resolves) |
 
 ## WASM Support
 
-The crate supports WebAssembly (see [WASM README](WASM_README.md) for details).
+`walrs_rbac` is `no_std`-compatible (with `alloc`) when built with `default-features = false`. JavaScript/TypeScript bindings live in the companion crate [`walrs_rbac_wasm`](../rbac-wasm/README.md), which exposes `JsRbac`, `JsRbacBuilder`, and convenience helpers via `wasm-bindgen`.
 
-### Build
-
-```bash
-$ sh ./ci-cd-wasm.sh
-```
+To build the WASM bindings, work in `crates/rbac-wasm/` (see its README).
 
 ## Prior Art
 


### PR DESCRIPTION
Closes part of #292.

## Summary

Docs-only refresh for the RBAC pair. Augments both READMEs to match current code; no Rust source touched, no Cargo.toml changes, no version bumps.

### `crates/rbac/README.md`

- **Feature flags**: documents the actual flags (`std` default, `yaml`). Drops the stale **`wasm`** feature claim — there is no `wasm` feature in `crates/rbac/Cargo.toml`; WASM-compatible mode is `default-features = false` (no_std + alloc). README now explains this correctly.
- **Public API surface**: top-level re-exports from `src/lib.rs` (`Rbac`, `RbacBuilder`, `Role`, `RbacData`, `RbacError`, `Result`) plus `RbacError` variants.
- **Examples table**: covers both runnable examples (`rbac_builder_example`, `rbac_try_from_json`) with run commands; notes the JSON example needs to be run from `crates/rbac/` so the relative fixture path resolves.
- **WASM section**: replaces the broken `WASM_README.md` link / `ci-cd-wasm.sh` reference (that script lives in `rbac-wasm`, not here) with a pointer to the companion `walrs_rbac_wasm` crate.
- Adds a `role_names()` row to the Key API table.

### `crates/rbac-wasm/README.md`

- **Cross-link** to parent `walrs_rbac` crate README; clarifies this crate is a wasm-bindgen wrapper, not a standalone implementation.
- **Public API surface (JS)** section listing `JsRbac`, `JsRbacBuilder`, `createRbacFromJson`, `checkPermission`.
- Adds a `sh ./ci-cd-wasm.sh` quick-build note (matches `.github/workflows/wasm.yml`) plus a `cargo check -p walrs_rbac_wasm` sanity-check.
- **License fix**: Cargo.toml says `Elastic-2.0`; README incorrectly claimed `Apache-2.0 AND GPL-3.0-only`.
- Tightens the `JsRbac` methods list (notes `new JsRbac()` is rarely used directly; static `fromJson` is the typical entry point).

## Out of scope (spotted, not fixed)

- The `walrs_rbac` crate has no `wasm` feature in `Cargo.toml`, but the docs and one comment chain elsewhere may still reference it; only the rbac README was in scope here. Worth a follow-up grep.
- `cargo fmt --check` reports pre-existing drift in unrelated crates (carried over from the fieldfilter PR observation); intentionally left alone.

## Test plan

- [x] `cargo build -p walrs_rbac` (default features) — clean
- [x] `cargo build -p walrs_rbac --features yaml` — clean
- [x] `cargo test -p walrs_rbac` — 30 passed (including doctests)
- [x] `cargo run -p walrs_rbac --example rbac_builder_example` — output matches expected role-inheritance behavior
- [x] `cargo run --example rbac_try_from_json` (from `crates/rbac/`) — loads `./test-fixtures/example-rbac.json`, prints expected results
- [x] `cargo check -p walrs_rbac_wasm` — clean (CI workflow `.github/workflows/wasm.yml` builds the actual `.wasm` via `wasm-pack`)
- [x] Cross-checked every documented re-export against `crates/rbac/src/lib.rs` and every JS export against `crates/rbac-wasm/src/lib.rs`

## Notes

- Docs-only — `cargo fmt`/`clippy` and coverage gate N/A.
- All Cargo.toml versions left at `0.1.0` (prepublish mode).