### PR TITLE
docs(walrs_digraph,walrs_graph): #292-graph-pair refresh READMEs — features, public API, examples

### DIFF
--- a/crates/digraph/README.md
+++ b/crates/digraph/README.md
@@ -1,20 +1,179 @@
-# digraph
+# walrs_digraph
 
-Directed graph structure.
+Directed graph data structures and algorithms for the walrs project. Adjacency-list-backed `Digraph` plus a small set of classic DFS-based algorithms (cycle detection, depth-first ordering, topological sort, single-source reachability) and a string-keyed symbol-graph wrapper, all based on *Algorithms, 4th Edition* by Robert Sedgewick and Kevin Wayne.
+
+## Overview
+
+`walrs_digraph` provides:
+
+- **`Digraph`** — directed graph with `usize`-indexed vertices, separate in-degree tracking, and `TryFrom` impls for files / `BufReader` so a graph can be loaded from a Sedgewick-format text file.
+- **`DirectedCycle`** — depth-first cycle finder. Reports whether a cycle exists and returns one cycle when present. Handles self-loops and multiple components.
+- **`DepthFirstOrder`** — DFS preorder, postorder, and reverse-postorder traversals (the latter is the basis of topological sort).
+- **`Topology`** — topological order for a DAG, plus `is_dag()` / per-vertex `rank(v)`.
+- **`DirectedPathsDFS`** — single-source reachability and path reconstruction from a given source vertex.
+- **`DisymGraph`** — directed symbol graph that maps `String` names onto an underlying `Digraph` and supports `TryFrom<&File>` / `TryFrom<&mut BufReader<R>>` plus `TryFrom<DisymGraphData>` round-trips.
+
+## Public API surface
+
+Top-level re-exports from `walrs_digraph` (see `src/lib.rs`):
+
+- **Core**: `Digraph`
+- **Traversals & algorithms**: `DepthFirstOrder`, `DirectedCycle`, `DirectedPathsDFS`, `Topology`
+- **Symbol graph**: `DisymGraph`, `DisymGraphData`, `invalid_vert_symbol_msg`
+- **Traits**: `DigraphDFSShape` (shared marker for DFS structs)
+- **Utilities**: `extract_vert_and_edge_counts_from_bufreader`, `invalid_vertex_msg`, `vertex_marked`
+
+Submodules (`digraph`, `directed_cycle`, `depth_first_order`, `topology`, `directed_paths_dfs`, `disymgraph`, `traits`, `utils`) are also `pub` if you want to refer to a type by its full path.
+
+## Installation
+
+```toml
+[dependencies]
+walrs_digraph = { path = "../digraph" }
+```
+
+This crate has no Cargo features and no runtime dependencies.
 
 ## Usage
 
-TODO
+### Building a digraph
 
