### PR TITLE
ci(fuzz): #306 derive scheduled workflow matrix from cargo fuzz list

### DIFF
--- a/.github/workflows/fuzz-scheduled.yml
+++ b/.github/workflows/fuzz-scheduled.yml
@@ -12,36 +12,46 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  list-targets:
+    name: Discover fuzz targets
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.collect.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Collect targets
+        id: collect
+        run: |
+          set -euo pipefail
+          matrix=$(
+            for crate in validation filter fieldfilter; do
+              while IFS= read -r target; do
+                jq -nc --arg c "$crate" --arg t "$target" \
+                  '{crate: $c, target: $t}'
+              done < <(cd "crates/$crate" && cargo fuzz list)
+            done | jq -sc .
+          )
+          if [ "$matrix" = "[]" ]; then
+            echo "::error::No fuzz targets discovered — refusing to publish empty matrix"
+            exit 1
+          fi
+          echo "Discovered matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   fuzz:
     name: Deep fuzz ${{ matrix.crate }}/${{ matrix.target }}
+    needs: list-targets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # walrs_validation targets
-          - crate: validation
-            target: fuzz_email
-          - crate: validation
-            target: fuzz_url
-          - crate: validation
-            target: fuzz_ip
-          - crate: validation
-            target: fuzz_hostname
-          - crate: validation
-            target: fuzz_date
-          - crate: validation
-            target: fuzz_rule_composition
-          # walrs_filter targets
-          - crate: filter
-            target: fuzz_strip_tags
-          - crate: filter
-            target: fuzz_slug
-          - crate: filter
-            target: fuzz_filter_op_string
-          # walrs_fieldfilter targets
-          - crate: fieldfilter
-            target: fuzz_field_string_sanitize
+        include: ${{ fromJson(needs.list-targets.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 10-entry matrix in `.github/workflows/fuzz-scheduled.yml` with a `list-targets` job that runs `cargo fuzz list` over each fuzzed crate (`validation`, `filter`, `fieldfilter`) and emits a JSON matrix.
- The `fuzz` job consumes the matrix via `fromJson(needs.list-targets.outputs.matrix)`. Adding or removing a fuzz target file (and registering it in the crate's fuzz `Cargo.toml`) requires no further workflow edit.
- `fail-fast: false` is preserved.
- The listing job hard-fails (`::error::`) on an empty matrix so a silent regression in target discovery surfaces instead of masquerading as a successful no-op weekly run.

## Related issue

Closes #306. Follows up on #304 / #305 — the prior surgical fix that motivated this drift-elimination.

## Verification

Locally simulated the bash that builds the matrix against the three fuzz `Cargo.toml` files and confirmed it produces the same 10 entries that were previously hardcoded:

```
validation/fuzz_email, fuzz_url, fuzz_ip, fuzz_hostname, fuzz_date, fuzz_rule_composition
filter/fuzz_strip_tags, fuzz_slug, fuzz_filter_op_string
fieldfilter/fuzz_field_string_sanitize
```

`jq` is preinstalled on `ubuntu-latest` runners, so no extra setup step is needed.

## Test plan

- [ ] CI passes on this PR (no fuzz job runs on PR — fuzz-scheduled.yml is `schedule` + `workflow_dispatch` only).
- [ ] After merge, manually trigger via Actions → "Scheduled Deep Fuzz" → Run workflow, and confirm the matrix expansion in the Actions UI lists exactly the targets present under `crates/*/fuzz/fuzz_targets/`.
- [ ] Verify next scheduled Monday 03:00 UTC run completes with the same per-target jobs as before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)