### PR TITLE
docs(walrs_acl_wasm): #300 fix wrong license claim

### DIFF
--- a/crates/acl-wasm/README.md
+++ b/crates/acl-wasm/README.md
@@ -520,5 +520,5 @@ file pkg/walrs_acl_wasm_bg.wasm
 
 ## License
 
-Same as the main crate: Apache + GPL v3.
+Elastic-2.0 (matches the parent [`walrs_acl`](../acl/README.md) crate).
 


### PR DESCRIPTION
Closes #300.

## Summary

`crates/acl-wasm/README.md` License section claimed "Same as the main crate: Apache + GPL v3." but `Cargo.toml` is `Elastic-2.0`. Replaced with the same wording used in `crates/rbac-wasm/README.md` (the equivalent fix landed in PR #294).

## Test plan

- [x] `grep -n 'Apache\|GPL' crates/acl-wasm/README.md` returns nothing
- [x] Docs-only — no code changes