-## API
+```rust
+use walrs_digraph::Digraph;
 
-TODO
+let mut g = Digraph::new(4);
+g.add_edge(0, 1).unwrap()
+ .add_edge(0, 2).unwrap()
+ .add_edge(1, 3).unwrap()
+ .add_edge(2, 3).unwrap();
 
-## References
+assert_eq!(g.vert_count(), 4);
+assert_eq!(g.edge_count(), 4);
+assert_eq!(g.outdegree(0).unwrap(), 2);
+assert_eq!(g.indegree(3).unwrap(), 2);
 
-- Algorithms 4th Ed. - Chapters on 'graphs' - https://algs4.cs.princeton.edu/40graphs/ - namely
-  https://algs4.cs.princeton.edu/42digraph/Digraph.java.html implementation.
+// Reverse all edges
+let r = g.reverse().unwrap();
+assert_eq!(r.outdegree(3).unwrap(), 2);
+```
+
+### Loading from a file
+
+`Digraph` parses the Sedgewick text format:
+
+```text
+<num_vertices>
+<num_edges>
+<from> <to>
+<from> <to>
+...
+```
+
+```rust
+use std::fs::File;
+use walrs_digraph::Digraph;
+
+let f = File::open("./test-fixtures/digraph_test_tinyDG.txt")?;
+let g: Digraph = (&f).try_into()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+### Cycle detection
+
+```rust
+use walrs_digraph::{Digraph, DirectedCycle};
+
+let mut g = Digraph::new(3);
+g.add_edge(0, 1).unwrap();
+g.add_edge(1, 2).unwrap();
+g.add_edge(2, 0).unwrap(); // closes the cycle
+
+let finder = DirectedCycle::new(&g);
+assert!(finder.has_cycle());
+assert!(finder.cycle().is_some());
+```
+
+### Topological sort
+
+```rust
+use walrs_digraph::{Digraph, Topology};
+
+let mut g = Digraph::new(4);
+g.add_edge(0, 1).unwrap();
+g.add_edge(0, 2).unwrap();
+g.add_edge(1, 3).unwrap();
+g.add_edge(2, 3).unwrap();
+
+let topo = Topology::new(&g);
+assert!(topo.is_dag());
+let order = topo.order().unwrap();
+assert_eq!(order.len(), 4);
+```
+
+`Topology::new` returns a no-order instance when the digraph contains a cycle; check with `has_order()` / `is_dag()`.
+
+### Single-source paths
+
+```rust
+use walrs_digraph::{Digraph, DirectedPathsDFS, DigraphDFSShape};
+
+let mut g = Digraph::new(4);
+g.add_edge(0, 1).unwrap();
+g.add_edge(1, 2).unwrap();
+
+let dfs = DirectedPathsDFS::new(&g, 0).unwrap();
+assert!(dfs.marked(2).unwrap());
+assert!(dfs.path_to(2).is_some());
+assert_eq!(dfs.count(), 3);
+```
+
+### Symbol graph
+
+```rust
+use walrs_digraph::DisymGraph;
+
+let mut sg = DisymGraph::new();
+sg.add_edge("admin", &["user", "moderator"]).unwrap();
+sg.add_edge("user", &["guest"]).unwrap();
+
+assert!(sg.contains("admin"));
+assert_eq!(sg.adj("admin").unwrap().len(), 2);
+```
+
+`DisymGraph` also implements `TryFrom<&File>` / `TryFrom<&mut BufReader<R>>` for whitespace-delimited adjacency files (one `<vertex> <neighbor>...` line per row), and `TryFrom<DisymGraphData>` (`Vec<(String, Option<Vec<String>>)>`) for in-memory construction.
+
+## API conventions
+
+- Vertices are `usize` indices (0-based).
+- Methods that may fail return `Result<T, String>` with messages produced via `invalid_vertex_msg` / `invalid_vert_symbol_msg`.
+- `add_edge(v, w)` records `v -> w` and increments `indegree(w)`. Self-loops and duplicate edges are allowed.
+- Private fields are prefixed with `_`.
+
+## Examples
+
+Runnable examples live in [`examples/`](./examples/).
+
+| Example            | Demonstrates                                                            | Run                                                                                           |
+| ------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `directed_cycle`   | Loading a `Digraph` from a file and reporting any cycle via `DirectedCycle` | `cargo run -p walrs_digraph --example directed_cycle -- ./crates/digraph/test-fixtures/digraph_test_tinyDG.txt` |
+
+## Testing
+
+```sh
+cargo test -p walrs_digraph
+```
+
+Doc tests on most public methods exercise the documented behaviour, alongside per-module unit tests under `src/`.
+
+## Reference
+
+- *Algorithms, 4th Edition* by Robert Sedgewick and Kevin Wayne — chapter 4.2 ("Directed Graphs"): https://algs4.cs.princeton.edu/42digraph/
+- Reference Java implementations: `Digraph.java`, `DirectedCycle.java`, `DepthFirstOrder.java`, `Topological.java`.
+
+## Related crates
+
+- **walrs_graph** — undirected counterpart with `Graph`, `DFS`, and `SymbolGraph<T>`.
 
 ## License
 
-Elastic-2.0
+Elastic-2.0. See the [LICENSE](./LICENSE) file alongside this crate.

--- a/crates/graph/README.md
+++ b/crates/graph/README.md
@@ -1,15 +1,23 @@
-# walrs_graph crate
+# walrs_graph
 
 Undirected graph data structures and algorithms for the walrs project. This crate provides efficient implementations of graph data structures and classic graph algorithms based on *Algorithms, 4th Edition* by Robert Sedgewick and Kevin Wayne.
 
-## Features
+## Overview
 
-- **Graph** - Undirected graph with adjacency list representation
-- **SymbolGraph** - Graph with string-based vertex names
-- **DFS** - Depth-first search for connectivity and path finding
-- Comprehensive test coverage
-- Benchmarks for performance tracking
-- Example programs demonstrating usage
+- **`Graph`** — undirected adjacency-list graph over `usize` vertex indices. Each undirected edge is stored in both endpoints' adjacency lists, so `edge_count()` reports twice the number of logical edges. Adjacency lists are kept sorted, enabling O(log deg(v)) `has_edge` via binary search.
+- **`DFS`** — single-source depth-first search with reachability (`marked` / `has_path_to`), reachability count (`count`), and `path_to` reconstruction.
+- **`SymbolGraph<T: Symbol>`** — graph keyed by typed symbols. Wraps a `Graph` and deduplicates vertices on insert. Comes with `GenericSymbol` (a `String`-backed implementation of `Symbol`) and a `TryFrom<&mut BufReader<File>>` impl that ingests whitespace-delimited adjacency files.
+
+## Public API surface
+
+Top-level re-exports from `walrs_graph` (everything in `src/graph/` is glob-re-exported via `src/lib.rs`):
+
+- **Core**: `Graph`, `invalid_vertex_msg`
+- **Search**: `DFS`
+- **Symbol graph**: `SymbolGraph<T>`, `GenericSymbol`, `Symbol` (trait)
+- **Utilities**: `extract_vert_and_edge_counts_from_bufreader`
+
+Submodules (`graph`, `single_source_dfs`, `symbol_graph`, `traits`, `shared_utils`) are also `pub` if you'd rather refer to a type by its full path.
 
 ## Installation
 
@@ -19,6 +27,8 @@ Add this to your `Cargo.toml`:
 [dependencies]
 walrs_graph = { path = "../graph" }
 ```
