### PR TITLE
ci(fuzz): #304 fix stale fieldfilter targets in scheduled workflow

### DIFF
--- a/.github/workflows/fuzz-scheduled.yml
+++ b/.github/workflows/fuzz-scheduled.yml
@@ -41,9 +41,7 @@ jobs:
             target: fuzz_filter_op_string
           # walrs_fieldfilter targets
           - crate: fieldfilter
-            target: fuzz_field_string_clean
-          - crate: fieldfilter
-            target: fuzz_fieldfilter_validate
+            target: fuzz_field_string_sanitize
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- The scheduled deep-fuzz workflow (`.github/workflows/fuzz-scheduled.yml`) hardcoded a matrix containing `fuzz_field_string_clean` and `fuzz_fieldfilter_validate` for the `fieldfilter` crate. Neither target exists.
- Only `crates/fieldfilter/fuzz/fuzz_targets/fuzz_field_string_sanitize.rs` is real (the post-`clean → sanitize` rename target). Replace the two stale entries with the single correct one.
- Result: 10 matrix entries, all of which now map to real fuzz targets on disk.

Closes #304.

## Verification

- `python3 -c "import yaml; ..."` parses the workflow successfully.
- Cross-checked every `(crate, target)` matrix entry against `ls crates/<crate>/fuzz/fuzz_targets/` — all 10 exist.
- The PR-trigger workflow (`fuzz.yml`) is unaffected; it uses `cargo fuzz list` and adapts dynamically.

## Out of scope

The stretch goal in #304 (refactor scheduled matrix to derive from `cargo fuzz list` so future drift is impossible) is intentionally not done here — that's a larger structural change worth its own PR. This change is the surgical one-liner that fixes the immediate breakage.

## Test plan

- [x] YAML parses.
- [x] Every target in the matrix exists on disk.
- [ ] Manual `workflow_dispatch` of the scheduled run after merge to confirm `fieldfilter` job no longer errors with "target not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)