### PR TITLE
docs(walrs_acl,walrs_acl_wasm): #292-acl-pair refresh READMEs — features, public API, examples

### DIFF
--- a/crates/acl-wasm/README.md
+++ b/crates/acl-wasm/README.md
@@ -12,6 +12,15 @@ Any environment that supports WebAssembly:
 - Firefox 52+
 - Safari 11+
 
+## Public API surface
+
+Wraps `walrs_acl::simple` for JavaScript consumers. All names below are exported from `wasm-bindgen` with their JS-style aliases:
+
+- **Classes**: `JsAclBuilder`, `JsAcl`
+- **Functions**: `createAclFromJson(json)`, `checkPermission(aclJson, role?, resource?, privilege?)`
+
+This crate does not expose feature flags — all configuration is via the JS API. For Rust-side conditional assertions and async resolvers, see the parent [`walrs_acl` README](../acl/README.md).
+
 ## JavaScript API
 
 ### JsAclBuilder
@@ -45,12 +54,18 @@ try {
 #### Methods
 
 - **`new JsAclBuilder()`** - Create a new builder
-- **`fromJson(json: string): JsAclBuilder`** - Load from JSON string
+- **`JsAclBuilder.fromJson(json: string): JsAclBuilder`** - Load from JSON string (static)
 - **`addRole(role: string, parents?: string[]): JsAclBuilder`** - Add a role
+- **`addRoles(entries: [string, string[] | null][]): JsAclBuilder`** - Bulk-add roles as `[name, parents | null]` tuples
 - **`addResource(resource: string, parents?: string[]): JsAclBuilder`** - Add a resource
+- **`addResources(entries: [string, string[] | null][]): JsAclBuilder`** - Bulk-add resources as `[name, parents | null]` tuples
 - **`allow(roles?: string[], resources?: string[], privileges?: string[]): JsAclBuilder`** - Add allow rule
 - **`deny(roles?: string[], resources?: string[], privileges?: string[]): JsAclBuilder`** - Add deny rule
+- **`allowIf(roles?, resources?, privileges?, assertionKey: string): JsAclBuilder`** - Add a conditional allow rule keyed by an assertion (resolved at check time via `JsAcl.isAllowedWith`)
+- **`denyIf(roles?, resources?, privileges?, assertionKey: string): JsAclBuilder`** - Add a conditional deny rule (mirrors `allowIf`)
 - **`build(): JsAcl`** - Build the final ACL
+
+See the [conditional assertions](../acl/README.md#assertions) section in the `walrs_acl` README for the semantics of `allowIf` / `denyIf` (conservative defaults, opposing-family clearing, etc.).
 
 ### JsAcl
 
@@ -77,14 +92,15 @@ console.log(acl.inheritsResource("blog", "index"));  // depends on structure
 #### Methods
 
 - **`new JsAcl()`** - Create empty ACL (not usually needed)
-- **`fromJson(json: string): JsAcl`** - Load from JSON configuration
-- **`isAllowed(role?: string, resource?: string, privilege?: string): boolean`** - Check permission
-- **`isAllowedAny(role?: string, resource?: string, privileges: string[]): boolean`** - Check if any privilege is allowed
+- **`JsAcl.fromJson(json: string): JsAcl`** - Load from JSON configuration (static)
+- **`isAllowed(role?: string, resource?: string, privilege?: string): boolean`** - Check permission. Conditional rules (`AllowIf` / `DenyIf`) are treated conservatively — see `isAllowedWith` to evaluate them.
+- **`isAllowedAny(roles?: string[], resources?: string[], privileges?: string[]): boolean`** - Check if any of the given roles/resources/privileges combinations is allowed
+- **`isAllowedWith(role?, resource?, privilege?, resolver: (key: string) => boolean): boolean`** - Like `isAllowed`, but evaluates conditional rules using the supplied JS callback. Non-boolean returns and exceptions are treated as `false` (and logged via `console.warn`).
 - **`hasRole(role: string): boolean`** - Check if role exists
 - **`hasResource(resource: string): boolean`** - Check if resource exists
 - **`inheritsRole(role: string, inherits: string): boolean`** - Check role inheritance - Throws if any of the parameters don't exist in the ACL - Enforces strongly typed/architected code.
 - **`inheritsResource(resource: string, inherits: string): boolean`** - Check resource inheritance - "".
-- **`toJson(): string`** - Serialize to JSON (not yet implemented)
+- **`toJson(): string`** - Serialize to JSON (not yet implemented — currently throws)
 
 ### Convenience Functions
 
@@ -231,6 +247,14 @@ function AdminPanel() {
     return <div>Admin Panel Content</div>;
 }
 ```
+
+### Rust example (host build)
+
+A Rust example mirroring the JS API surface with a host-side build lives at [`examples/wasm_example.rs`](./examples/wasm_example.rs). It uses `walrs_acl::simple` directly (no `wasm-bindgen`) and is convenient for iterating on ACL shape without rebuilding the WASM artifact.
+
+| Example | Demonstrates | Run command |
+|---|---|---|
+| `wasm_example` | Building an ACL programmatically, loading from a JSON string, and converting an `Acl` back into an `AclBuilder` for incremental edits — all WASM-friendly (no file I/O) | `cargo run -p walrs_acl_wasm --example wasm_example` |
 
 ### Error Handling
 

--- a/crates/acl/README.md
+++ b/crates/acl/README.md
@@ -177,14 +177,72 @@ The ACL structure is made up of a `roles`, and a `resources`, symbol graph, and 
 
 See tests, [benchmarks](benchmarks), and/or [examples](examples) for more details.
 
+## Public API surface
+
+Top-level re-exports from `walrs_acl::simple` (see `src/simple/mod.rs`):
+
+- **Core**: `Acl`, `AclBuilder`, `AclData`
+- **Rules**: `Rule`, `RuleContextScope`, `PrivilegeRules`, `RolePrivilegeRules`, `ResourceRoleRules`
+- **Type aliases**: `Role`, `Resource`, `Privilege`, `AssertionKey` (all `String`)
+- **Conditional assertions**: `AssertionResolver` trait (any `Fn(&str) -> bool` qualifies via blanket impl)
+- **Async** (feature `async`): `AsyncAssertionResolver` trait
+
+The crate is `#![no_std]`-compatible when `std` is disabled (uses `alloc`); JSON construction via `AclBuilder::try_from(&mut File)` is gated on `std`.
+
+## Installation
+
+### Default (std)
+
+```toml
+[dependencies]
+walrs_acl = { version = "0.1.0" }
+```
+
+### `no_std` (alloc only)
+
+```toml
+[dependencies]
+walrs_acl = { version = "0.1.0", default-features = false }
+```
+
+### With async assertion resolvers
+
+```toml
+[dependencies]
+walrs_acl = { version = "0.1.0", features = ["async"] }
+```
+
+### Feature flags
+
+| Feature | Default | Enables |
+|---|---|---|
+| `std` | yes | Standard library support, file I/O constructors (`AclBuilder::try_from(&mut File)`, `AclData::try_from(&mut File)`), and `serde`/`serde_json` `std` features. |
+| `async` | no | `AsyncAssertionResolver` trait and `Acl::is_allowed_with_async` / `is_allowed_any_with_async` for assertions that need I/O. |
+
+## Examples
+
+Runnable examples live in [`examples/`](./examples/). Run any of them with `cargo run -p walrs_acl --example <name>`.
+
+| Example | Demonstrates | Required features |
+|---|---|---|
+| `acl_builder_example` | Building an ACL with `AclBuilder` — roles with inheritance, resources, allow/deny rules, permission checks, role-inheritance queries | _none_ |
+| `acl_try_from_json` | Loading an `AclData` from a JSON file via `AclBuilder::try_from(&mut File)` and printing the resulting ACL | `std` (default) |
+
+Example invocations:
+
+```sh
+cargo run -p walrs_acl --example acl_builder_example
+
+# acl_try_from_json reads ./acl/test-fixtures/example-acl-allow-and-deny-rules.json,
+# so run it from the workspace `crates/` directory:
+(cd crates && cargo run -p walrs_acl --example acl_try_from_json)
+```
+
+Two further runnable benchmarks live under [`benchmarks/`](./benchmarks/) (`benchmark_extensive_acl`, `benchmark_actix_middleware`) and are wired up as `[[example]]` targets in `Cargo.toml`; see [`benchmarks/README.md`](./benchmarks/README.md) for details and run commands.
+
 ## WASM Support
 
 WebAssembly bindings live in the sibling crate [`walrs_acl_wasm`](../acl-wasm/README.md).
-
-### Features
-
-- **`std`** (default): Full standard library support with file I/O
-- **`async`**: Adds `AsyncAssertionResolver` and `Acl::is_allowed_with_async` / `is_allowed_any_with_async` for assertions that need I/O
 
 ## Prior Art:
 


### PR DESCRIPTION
Closes part of #292.

## Summary

Refreshes the READMEs for `walrs_acl` and `walrs_acl_wasm` to match the pattern established by PR #291 (fieldfilter): feature-flags table, public API surface, examples table with run commands.

### `crates/acl/README.md`
- New **Public API surface** section listing the top-level re-exports from `walrs_acl::simple` (`Acl`, `AclBuilder`, `AclData`, `Rule` / `RuleContextScope`, the rules structs, type aliases, `AssertionResolver`, and the feature-gated `AsyncAssertionResolver`).
- New **Installation** section with three snippets (default `std`, `no_std`, `async`) plus a **Feature flags** table covering `std` (default) and `async`.
- New **Examples** table for the two examples (`acl_builder_example`, `acl_try_from_json`) and a pointer to the runnable benchmarks. Documents the `acl_try_from_json` cwd requirement (`(cd crates && cargo run -p walrs_acl --example acl_try_from_json)` — the example reads `./acl/test-fixtures/...` relative to `crates/`).
- Existing prose, the `Sync vs. async resolvers` subsection, JSON config explanation, and inline-build example are preserved.

### `crates/acl-wasm/README.md`
- New **Public API surface** summary near the top, with a cross-link to the parent `walrs_acl` for Rust-side conditional-assertion semantics.
- **`JsAclBuilder` Methods** list filled in: `addRoles`, `addResources`, `allowIf`, `denyIf` (all already exposed by `src/lib.rs` but undocumented).
- **`JsAcl` Methods** list filled in: `isAllowedWith`; clarified that plain `isAllowed` is conservative for `AllowIf` / `DenyIf`; noted `toJson()` currently throws (not yet implemented).
- New **Rust example (host build)** subsection documenting `examples/wasm_example.rs` and its run command.
- Existing wasm-pack build/optimization/troubleshooting sections preserved.

## Out of scope (spotted, not fixed)

- `crates/acl/examples/acl_try_from_json.rs` hardcodes the path `./acl/test-fixtures/example-acl-allow-and-deny-rules.json`, which only resolves when the binary is run from `crates/`. This is a pre-existing source quirk; the README now documents the cwd workaround.
- `crates/acl-wasm/README.md` line 499: `License` says `Apache + GPL v3.` but `Cargo.toml` declares `Elastic-2.0`. Stale, but out of scope for this docs sweep.

## Test plan

- [x] `cargo build -p walrs_acl` (default features) — clean
- [x] `cargo build -p walrs_acl --features async` — clean
- [x] `cargo test -p walrs_acl` — 23 doctests pass, 0 failures
- [x] `cargo run -p walrs_acl --example acl_builder_example` — runs to completion
- [x] `(cd crates && cargo run -p walrs_acl --example acl_try_from_json)` — runs to completion (matches the cwd note added to the README)
- [x] `cargo check -p walrs_acl_wasm` — clean on host
- [x] `cargo run -p walrs_acl_wasm --example wasm_example` — runs to completion (this example is also a normal Rust binary)
- [x] Cross-checked every documented `JsAclBuilder` / `JsAcl` method against `crates/acl-wasm/src/lib.rs`

Docs-only — no Rust source modified, so `cargo fmt`/`clippy` are N/A.