+
+This crate has no Cargo features.
 
 ## Usage
 
@@ -136,15 +146,12 @@ This crate follows the same conventions as the `walrs_digraph` crate:
 
 ## Examples
 
-Run the included examples:
+Runnable examples live in [`examples/`](./examples/).
 
-```bash
-# Graph traversal (DFS)
-cargo run --example graph_traversal -- graph.txt 0
-
-# Symbol graph demo (interactive)
-cargo run --example symbol_graph_demo -- routes.txt
-```
+| Example             | Demonstrates                                                                  | Run                                                                                                                  |
+| ------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `graph_traversal`   | Loading a `Graph` from a file and running `DFS` from a chosen source vertex   | `cargo run -p walrs_graph --example graph_traversal -- ./crates/graph/test-fixtures/graph_test_tinyG.txt 0`          |
+| `symbol_graph_demo` | Loading a `SymbolGraph<GenericSymbol>` and interactively querying neighbors via stdin | `cargo run -p walrs_graph --example symbol_graph_demo -- ./crates/graph/test-fixtures/acl_roles_symbol_graph.txt`    |
 
 ## Benchmarks
 
@@ -191,10 +198,8 @@ Based on *Algorithms, 4th Edition* by Robert Sedgewick and Kevin Wayne:
 
 ## Related Crates
 
-- **walrs_digraph** - Directed graph data structures and algorithms
-- **walrs_acl** - Access control lists using graph structures
-- **walrs_navigation** - Navigation structures using graphs
+- **walrs_digraph** — directed counterpart with `Digraph`, `DirectedCycle`, `Topology`, `DirectedPathsDFS`, and `DisymGraph`.
 
 ## License
 
-This crate is licensed as specified in the [LICENSE](../../LICENSE) file at the root of this repository.
+Elastic-2.0. See the [LICENSE](./LICENSE) file alongside this crate.


### PR DESCRIPTION
Closes part of #292.

## Summary

- **`crates/digraph/README.md`** — full rewrite of a 20-line stub. New README documents the actual public API (`Digraph`, `DirectedCycle`, `DepthFirstOrder`, `Topology`, `DirectedPathsDFS`, `DisymGraph` plus `DigraphDFSShape` and the `invalid_vertex_msg` / `extract_vert_and_edge_counts_from_bufreader` / `vertex_marked` utility re-exports), with runnable snippets for each and a fixture-aware run command for the `directed_cycle` example.
- **`crates/graph/README.md`** — augment without rewrite (the existing README was already substantial). Adds a *Public API surface* section listing every re-export from `src/lib.rs` (`Graph`, `DFS`, `SymbolGraph<T>`, `GenericSymbol`, `Symbol`, `invalid_vertex_msg`, `extract_vert_and_edge_counts_from_bufreader`), tightens the Overview to describe `Graph` / `DFS` / `SymbolGraph<T>` accurately, replaces the example list with a table of fixture-aware run commands, and corrects the Related Crates section (`walrs_acl` consumes `walrs_digraph`, not `walrs_graph`; `walrs_navigation` consumes neither).

## Verification

- [x] `cargo build -p walrs_digraph -p walrs_graph` — clean
- [x] `cargo test -p walrs_digraph -p walrs_graph` — all unit + doc tests pass (digraph tests + 23 graph unit tests + 16 graph doc tests)
- [x] `cargo run -p walrs_digraph --example directed_cycle -- ./crates/digraph/test-fixtures/digraph_test_tinyDG.txt` → reports `Directed cycle: 3 2 3`
- [x] `cargo run -p walrs_graph --example graph_traversal -- ./crates/graph/test-fixtures/graph_test_tinyG.txt 0` → reachable set + adjacency lists
- [x] `cargo run -p walrs_graph --example symbol_graph_demo -- ./crates/graph/test-fixtures/acl_roles_symbol_graph.txt` → loads 12 vertices / 13 edges, prompts for input
- [x] Cross-checked every documented re-export against `crates/{digraph,graph}/src/lib.rs` and `crates/graph/src/graph/mod.rs`

## Notes

- Docs-only change — `cargo fmt`/`clippy` are N/A.
- Out-of-scope finding (NOT fixed in this PR): `crates/graph/Cargo.toml` declares `walrs_digraph = { path = '../digraph' }` as a dependency, but the `walrs_graph` source tree does not reference `walrs_digraph` anywhere. Likely an unused dep that could be dropped in a future cleanup.
- Out-of-scope finding (NOT fixed): `crates/digraph/src/digraph_dicycle_README.md` is a stale per-module doc that references a `DigraphDicycle` type which does not exist (the actual type is `DirectedCycle`). Mentioned for awareness; not touched per scope.